### PR TITLE
raid1: Fix defunct device remount failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.21.2
+- raid1: Fix the bringing up a degraded array with a defunct disk in slot A.
+
 ## 0.21.1
 - New functional testing framework. See `docs/functional_testing.md` for details.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## 0.21.2
-- raid1: Fix the bringing up a degraded array with a defunct disk in slot A.
+- raid1: Fix remount failure when bringing up a degraded array with a defunct device
 
 ## 0.21.1
 - New functional testing framework. See `docs/functional_testing.md` for details.

--- a/conanfile.py
+++ b/conanfile.py
@@ -10,7 +10,7 @@ required_conan_version = ">=2.0"
 
 class UBlkPPConan(ConanFile):
     name = "ublkpp"
-    version = "0.21.1"
+    version = "0.21.2"
 
     homepage = "https://github.com/szmyd/ublkpp"
     description = "A UBlk library for CPP application"

--- a/src/raid/raid1/raid1.cpp
+++ b/src/raid/raid1/raid1.cpp
@@ -214,8 +214,7 @@ void Raid1DiskImpl::__init_bitmap_and_degraded_route() {
         _sb->fields.bitmap.age = htobe64(be64toh(_sb->fields.bitmap.age) + 16);
         RLOGW("Unclean shutdown in degraded mode! Dirty all of BITMAP")
         _dirty_bitmap->dirty_region(0, capacity());
-    } else if (read_route::EITHER != __get_read_route()) {
-        auto const route = __get_read_route();
+    } else if (auto const route = __get_read_route(); read_route::EITHER != route) {
         auto const& active_dev = (route == read_route::DEVB) ? _device_b : _device_a;
         auto const& backup_dev = (route == read_route::DEVB) ? _device_a : _device_b;
         RLOGW("Raid1 is starting in degraded mode [uuid:{}]! Degraded device: {}", _str_uuid, *backup_dev->disk)

--- a/src/raid/raid1/raid1.cpp
+++ b/src/raid/raid1/raid1.cpp
@@ -184,37 +184,42 @@ void Raid1DiskImpl::__load_and_select_superblock(boost::uuids::uuid const& uuid,
 }
 
 void Raid1DiskImpl::__init_bitmap_and_degraded_route() {
-    auto const state = __capture_route_state();
     // Read in existing dirty BITMAP pages
     _dirty_bitmap = std::make_shared< Bitmap >(capacity(), be32toh(_sb->fields.bitmap.chunk_size), block_size(),
                                                _sb->superbitmap_reserved, _str_uuid);
-    if (state.active_dev->new_device) _dirty_bitmap->init_to(state.active_dev->disk);
-    if (state.backup_dev->new_device) _dirty_bitmap->init_to(state.backup_dev->disk);
+    // Initialize bitmap pages for any new (or defunct) device slots
+    if (_device_a->new_device) _dirty_bitmap->init_to(_device_a->disk);
+    if (_device_b->new_device) _dirty_bitmap->init_to(_device_b->disk);
 
-    // We need to completely dirty one side if either is new when the other is not, this will also
-    // apply to when a DefunctDisk is provided, load_from will be skipped in this case.
-    if ((DEFUNCT_DEVICE(state.active_dev->disk) || DEFUNCT_DEVICE(state.backup_dev->disk))) {
+    // Use physical slot references (_device_a/_device_b) directly to avoid the ambiguity of
+    // role-relative state captured by __capture_route_state(). The read_route enum refers to
+    // physical slots (DEVA=_device_a, DEVB=_device_b), so mapping must be slot-based.
+    if (DEFUNCT_DEVICE(_device_a->disk) || DEFUNCT_DEVICE(_device_b->disk)) {
         RLOGW("RAID1 device [uuid:{}] is running with a defunct device!", _str_uuid)
-        // Defunct disks are marked NEW
-        __store_read_route(state.active_dev->new_device ? read_route::DEVB : read_route::DEVA);
-        // We still want to load from the BITMAP and not bump the age, maybe we'll get the orig
-        // disk back in a swap when it becomes available?
-        _dirty_bitmap->load_from(*state.active_dev->disk);
-    } else if (state.active_dev->new_device xor state.backup_dev->new_device) {
+        bool const a_is_defunct = DEFUNCT_DEVICE(_device_a->disk);
+        // Route reads to whichever physical slot is live
+        __store_read_route(a_is_defunct ? read_route::DEVB : read_route::DEVA);
+        // Load bitmap from the live slot; don't bump age — we may get the original disk back via swap
+        _dirty_bitmap->load_from(*(a_is_defunct ? _device_b : _device_a)->disk);
+    } else if (_device_a->new_device xor _device_b->new_device) {
         // Bump the bitmap age
         _sb->fields.bitmap.age = htobe64(be64toh(_sb->fields.bitmap.age) + 16);
         RLOGW("Device is replacement {}, dirty all of BITMAP",
-              *(state.active_dev->new_device ? state.active_dev->disk : state.backup_dev->disk))
+              *(_device_a->new_device ? _device_a->disk : _device_b->disk))
         _dirty_bitmap->dirty_region(0, capacity());
-        __store_read_route(state.active_dev->new_device ? read_route::DEVB : read_route::DEVA);
+        // Route reads to the existing (non-new) physical slot
+        __store_read_route(_device_a->new_device ? read_route::DEVB : read_route::DEVA);
     } else if ((read_route::EITHER != __get_read_route()) && (0 == _sb->fields.clean_unmount)) {
         // Bump the bitmap age
         _sb->fields.bitmap.age = htobe64(be64toh(_sb->fields.bitmap.age) + 16);
         RLOGW("Unclean shutdown in degraded mode! Dirty all of BITMAP")
         _dirty_bitmap->dirty_region(0, capacity());
     } else if (read_route::EITHER != __get_read_route()) {
-        RLOGW("Raid1 is starting in degraded mode [uuid:{}]! Degraded device: {}", _str_uuid, *state.backup_dev->disk)
-        _dirty_bitmap->load_from(*state.active_dev->disk);
+        auto const route = __get_read_route();
+        auto const& active_dev = (route == read_route::DEVB) ? _device_b : _device_a;
+        auto const& backup_dev = (route == read_route::DEVB) ? _device_a : _device_b;
+        RLOGW("Raid1 is starting in degraded mode [uuid:{}]! Degraded device: {}", _str_uuid, *backup_dev->disk)
+        _dirty_bitmap->load_from(*active_dev->disk);
     } else if (0 == _sb->fields.clean_unmount) {
         RLOGW("Raid1 was not cleanly shutdown last time [uuid:{}]!", _str_uuid)
     }

--- a/src/raid/raid1/tests/misc/edge_cases.cpp
+++ b/src/raid/raid1/tests/misc/edge_cases.cpp
@@ -75,7 +75,138 @@ TEST(Raid1, BothDevicesSameSlot) {
                  std::runtime_error);
 }
 
-// Test 4: Unclean shutdown while degraded
+// Test 4: Unclean shutdown while degraded — both devices valid, route persisted, clean_unmount=0.
+// Exercises the (read_route != EITHER && clean_unmount == 0) branch: full bitmap dirty + age bump.
+TEST(Raid1, UncleanShutdownWhileDegraded) {
+    // device_a wins pick_superblock (higher age); its read_route=DEVA is used.
+    // Age diff of 1 keeps device_b marked valid (not new_device).
+    auto device_a = std::make_shared< ublkpp::TestDisk >(TestParams{.capacity = Gi});
+    auto device_b = std::make_shared< ublkpp::TestDisk >(TestParams{.capacity = Gi, .is_slot_b = true});
+
+    EXPECT_CALL(*device_a, sync_iov(UBLK_IO_OP_READ, _, _, _))
+        .Times(1)
+        .WillOnce([](uint8_t, iovec* iovecs, uint32_t nr_vecs, off_t addr) -> io_result {
+            EXPECT_EQ(1U, nr_vecs);
+            EXPECT_EQ(ublkpp::raid1::k_page_size, ublkpp::__iovec_len(iovecs, iovecs + nr_vecs));
+            EXPECT_EQ(0UL, addr);
+            memcpy(iovecs->iov_base, &normal_superblock, ublkpp::raid1::k_page_size);
+            auto* sb = reinterpret_cast< ublkpp::raid1::SuperBlock* >(iovecs->iov_base);
+            sb->fields.read_route = static_cast< uint8_t >(ublkpp::raid1::read_route::DEVA);
+            sb->fields.device_b = 0;
+            sb->fields.clean_unmount = 0;
+            sb->fields.bitmap.age = htobe64(2);
+            return ublkpp::raid1::k_page_size;
+        });
+    EXPECT_CALL(*device_b, sync_iov(UBLK_IO_OP_READ, _, _, _))
+        .Times(1)
+        .WillOnce([](uint8_t, iovec* iovecs, uint32_t nr_vecs, off_t addr) -> io_result {
+            EXPECT_EQ(1U, nr_vecs);
+            EXPECT_EQ(ublkpp::raid1::k_page_size, ublkpp::__iovec_len(iovecs, iovecs + nr_vecs));
+            EXPECT_EQ(0UL, addr);
+            memcpy(iovecs->iov_base, &normal_superblock, ublkpp::raid1::k_page_size);
+            auto* sb = reinterpret_cast< ublkpp::raid1::SuperBlock* >(iovecs->iov_base);
+            sb->fields.device_b = 1;
+            sb->fields.clean_unmount = 0;
+            sb->fields.bitmap.age = htobe64(1);
+            return ublkpp::raid1::k_page_size;
+        });
+
+    // device_a: SB from __become_active, bitmap page from sync_to at shutdown, SB from destructor
+    EXPECT_CALL(*device_a, sync_iov(UBLK_IO_OP_WRITE, _, _, _))
+        .Times(3)
+        .WillOnce([](uint8_t, iovec* iovecs, uint32_t nr_vecs, off_t addr) -> io_result {
+            // __become_active: SB written with age bumped +16, route=DEVA, clean_unmount=0
+            EXPECT_EQ(1U, nr_vecs);
+            EXPECT_EQ(ublkpp::raid1::k_page_size, ublkpp::__iovec_len(iovecs, iovecs + nr_vecs));
+            EXPECT_EQ(0UL, addr);
+            auto* sb = reinterpret_cast< ublkpp::raid1::SuperBlock* >(iovecs->iov_base);
+            EXPECT_EQ(ublkpp::raid1::read_route::DEVA, static_cast< ublkpp::raid1::read_route >(sb->fields.read_route));
+            EXPECT_EQ(htobe64(18), sb->fields.bitmap.age); // age 2 + 16 bump
+            return ublkpp::raid1::k_page_size;
+        })
+        .WillOnce([](uint8_t, iovec* iovecs, uint32_t nr_vecs, off_t addr) -> io_result {
+            // sync_to at shutdown: bitmap page written to active device
+            EXPECT_EQ(1U, nr_vecs);
+            EXPECT_EQ(ublkpp::raid1::k_page_size, ublkpp::__iovec_len(iovecs, iovecs + nr_vecs));
+            EXPECT_GE(addr, ublkpp::raid1::k_page_size); // bitmap area, not SB
+            return ublkpp::raid1::k_page_size;
+        })
+        .WillOnce([](uint8_t, iovec* iovecs, uint32_t nr_vecs, off_t addr) -> io_result {
+            // destructor: SB written with clean_unmount=1
+            EXPECT_EQ(1U, nr_vecs);
+            EXPECT_EQ(ublkpp::raid1::k_page_size, ublkpp::__iovec_len(iovecs, iovecs + nr_vecs));
+            EXPECT_EQ(0UL, addr);
+            auto* sb = reinterpret_cast< ublkpp::raid1::SuperBlock* >(iovecs->iov_base);
+            EXPECT_EQ(1, sb->fields.clean_unmount);
+            return ublkpp::raid1::k_page_size;
+        });
+    // device_b: only SB from __become_active (backup device not written at shutdown when degraded)
+    EXPECT_CALL(*device_b, sync_iov(UBLK_IO_OP_WRITE, _, _, _))
+        .Times(1)
+        .WillOnce([](uint8_t, iovec* iovecs, uint32_t nr_vecs, off_t addr) -> io_result {
+            EXPECT_EQ(1U, nr_vecs);
+            EXPECT_EQ(ublkpp::raid1::k_page_size, ublkpp::__iovec_len(iovecs, iovecs + nr_vecs));
+            EXPECT_EQ(0UL, addr);
+            return ublkpp::raid1::k_page_size;
+        });
+
+    auto raid_device = ublkpp::Raid1Disk(boost::uuids::string_generator()(test_uuid), device_a, device_b);
+}
+
+// Test 5: Unclean shutdown while healthy — route=EITHER, clean_unmount=0.
+// Exercises the final (clean_unmount == 0) branch: just a log warning, no bitmap changes.
+TEST(Raid1, UncleanShutdownWhileHealthy) {
+    auto device_a = std::make_shared< ublkpp::TestDisk >(TestParams{.capacity = Gi});
+    auto device_b = std::make_shared< ublkpp::TestDisk >(TestParams{.capacity = Gi, .is_slot_b = true});
+
+    EXPECT_CALL(*device_a, sync_iov(UBLK_IO_OP_READ, _, _, _))
+        .Times(1)
+        .WillOnce([](uint8_t, iovec* iovecs, uint32_t nr_vecs, off_t addr) -> io_result {
+            EXPECT_EQ(1U, nr_vecs);
+            EXPECT_EQ(ublkpp::raid1::k_page_size, ublkpp::__iovec_len(iovecs, iovecs + nr_vecs));
+            EXPECT_EQ(0UL, addr);
+            memcpy(iovecs->iov_base, &normal_superblock, ublkpp::raid1::k_page_size);
+            reinterpret_cast< ublkpp::raid1::SuperBlock* >(iovecs->iov_base)->fields.clean_unmount = 0;
+            return ublkpp::raid1::k_page_size;
+        });
+    EXPECT_CALL(*device_b, sync_iov(UBLK_IO_OP_READ, _, _, _))
+        .Times(1)
+        .WillOnce([](uint8_t, iovec* iovecs, uint32_t nr_vecs, off_t addr) -> io_result {
+            EXPECT_EQ(1U, nr_vecs);
+            EXPECT_EQ(ublkpp::raid1::k_page_size, ublkpp::__iovec_len(iovecs, iovecs + nr_vecs));
+            EXPECT_EQ(0UL, addr);
+            memcpy(iovecs->iov_base, &normal_superblock, ublkpp::raid1::k_page_size);
+            auto* sb = reinterpret_cast< ublkpp::raid1::SuperBlock* >(iovecs->iov_base);
+            sb->fields.device_b = 1;
+            sb->fields.clean_unmount = 0;
+            return ublkpp::raid1::k_page_size;
+        });
+
+    // __become_active writes SB to both (clean_unmount=0); destructor writes SB to both (clean_unmount=1).
+    // No bitmap sync — route=EITHER means not degraded, so sync_to is not called at shutdown.
+    EXPECT_CALL(*device_a, sync_iov(UBLK_IO_OP_WRITE, _, _, _))
+        .Times(1)
+        .WillOnce([](uint8_t, iovec* iovecs, uint32_t nr_vecs, off_t addr) -> io_result {
+            EXPECT_EQ(1U, nr_vecs);
+            EXPECT_EQ(ublkpp::raid1::k_page_size, ublkpp::__iovec_len(iovecs, iovecs + nr_vecs));
+            EXPECT_EQ(0UL, addr);
+            return ublkpp::raid1::k_page_size;
+        });
+    EXPECT_CALL(*device_b, sync_iov(UBLK_IO_OP_WRITE, _, _, _))
+        .Times(1)
+        .WillOnce([](uint8_t, iovec* iovecs, uint32_t nr_vecs, off_t addr) -> io_result {
+            EXPECT_EQ(1U, nr_vecs);
+            EXPECT_EQ(ublkpp::raid1::k_page_size, ublkpp::__iovec_len(iovecs, iovecs + nr_vecs));
+            EXPECT_EQ(0UL, addr);
+            return ublkpp::raid1::k_page_size;
+        });
+
+    auto raid_device = ublkpp::Raid1Disk(boost::uuids::string_generator()(test_uuid), device_a, device_b);
+    EXPECT_TO_WRITE_SB(device_a);
+    EXPECT_TO_WRITE_SB(device_b);
+}
+
+// Test 6: Unclean shutdown while degraded (original broken test kept for documentation)
 TEST(Raid1, UncleanShutdownDegraded) {
     // Create devices without setting up any expectations
     auto device_a = std::make_shared< ublkpp::TestDisk >(TestParams{.capacity = Gi});

--- a/src/raid/raid1/tests/superblock/defunct_disk.cpp
+++ b/src/raid/raid1/tests/superblock/defunct_disk.cpp
@@ -46,8 +46,7 @@ TEST(Raid1, DefunctRemountA) {
             EXPECT_EQ(ublkpp::raid1::k_page_size, ublkpp::__iovec_len(iovecs, iovecs + nr_vecs));
             EXPECT_EQ(0UL, addr);
             auto* sb = reinterpret_cast< ublkpp::raid1::SuperBlock* >(iovecs->iov_base);
-            EXPECT_EQ(ublkpp::raid1::read_route::DEVB,
-                      static_cast< ublkpp::raid1::read_route >(sb->fields.read_route));
+            EXPECT_EQ(ublkpp::raid1::read_route::DEVB, static_cast< ublkpp::raid1::read_route >(sb->fields.read_route));
             return ublkpp::raid1::k_page_size;
         });
 
@@ -80,8 +79,7 @@ TEST(Raid1, DefunctRemountB) {
             EXPECT_EQ(ublkpp::raid1::k_page_size, ublkpp::__iovec_len(iovecs, iovecs + nr_vecs));
             EXPECT_EQ(0UL, addr);
             auto* sb = reinterpret_cast< ublkpp::raid1::SuperBlock* >(iovecs->iov_base);
-            EXPECT_EQ(ublkpp::raid1::read_route::DEVA,
-                      static_cast< ublkpp::raid1::read_route >(sb->fields.read_route));
+            EXPECT_EQ(ublkpp::raid1::read_route::DEVA, static_cast< ublkpp::raid1::read_route >(sb->fields.read_route));
             return ublkpp::raid1::k_page_size;
         });
 

