### PR TITLE
raid1: Fix on_io_complete metrics mapping after device swap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.20.9
+- raid1: Fix on_io_complete metrics mapping after device swap - I/O metrics were incorrectly attributed to the wrong device when completions occurred after swap_device() changed the route.
+
 ## 0.20.8
 - Fix some more cases where __capture_route_state was being misused.
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -10,7 +10,7 @@ required_conan_version = ">=2.0"
 
 class UBlkPPConan(ConanFile):
     name = "ublkpp"
-    version = "0.20.8"
+    version = "0.20.9"
 
     homepage = "https://github.com/szmyd/ublkpp"
     description = "A UBlk library for CPP application"

--- a/src/raid/raid1/raid1.cpp
+++ b/src/raid/raid1/raid1.cpp
@@ -748,10 +748,10 @@ io_result Raid1DiskImpl::__failover_read(sub_cmd_t sub_cmd, auto&& func, uint64_
 
     // Attempt read on device using captured state shared_ptrs to avoid races with swap_device
     // Map logical route (DEVA/DEVB) to physical device and subcmd from captured state
+    auto const& chosen_dev = __route_to_device(*state, route);
+    // Use subcmd from captured state, adding RETRIED flag if this is a retry attempt
     bool const going_to_a = (read_route::DEVA == route);
     auto const use_active = going_to_a ? (state->route != read_route::DEVB) : (state->route == read_route::DEVB);
-    auto const& chosen_dev = use_active ? state->active_dev : state->backup_dev;
-    // Use subcmd from captured state, adding RETRIED flag if this is a retry attempt
     auto chosen_sub = use_active ? state->active_subcmd : state->backup_subcmd;
     if (retry) chosen_sub = set_flags(chosen_sub, sub_cmd_flags::RETRIED);
 
@@ -883,9 +883,7 @@ void Raid1DiskImpl::on_io_complete(ublk_io_data const* data, sub_cmd_t sub_cmd, 
 
     // Pass completion notification to the underlying device for its metrics
     // Map orig_route to physical device accounting for potential swap
-    bool const was_slot_a = (read_route::DEVA == orig_route);
-    auto const use_active = was_slot_a ? (state.route != read_route::DEVB) : (state.route == read_route::DEVB);
-    (use_active ? state.active_dev->disk : state.backup_dev->disk)->on_io_complete(data, sub_cmd, res);
+    __route_to_device(state, orig_route)->disk->on_io_complete(data, sub_cmd, res);
 
     // Decrement outstanding write counter for writes (not reads), but only if it was a
     // success.

--- a/src/raid/raid1/raid1.cpp
+++ b/src/raid/raid1/raid1.cpp
@@ -387,6 +387,16 @@ RouteState Raid1DiskImpl::__capture_route_state(sub_cmd_t sub_cmd) const {
     }
 }
 
+// Helper: Decode logical route to physical device from captured state
+// Maps DEVA/DEVB to the actual device currently in that physical slot,
+// accounting for swaps that may have changed active/backup mapping
+static inline std::shared_ptr< MirrorDevice > const& __route_to_device(RouteState const& state,
+                                                                       raid1::read_route logical_route) noexcept {
+    bool const is_slot_a = (read_route::DEVA == logical_route);
+    auto const use_active = is_slot_a ? (state.route != read_route::DEVB) : (state.route == read_route::DEVB);
+    return use_active ? state.active_dev : state.backup_dev;
+}
+
 // RAID1 devices have the property of being replacable while maintaining
 // consistency due to the fact that the data is replicated. Swapping a device
 // may occur for a multitude of _reasons_ but the following RULES apply when

--- a/src/raid/raid1/raid1.cpp
+++ b/src/raid/raid1/raid1.cpp
@@ -387,14 +387,19 @@ RouteState Raid1DiskImpl::__capture_route_state(sub_cmd_t sub_cmd) const {
     }
 }
 
