### PR TITLE
Fix Raid1ResyncTask::launch() crash on joinable thread reassignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.21.3
+- raid1: Fix Raid1ResyncTask::launch() crash on joinable thread reassignment
+
 ## 0.21.2
 - raid1: Fix remount failure when bringing up a degraded array with a defunct device
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -10,7 +10,7 @@ required_conan_version = ">=2.0"
 
 class UBlkPPConan(ConanFile):
     name = "ublkpp"
-    version = "0.21.2"
+    version = "0.21.3"
 
     homepage = "https://github.com/szmyd/ublkpp"
     description = "A UBlk library for CPP application"

--- a/src/raid/raid1/raid1_resync_task.cpp
+++ b/src/raid/raid1/raid1_resync_task.cpp
@@ -148,6 +148,11 @@ void Raid1ResyncTask::launch(std::string const& str_uuid, std::shared_ptr< Mirro
         return;
     }
 
+    // The previous resync thread may still be joinable even though state is IDLE — there is a
+    // window between _start() setting state to IDLE and the thread actually returning. Assigning
+    // to a joinable std::thread calls std::terminate(), so join here first.
+    if (_resync_task.joinable()) _resync_task.join();
+
     _resync_task = sisl::named_thread(
         fmt::format("r_{}", str_uuid.substr(0, 13)),
         [this, uuid = str_uuid, clean = std::move(clean_mirror), dirty = std::move(dirty_mirror),

--- a/src/raid/raid1/tests/concurrency/CMakeLists.txt
+++ b/src/raid/raid1/tests/concurrency/CMakeLists.txt
@@ -6,5 +6,6 @@ list(APPEND RAID1_TEST_SRCS
   concurrency/failover_retry_during_swap.cpp
   concurrency/api_calls_during_swap.cpp
   concurrency/multi_reader_swap.cpp
+  concurrency/resync_relaunch_after_complete.cpp
 )
 set(RAID1_TEST_SRCS "${RAID1_TEST_SRCS}" PARENT_SCOPE)

--- a/src/raid/raid1/tests/concurrency/resync_relaunch_after_complete.cpp
+++ b/src/raid/raid1/tests/concurrency/resync_relaunch_after_complete.cpp
@@ -1,0 +1,77 @@
+#include "test_raid1_common.hpp"
+
+#include <atomic>
+#include <boost/uuid/string_generator.hpp>
+#include <thread>
+
+#include "raid/raid1/bitmap.hpp"
+#include "raid/raid1/raid1_impl.hpp"
+#include "raid/raid1/raid1_resync_task.hpp"
+
+using namespace std::chrono_literals;
+using namespace ublkpp::raid1;
+
+// Regression test for: Raid1ResyncTask::launch() crash on joinable thread reassignment.
+// SDSTOR-21864
+//
+// Root cause: stop() is only called during swap or shutdown — never between resyncs. So
+// after any completed resync, _resync_task remains joinable (join()/detach() not called).
+// The next launch() call will assign to a joinable std::thread, which calls
+// std::terminate() -> abort() -> SIGABRT.
+//
+// The fix joins _resync_task in launch() before assigning the new thread.
+//
+// Test strategy: use Raid1ResyncTask directly with an empty bitmap so the resync thread
+// completes immediately. After the first launch() completes, _resync_task is joinable but
+// state is IDLE. The second launch() exercises the assignment — without the fix this
+// crashes; with the fix it joins first and succeeds.
+TEST(Raid1Concurrency, ResyncRelaunchAfterComplete) {
+    auto device_a = std::make_shared< ublkpp::TestDisk >(TestParams{.capacity = Gi, .id = "DiskA"});
+    auto device_b = std::make_shared< ublkpp::TestDisk >(TestParams{.capacity = Gi, .id = "DiskB", .is_slot_b = true});
+
+    // All sync I/O succeeds (bitmap page reads/writes during resync)
+    EXPECT_CALL(*device_a, sync_iov(::testing::_, _, _, _))
+        .Times(::testing::AnyNumber())
+        .WillRepeatedly([](uint8_t, iovec* iovecs, uint32_t, off_t) -> ublkpp::io_result {
+            return static_cast< int >(iovecs->iov_len);
+        });
+    EXPECT_CALL(*device_b, sync_iov(::testing::_, _, _, _))
+        .Times(::testing::AnyNumber())
+        .WillRepeatedly([](uint8_t, iovec* iovecs, uint32_t, off_t) -> ublkpp::io_result {
+            return static_cast< int >(iovecs->iov_len);
+        });
+
+    auto uuid = boost::uuids::string_generator()(test_uuid);
+    auto mirror_a = std::make_shared< MirrorDevice >(uuid, device_a);
+    auto mirror_b = std::make_shared< MirrorDevice >(uuid, device_b);
+
+    // Empty bitmap (no dirty pages) so the resync thread exits immediately.
+    auto superbitmap_buf = make_test_superbitmap();
+    auto bitmap = std::make_shared< Bitmap >(Gi, 32 * Ki, 4 * Ki, superbitmap_buf.get());
+
+    constexpr uint32_t io_size = 4 * Ki;
+    Raid1ResyncTask task{bitmap, Bitmap::page_size(), io_size, io_size};
+
+    // Track when the resync complete callback fires (called just before state→IDLE CAS).
+    std::atomic< bool > first_complete{false};
+    task.launch(test_uuid, mirror_a, mirror_b,
+                [&first_complete] { first_complete.store(true, std::memory_order_release); });
+
+    // Wait for the complete callback then sleep briefly to let the IDLE CAS happen.
+    // _resync_task is joinable for the entire period from launch() until stop() — which
+    // is never called between resyncs in production.
+    auto const deadline = std::chrono::steady_clock::now() + 2s;
+    while (!first_complete.load(std::memory_order_acquire)) {
+        ASSERT_LT(std::chrono::steady_clock::now(), deadline) << "Resync did not complete";
+        std::this_thread::sleep_for(1ms);
+    }
+    // Brief sleep so the IDLE CAS in _start() can execute before we call launch() again.
+    std::this_thread::sleep_for(5ms);
+
+    // Second launch(): state is IDLE, _resync_task is joinable (never joined).
+    // Without the fix: std::thread::operator= on joinable thread → std::terminate() → crash.
+    // With the fix: joins first, then starts new thread cleanly.
+    task.launch(test_uuid, mirror_a, mirror_b, [] {});
+
+    task.stop();
+}


### PR DESCRIPTION
## Problem

`Raid1ResyncTask::launch()` can crash with `std::terminate()` → SIGABRT on the second invocation.

Root cause: `_start()` sets resync state to IDLE at line 125 (`__cas_state_strong(cur_state, resync_state::IDLE)`) and then returns — but there is a window between the state CAS and the thread actually exiting. During this window, `_resync_task.joinable()` is still `true`.

`stop()` (which joins the thread) is only called during device swap or shutdown — never between consecutive resyncs. So after any completed resync, `_resync_task` remains joinable indefinitely. The next `launch()` call assigns a new `std::thread` to a joinable `_resync_task`, which calls `std::thread::operator=` on a joinable thread → `std::terminate()` → SIGABRT.

This is not a narrow race: it's deterministic after the first resync completes.

Observed in production.

## Fix

Join the previous thread in `launch()` before assigning the new one:

```cpp
if (_resync_task.joinable()) _resync_task.join();
```

The join is safe and cheap — the thread has already set state to IDLE and is effectively done. Concurrent `launch()` calls are serialized by the `__set_read_route` CAS in `__become_degraded`, so no additional locking is needed.

## Test

Added `Raid1Concurrency.ResyncRelaunchAfterComplete` — tests `Raid1ResyncTask` directly with an empty bitmap so the resync thread completes immediately. After the first `launch()` completes and state returns to IDLE, the second `launch()` exercises the joinable-thread assignment path.

Verified with ASAN:
- **Without fix**: `terminate called without an active exception` → SIGABRT ✓
- **With fix**: all 12 test suites pass (100%) ✓