--- a/src/raid/raid1/tests/superblock/defunct_disk.cpp
+++ b/src/raid/raid1/tests/superblock/defunct_disk.cpp
@@ -52,6 +52,7 @@ TEST(Raid1, DefunctRemountA) {
 
     auto device_a = std::make_shared< ublkpp::DefunctDisk >();
     auto raid_device = ublkpp::Raid1Disk(boost::uuids::string_generator()(test_uuid), device_a, device_b);
+    // Set up destructor's clean-unmount write expectation (fires before raid_device leaves scope)
     EXPECT_TO_WRITE_SB(device_b);
 }
 
@@ -85,6 +86,7 @@ TEST(Raid1, DefunctRemountB) {
 
     auto device_b = std::make_shared< ublkpp::DefunctDisk >();
     auto raid_device = ublkpp::Raid1Disk(boost::uuids::string_generator()(test_uuid), device_a, device_b);
+    // Set up destructor's clean-unmount write expectation (fires before raid_device leaves scope)
     EXPECT_TO_WRITE_SB(device_a);
 }
 

--- a/src/raid/raid1/tests/superblock/defunct_disk.cpp
+++ b/src/raid/raid1/tests/superblock/defunct_disk.cpp
@@ -19,6 +19,77 @@ TEST(Raid1, DefunctDiskA) {
     EXPECT_TO_WRITE_SB(device_b);
 }
 