-// Helper: Decode logical route to physical device from captured state
-// Maps DEVA/DEVB to the actual device currently in that physical slot,
+// Helper return type for route-to-device mapping
+struct RouteSelection {
+    std::shared_ptr< MirrorDevice > const& device;
+    sub_cmd_t subcmd;
+};
+
+// Helper: Decode logical route to physical device and subcmd from captured state
+// Maps DEVA/DEVB to the actual device/subcmd currently in that physical slot,
 // accounting for swaps that may have changed active/backup mapping
-static inline std::shared_ptr< MirrorDevice > const& __route_to_device(RouteState const& state,
-                                                                       raid1::read_route logical_route) noexcept {
+static inline RouteSelection __route_to_device(RouteState const& state, raid1::read_route logical_route) noexcept {
     bool const is_slot_a = (read_route::DEVA == logical_route);
     auto const use_active = is_slot_a ? (state.route != read_route::DEVB) : (state.route == read_route::DEVB);
-    return use_active ? state.active_dev : state.backup_dev;
+    return {use_active ? state.active_dev : state.backup_dev, use_active ? state.active_subcmd : state.backup_subcmd};
 }
 
 // RAID1 devices have the property of being replacable while maintaining
@@ -758,12 +763,9 @@ io_result Raid1DiskImpl::__failover_read(sub_cmd_t sub_cmd, auto&& func, uint64_
 
     // Attempt read on device using captured state shared_ptrs to avoid races with swap_device
     // Map logical route (DEVA/DEVB) to physical device and subcmd from captured state
-    auto const& chosen_dev = __route_to_device(*state, route);
-    // Use subcmd from captured state, adding RETRIED flag if this is a retry attempt
-    bool const going_to_a = (read_route::DEVA == route);
-    auto const use_active = going_to_a ? (state->route != read_route::DEVB) : (state->route == read_route::DEVB);
-    auto chosen_sub = use_active ? state->active_subcmd : state->backup_subcmd;
-    if (retry) chosen_sub = set_flags(chosen_sub, sub_cmd_flags::RETRIED);
+    auto const [chosen_dev, chosen_sub_base] = __route_to_device(*state, route);
+    // Add RETRIED flag if this is a retry attempt
+    auto const chosen_sub = retry ? set_flags(chosen_sub_base, sub_cmd_flags::RETRIED) : chosen_sub_base;
 
     if (auto res = func(*chosen_dev->disk, chosen_sub); res || retry) { return res; }
 
@@ -893,7 +895,7 @@ void Raid1DiskImpl::on_io_complete(ublk_io_data const* data, sub_cmd_t sub_cmd, 
 
     // Pass completion notification to the underlying device for its metrics
     // Map orig_route to physical device accounting for potential swap
-    __route_to_device(state, orig_route)->disk->on_io_complete(data, sub_cmd, res);
+    __route_to_device(state, orig_route).device->disk->on_io_complete(data, sub_cmd, res);
 
     // Decrement outstanding write counter for writes (not reads), but only if it was a
     // success.

--- a/src/raid/raid1/raid1.cpp
+++ b/src/raid/raid1/raid1.cpp
@@ -366,9 +366,6 @@ bool Raid1DiskImpl::__swap_device(std::string const& outgoing_device_id,
 // ⚠️  DO NOT MODIFY UNLESS YOU FULLY UNDERSTAND LOCK-FREE MEMORY MODELS ⚠️
 //
 // ═══════════════════════════════════════════════════════════════════════════════
-#ifndef NDEBUG
-__attribute__((noinline, no_sanitize_thread))
-#endif
 RouteState Raid1DiskImpl::__capture_route_state(sub_cmd_t sub_cmd) const {
     auto const sub_to_a = (sub_cmd & ((1U << sqe_tgt_data_width) - 2));
     auto const sub_to_b = (sub_cmd | 0b1);

--- a/src/raid/raid1/raid1.cpp
+++ b/src/raid/raid1/raid1.cpp
@@ -882,8 +882,10 @@ void Raid1DiskImpl::on_io_complete(ublk_io_data const* data, sub_cmd_t sub_cmd, 
           orig_route)
 
     // Pass completion notification to the underlying device for its metrics
-    ((read_route::DEVA == orig_route) ? state.active_dev->disk : state.backup_dev->disk)
-        ->on_io_complete(data, sub_cmd, res);
+    // Map orig_route to physical device accounting for potential swap
+    bool const was_slot_a = (read_route::DEVA == orig_route);
+    auto const use_active = was_slot_a ? (state.route != read_route::DEVB) : (state.route == read_route::DEVB);
+    (use_active ? state.active_dev->disk : state.backup_dev->disk)->on_io_complete(data, sub_cmd, res);
 
     // Decrement outstanding write counter for writes (not reads), but only if it was a
     // success.

--- a/src/raid/raid1/raid1_impl.hpp
+++ b/src/raid/raid1/raid1_impl.hpp
@@ -100,16 +100,6 @@ class Raid1DiskImpl : public UblkDisk {
 #endif
     RouteState __capture_route_state(sub_cmd_t sub_cmd = 0) const;
 
-    // Helper: Decode logical route to physical device from captured state
-    // Maps DEVA/DEVB to the actual device currently in that physical slot,
-    // accounting for swaps that may have changed active/backup mapping
-    inline std::shared_ptr< MirrorDevice > const& __route_to_device(RouteState const& state,
-                                                                    raid1::read_route logical_route) const noexcept {
-        bool const is_slot_a = (read_route::DEVA == logical_route);
-        auto const use_active = is_slot_a ? (state.route != read_route::DEVB) : (state.route == read_route::DEVB);
-        return use_active ? state.active_dev : state.backup_dev;
-    }
-
     // CAS with uint8_t (for when caller already has uint8_t)
     bool __set_read_route(uint8_t& old_route, uint8_t new_route) noexcept {
         return _read_route_cache.compare_exchange_strong(old_route, new_route);

--- a/src/raid/raid1/raid1_impl.hpp
+++ b/src/raid/raid1/raid1_impl.hpp
@@ -100,6 +100,16 @@ class Raid1DiskImpl : public UblkDisk {
 #endif
     RouteState __capture_route_state(sub_cmd_t sub_cmd = 0) const;
 
+    // Helper: Decode logical route to physical device from captured state
+    // Maps DEVA/DEVB to the actual device currently in that physical slot,
+    // accounting for swaps that may have changed active/backup mapping
+    inline std::shared_ptr< MirrorDevice > const& __route_to_device(RouteState const& state,
+                                                                    raid1::read_route logical_route) const noexcept {
+        bool const is_slot_a = (read_route::DEVA == logical_route);
+        auto const use_active = is_slot_a ? (state.route != read_route::DEVB) : (state.route == read_route::DEVB);
+        return use_active ? state.active_dev : state.backup_dev;
+    }
+
     // CAS with uint8_t (for when caller already has uint8_t)
     bool __set_read_route(uint8_t& old_route, uint8_t new_route) noexcept {
         return _read_route_cache.compare_exchange_strong(old_route, new_route);

--- a/src/raid/raid1/tests/test_raid1_common.hpp
+++ b/src/raid/raid1/tests/test_raid1_common.hpp
@@ -105,7 +105,9 @@ inline std::unique_ptr< uint8_t[] > make_test_superbitmap() {
 
 #define CREATE_DISK_F(params, dev_b, no_read, fail_read, no_write, fail_write)                                         \
     [] {                                                                                                               \
-        auto device = std::make_shared< ublkpp::TestDisk >((params));                                                  \
+        auto p = (params);                                                                                             \
+        p.is_slot_b = (dev_b);                                                                                         \
+        auto device = std::make_shared< ublkpp::TestDisk >(p);                                                         \
         /* Expect to load and write clean_unmount bit */                                                               \
         if (!no_read) { EXPECT_TO_READ_SB_F(device, (dev_b), fail_read) }                                              \
         if (!no_write && !fail_read) { EXPECT_TO_WRITE_SB_F(device, fail_write) }                                      \

--- a/src/tests/test_disk.hpp
+++ b/src/tests/test_disk.hpp
@@ -2,6 +2,7 @@
 
 #include "ublkpp/lib/ublk_disk.hpp"
 
+#include <sisl/logging/logging.h>
 #include <ublksrv.h>
 
 using ::ublkpp::ilog2;
@@ -15,6 +16,7 @@ struct TestParams {
     uint32_t max_io{512 * Ki};
     bool can_discard{true};
     bool direct_io{true};
+    bool is_slot_b{false}; // True if device is in RAID1 slot B (expects sub_cmd bit=1)
 };
 
 namespace ublkpp {
@@ -22,7 +24,8 @@ namespace ublkpp {
 class TestDisk : public UblkDisk {
 public:
     std::string my_id;
-    explicit TestDisk(TestParams const& test_params) : UblkDisk(), my_id(test_params.id) {
+    bool expected_slot_b; // True if this device is in RAID1 slot B
+    explicit TestDisk(TestParams const& test_params) : UblkDisk(), my_id(test_params.id), expected_slot_b(test_params.is_slot_b) {
         auto& our_params = *params();
         our_params.basic.dev_sectors = test_params.capacity >> SECTOR_SHIFT;
         our_params.basic.logical_bs_shift = ilog2(test_params.l_size);
@@ -35,6 +38,25 @@ public:
         direct_io = test_params.direct_io;
     }
     std::string id() const noexcept override { return my_id; }
+
+private:
+    // Validate that sub_cmd bit matches expected slot for RAID1 devices
+    // Slot A devices should ALWAYS see bit=0, slot B should ALWAYS see bit=1
+    void validate_slot(sub_cmd_t sub_cmd, const char* method) const {
+        if (route_size() == 0) return; // Not a RAID device, skip validation
+
+        bool const sub_cmd_is_slot_b = (sub_cmd & 0b1) != 0;
+        DEBUG_ASSERT_EQ(expected_slot_b, sub_cmd_is_slot_b,
+                        "Device {} (slot {}) received {} with wrong sub_cmd bit={} (slot {})",
+                        my_id, expected_slot_b ? "B" : "A", method, sub_cmd_is_slot_b ? "1" : "0",
+                        sub_cmd_is_slot_b ? "B" : "A");
+    }
+
+public:
+    // Override on_io_complete to validate slot routing (only place with the bug)
+    void on_io_complete(ublk_io_data const*, sub_cmd_t sub_cmd, int) override {
+        validate_slot(sub_cmd, "on_io_complete");
+    }
 
     MOCK_METHOD(std::list< int >, open_for_uring, (int const), (override));
     MOCK_METHOD(io_result, handle_internal,

--- a/src/tests/test_disk.hpp
+++ b/src/tests/test_disk.hpp
@@ -25,7 +25,8 @@ class TestDisk : public UblkDisk {
 public:
     std::string my_id;
     bool expected_slot_b; // True if this device is in RAID1 slot B
-    explicit TestDisk(TestParams const& test_params) : UblkDisk(), my_id(test_params.id), expected_slot_b(test_params.is_slot_b) {
+    explicit TestDisk(TestParams const& test_params) :
+            UblkDisk(), my_id(test_params.id), expected_slot_b(test_params.is_slot_b) {
         auto& our_params = *params();
         our_params.basic.dev_sectors = test_params.capacity >> SECTOR_SHIFT;
         our_params.basic.logical_bs_shift = ilog2(test_params.l_size);
@@ -46,10 +47,9 @@ private:
         if (route_size() == 0) return; // Not a RAID device, skip validation
 
         bool const sub_cmd_is_slot_b = (sub_cmd & 0b1) != 0;
-        DEBUG_ASSERT_EQ(expected_slot_b, sub_cmd_is_slot_b,
-                        "Device {} (slot {}) received {} with wrong sub_cmd bit={} (slot {})",
-                        my_id, expected_slot_b ? "B" : "A", method, sub_cmd_is_slot_b ? "1" : "0",
-                        sub_cmd_is_slot_b ? "B" : "A");
+        RELEASE_ASSERT_EQ(
+            expected_slot_b, sub_cmd_is_slot_b, "Device {} (slot {}) received {} with wrong sub_cmd bit={} (slot {})",
+            my_id, expected_slot_b ? "B" : "A", method, sub_cmd_is_slot_b ? "1" : "0", sub_cmd_is_slot_b ? "B" : "A");
     }
 
 public:


### PR DESCRIPTION
## Summary

Fixes a race condition where I/O completion metrics are incorrectly attributed to the wrong device when completions occur after `swap_device()` has changed the route.

## Problem

The original code in `on_io_complete()` assumed that `orig_route` (DEVA/DEVB) could be directly mapped to `active_dev`/`backup_dev`:

```cpp
((read_route::DEVA == orig_route) ? state.active_dev->disk : state.backup_dev->disk)
    ->on_io_complete(data, sub_cmd, res);
```

However, after `swap_device()` changes the route (e.g., EITHER→DEVB), the `active_dev`/`backup_dev` mapping flips:
- Before swap (route=EITHER): active_dev=device_a, backup_dev=device_b  
- After swap (route=DEVB): active_dev=device_b, backup_dev=device_a

An I/O submitted with sub_cmd bit=0 (slot A) before the swap would complete after the swap, causing metrics to be incorrectly routed to the wrong device.

## Solution

Applied the same mapping logic already used in `__failover_read()` to correctly map the physical slot (from sub_cmd bit) to the current device pointer accounting for route changes.

### Helper Function Extraction

After initial fix, extracted the duplicated slot-to-device mapping logic into a static `__route_to_device()` helper:

```cpp
struct RouteSelection {
    std::shared_ptr<MirrorDevice> const& device;
    sub_cmd_t subcmd;
};

static inline RouteSelection __route_to_device(
    RouteState const& state, 
    raid1::read_route logical_route) noexcept;
```

The helper returns both the device and subcmd via a simple struct, eliminating **all** duplicated ternary logic from both call sites.

**Benefits:**
- Single source of truth for slot→device/subcmd mapping
- Eliminates all duplicate ternary logic (was: 2 locations × 3 lines each)
- Makes intent explicit: "map logical route to physical resources"
- Zero overhead (static inline, returns reference + uint16_t via struct)
- Future-proof: any new code needing this mapping has a clear helper to use

This addresses the review feedback about encapsulating the mapping logic while keeping the proven active/backup `RouteState` design.

## RouteState Abstraction

Explored whether to refactor `RouteState` from active/backup semantic to physical device_a/device_b slots. **Analysis concluded the current design is optimal**:
- 9/15 locations (60%) benefit from active/backup semantic  
- Only 2 locations need slot→device mapping (this fix + `__failover_read`)
- `__replicate` (hot path for all writes) is optimized with current abstraction
- Refactoring would trade 2 complex mappings for 9 semantic extractions (net negative)

Decision: Keep current active/backup design. The bug was incorrect usage, not a flaw in the abstraction.

## Test Infrastructure

Added slot validation to `TestDisk::on_io_complete()` that asserts:
- Slot A devices (is_slot_b=false) ALWAYS receive sub_cmd bit=0
- Slot B devices (is_slot_b=true) ALWAYS receive sub_cmd bit=1

This catches routing bugs in any test that triggers `on_io_complete`, regardless of whether the test explicitly checks for it. Uses `DEBUG_ASSERT_EQ` to abort on slot mismatches.

## Impact

- **Severity**: Medium - metrics incorrectly attributed post-swap
- **Data safety**: No data corruption
- **Scope**: Metrics tracking only (FSDisk I/O latency histograms)

## Test Plan

- [x] All existing tests pass (5/5)
- [x] Added slot validation assertions to catch regressions
- [x] Built and tested on remote (Debug mode)

## Files Changed

- `src/raid/raid1/raid1.cpp` - The fix + static helper with RouteSelection struct
- `conanfile.py` - Version bump to 0.20.9
- `CHANGELOG.md` - Added entry
- `src/tests/test_disk.hpp` - Added slot validation
- `src/raid/raid1/tests/test_raid1_common.hpp` - Pass slot info to TestDisk

🤖 Generated with [Claude Code](https://claude.com/claude-code)