+// Regression: on remount, a persisted read_route must be preserved when one device is still defunct.
+// Previously, __init_bitmap_and_degraded_route used role-relative active_dev->new_device to choose
+// the route — which inverted to the defunct slot on remount, causing a fatal superblock write error.
+TEST(Raid1, DefunctRemountA) {
+    // device_b returns the superblock as persisted from the first degraded mount:
+    // read_route=DEVB, device_b=1, clean_unmount=1 (i.e. device_a was defunct last time too)
+    auto device_b = std::make_shared< ublkpp::TestDisk >(TestParams{.capacity = Gi, .is_slot_b = true});
+    EXPECT_CALL(*device_b, sync_iov(UBLK_IO_OP_READ, _, _, _))
+        .Times(1)
+        .WillOnce([](uint8_t, iovec* iovecs, uint32_t nr_vecs, off_t addr) -> io_result {
+            EXPECT_EQ(1U, nr_vecs);
+            EXPECT_EQ(ublkpp::raid1::k_page_size, ublkpp::__iovec_len(iovecs, iovecs + nr_vecs));
+            EXPECT_EQ(0UL, addr);
+            memcpy(iovecs->iov_base, &normal_superblock, ublkpp::raid1::k_page_size);
+            auto* sb = reinterpret_cast< ublkpp::raid1::SuperBlock* >(iovecs->iov_base);
+            sb->fields.read_route = static_cast< uint8_t >(ublkpp::raid1::read_route::DEVB);
+            sb->fields.device_b = 1;
+            return ublkpp::raid1::k_page_size;
+        });
+    // __become_active must write to device_b (the live slot), not to device_a (defunct)
+    EXPECT_CALL(*device_b, sync_iov(UBLK_IO_OP_WRITE, _, _, _))
+        .Times(1)
+        .WillOnce([](uint8_t, iovec* iovecs, uint32_t nr_vecs, off_t addr) -> io_result {
+            EXPECT_EQ(1U, nr_vecs);
+            EXPECT_EQ(ublkpp::raid1::k_page_size, ublkpp::__iovec_len(iovecs, iovecs + nr_vecs));
+            EXPECT_EQ(0UL, addr);
+            auto* sb = reinterpret_cast< ublkpp::raid1::SuperBlock* >(iovecs->iov_base);
+            EXPECT_EQ(ublkpp::raid1::read_route::DEVB,
+                      static_cast< ublkpp::raid1::read_route >(sb->fields.read_route));
+            return ublkpp::raid1::k_page_size;
+        });
+
+    auto device_a = std::make_shared< ublkpp::DefunctDisk >();
+    auto raid_device = ublkpp::Raid1Disk(boost::uuids::string_generator()(test_uuid), device_a, device_b);
+    EXPECT_TO_WRITE_SB(device_b);
+}
+
+TEST(Raid1, DefunctRemountB) {
+    // device_a returns the superblock as persisted from the first degraded mount:
+    // read_route=DEVA, device_b=0, clean_unmount=1 (i.e. device_b was defunct last time too)
+    auto device_a = std::make_shared< ublkpp::TestDisk >(TestParams{.capacity = Gi, .is_slot_b = false});
+    EXPECT_CALL(*device_a, sync_iov(UBLK_IO_OP_READ, _, _, _))
+        .Times(1)
+        .WillOnce([](uint8_t, iovec* iovecs, uint32_t nr_vecs, off_t addr) -> io_result {
+            EXPECT_EQ(1U, nr_vecs);
+            EXPECT_EQ(ublkpp::raid1::k_page_size, ublkpp::__iovec_len(iovecs, iovecs + nr_vecs));
+            EXPECT_EQ(0UL, addr);
+            memcpy(iovecs->iov_base, &normal_superblock, ublkpp::raid1::k_page_size);
+            auto* sb = reinterpret_cast< ublkpp::raid1::SuperBlock* >(iovecs->iov_base);
+            sb->fields.read_route = static_cast< uint8_t >(ublkpp::raid1::read_route::DEVA);
+            sb->fields.device_b = 0;
+            return ublkpp::raid1::k_page_size;
+        });
+    // __become_active must write to device_a (the live slot), not to device_b (defunct)
+    EXPECT_CALL(*device_a, sync_iov(UBLK_IO_OP_WRITE, _, _, _))
+        .Times(1)
+        .WillOnce([](uint8_t, iovec* iovecs, uint32_t nr_vecs, off_t addr) -> io_result {
+            EXPECT_EQ(1U, nr_vecs);
+            EXPECT_EQ(ublkpp::raid1::k_page_size, ublkpp::__iovec_len(iovecs, iovecs + nr_vecs));
+            EXPECT_EQ(0UL, addr);
+            auto* sb = reinterpret_cast< ublkpp::raid1::SuperBlock* >(iovecs->iov_base);
+            EXPECT_EQ(ublkpp::raid1::read_route::DEVA,
+                      static_cast< ublkpp::raid1::read_route >(sb->fields.read_route));
+            return ublkpp::raid1::k_page_size;
+        });
+
+    auto device_b = std::make_shared< ublkpp::DefunctDisk >();
+    auto raid_device = ublkpp::Raid1Disk(boost::uuids::string_generator()(test_uuid), device_a, device_b);
+    EXPECT_TO_WRITE_SB(device_a);
+}
+
 // We should throw if both devices are Defunct
 TEST(Raid1, DefunctDisks) {
     auto device_a = std::make_shared< ublkpp::DefunctDisk >();


### PR DESCRIPTION
## Problem

A degraded RAID-1 volume mounted via `forcedPartialExpose` (one iSCSI endpoint missing → `DefunctDisk`) works on first attach but fails fatally on every subsequent remount:

```
[error] [raid1_superblock.cpp:69] Error writing Superblock to: [~DEFUNCT~, size=17179869183Gi, lbs=0x200]
[error] [tgt_mgr.cpp:218:add_raid10] Failed to construct RAID-10 Array: Could not initialize superblocks!
```

## Root Cause

`__init_bitmap_and_degraded_route()` used `state.active_dev->new_device` (from `__capture_route_state()`) to decide whether to route reads to `DEVA` or `DEVB`. The problem is that `active_dev` is *role-relative* (whichever device is the current read target), not *slot-relative*, while `read_route::DEVA/DEVB` refer to physical slots.

**First mount** (defunct is `_device_a`, persisted route = `EITHER`):
- `__capture_route_state()` → `active_dev = _device_a` (defunct, `new_device=true`)
- `true ? DEVB : DEVA` → `DEVB` ✓ — routes to the live `_device_b`

**Remount** (defunct is still `_device_a`, persisted route = `DEVB`):
- `__capture_route_state()` with `route=DEVB` → `active_dev = _device_b` (live), `backup_dev = _device_a` (defunct)
- `DEFUNCT_DEVICE(backup_dev)` → true, enters defunct branch
- `active_dev->new_device = false` (live device has a valid superblock)
- `false ? DEVB : DEVA` → route overwritten to **`DEVA`** ← points to `DefunctDisk`
- `__become_active()` tries to `write_superblock(*defunct_disk)` → `io_error` → **throws**

The same inversion occurs symmetrically when `_device_b` is the defunct slot.

## Fix

Replace the role-relative `__capture_route_state()` lookup with direct references to `_device_a` and `_device_b` physical slots. Since `read_route::DEVA/DEVB` map directly to physical slots, the defunct check and route selection are now unambiguous regardless of which route was persisted in the superblock:

```cpp
bool const a_is_defunct = DEFUNCT_DEVICE(_device_a->disk);
__store_read_route(a_is_defunct ? read_route::DEVB : read_route::DEVA);
_dirty_bitmap->load_from(*(a_is_defunct ? _device_b : _device_a)->disk);
```

The same physical-slot approach is applied to the last `else if` (degraded + clean remount) branch, which also used `state.active_dev/backup_dev`.

## Tests

Two regression tests added to `superblock/defunct_disk.cpp`:

- **`DefunctRemountA`** — `device_a` is defunct, `device_b` returns a persisted superblock with `read_route=DEVB`. Asserts no throw and that `__become_active` writes to `device_b` (not `device_a`) with the route preserved.
- **`DefunctRemountB`** — symmetric case: `device_b` is defunct, persisted `read_route=DEVA`, asserts write goes to `device_a`.

All 140 Raid1 unit tests pass.