### PR TITLE
raid1: Fix resync task hang and launch race conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.21.4
+- raid1: Fix resync task hang when stop() is called during unavail wait loop
+- raid1: Fix concurrent launch()/stop() race on resync task thread assignment
+- raid1: Fix incorrect device logged as degraded in __become_degraded (DEVB route)
+
 ## 0.21.3
 - raid1: Fix Raid1ResyncTask::launch() crash on joinable thread reassignment
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -10,7 +10,7 @@ required_conan_version = ">=2.0"
 
 class UBlkPPConan(ConanFile):
     name = "ublkpp"
-    version = "0.21.3"
+    version = "0.21.4"
 
     homepage = "https://github.com/szmyd/ublkpp"
     description = "A UBlk library for CPP application"

--- a/src/raid/raid1/raid1.cpp
+++ b/src/raid/raid1/raid1.cpp
@@ -604,10 +604,12 @@ io_result Raid1DiskImpl::__become_degraded(sub_cmd_t failed_path, RouteState con
     }
 
     auto const backup_clean = (read_route::DEVB == new_route);
+    auto& failed_device = backup_clean ? cur_state->active_dev : cur_state->backup_dev;
+    auto& working_device = backup_clean ? *cur_state->backup_dev->disk : *cur_state->active_dev->disk;
 
     auto const old_age = _sb->fields.bitmap.age;
     _sb->fields.bitmap.age = htobe64(be64toh(_sb->fields.bitmap.age) + 1);
-    RLOGW("Device became degraded {} [age:{}] [uuid:{}]", *cur_state->backup_dev->disk,
+    RLOGW("Device became degraded {} [age:{}] [uuid:{}]", *failed_device->disk,
           static_cast< uint64_t >(be64toh(_sb->fields.bitmap.age)), _str_uuid);
 
     // Record degradation event in metrics with device name
@@ -617,7 +619,6 @@ io_result Raid1DiskImpl::__become_degraded(sub_cmd_t failed_path, RouteState con
     }
 
     // Must update age first; we do this synchronously to gate pending retry results
-    auto& working_device = backup_clean ? *cur_state->backup_dev->disk : *cur_state->active_dev->disk;
     if (auto sync_res = write_superblock(working_device, _sb.get(), backup_clean, new_route); !sync_res) {
         // Rollback the failure to update the header
         _sb->fields.bitmap.age = old_age;
@@ -625,7 +626,6 @@ io_result Raid1DiskImpl::__become_degraded(sub_cmd_t failed_path, RouteState con
         RLOGE("Could not become degraded [uuid:{}]: {}", _str_uuid, sync_res.error().message())
         return sync_res;
     }
-    auto& failed_device = backup_clean ? cur_state->active_dev : cur_state->backup_dev;
     failed_device->unavail.test_and_set(std::memory_order_acquire);
     if (spawn_resync && _resync_enabled) toggle_resync(true); // Launch a Resync Task
     return 0;

--- a/src/raid/raid1/raid1_resync_task.cpp
+++ b/src/raid/raid1/raid1_resync_task.cpp
@@ -52,74 +52,73 @@ bool Raid1ResyncTask::__transition_to(resync_state initial, resync_state target,
 
 void Raid1ResyncTask::_start(std::string str_uuid, std::shared_ptr< MirrorDevice >& clean_mirror,
                              std::shared_ptr< MirrorDevice >& dirty_mirror, std::function< void() >&& complete) {
-    // Set ourselves up with a buffer to do all the read/write operations from
-    auto iov = iovec{.iov_base = nullptr, .iov_len = 0};
-    if (auto err = ::posix_memalign(&iov.iov_base, _io_size, _max_size); 0 != err || nullptr == iov.iov_base)
-        [[unlikely]] { // LCOV_EXCL_START
-        RLOGE("Could not allocate memory for I/O: {}", strerror(err))
-        if (iov.iov_base) free(iov.iov_base);
-        return;
-    } // LCOV_EXCL_STOP
-
     RLOGD("Resync Task created for [uuid:{}]", str_uuid)
-    auto const resync_start = std::chrono::steady_clock::now();
+    // Wait to become Available & IDLE
     auto cur_state = resync_state::IDLE;
-    // Record resync start - increment global and per-device counters
-    auto const active_count = s_active_resyncs.fetch_add(1, std::memory_order_relaxed) + 1;
-    // Capture the initial size of data to resync
-    auto const initial_resync_size = _dirty_bitmap->dirty_data_est();
-    if (_metrics) {
-        _metrics->record_resync_start();
-        _metrics->record_active_resyncs(active_count);
-    }
+    while (dirty_mirror->unavail.test(std::memory_order_acquire) ||
+           !__cas_state_weak(cur_state, resync_state::ACTIVE)) {
+        // If we're stopped or another we should exit
+        if (resync_state::STOPPING == cur_state) break;
 
-    // Wait for the device to become available
-    auto nr_pages = _dirty_bitmap->dirty_pages();
-    if (_metrics) { _metrics->record_dirty_pages(nr_pages); }
-    while (dirty_mirror->unavail.test(std::memory_order_acquire)) {
-        std::this_thread::sleep_for(std::chrono::seconds(SISL_OPTIONS["avail_delay"].as< uint32_t >()));
-        probe_mirror(*dirty_mirror, _offset);
-    }
-
-    // Wait to become IDLE
-    while (!__cas_state_weak(cur_state, resync_state::ACTIVE)) {
-        // If we're stopped or another task was started we should exit
-        if ((resync_state::STOPPING == cur_state) || (resync_state::ACTIVE == cur_state) ||
-            (resync_state::SLEEPING == cur_state)) {
-            RLOGD("Resync Task aborted for [uuid:{}] state: {}", str_uuid, cur_state)
-            return;
-        }
         cur_state = resync_state::IDLE;
-        std::this_thread::sleep_for(std::chrono::microseconds(SISL_OPTIONS["resync_delay"].as< uint32_t >()));
+        if (dirty_mirror->unavail.test(std::memory_order_acquire)) {
+            cur_state = __load_state();
+            if (resync_state::STOPPING == cur_state) break;
+            std::this_thread::sleep_for(std::chrono::seconds(SISL_OPTIONS["avail_delay"].as< uint32_t >()));
+            probe_mirror(*dirty_mirror, _offset);
+        } else
+            std::this_thread::sleep_for(std::chrono::microseconds(SISL_OPTIONS["resync_delay"].as< uint32_t >()));
     }
+    cur_state = __load_state();
 
     // We are now guaranteed to be the only active thread performing I/O on the device
-    cur_state = __run(clean_mirror, dirty_mirror, &iov);
-    free(iov.iov_base);
+    if (resync_state::STOPPING != cur_state) {
+        auto const initial_resync_size = _dirty_bitmap->dirty_data_est();
+        // Set ourselves up with a buffer to do all the read/write operations from
+        auto iov = iovec{.iov_base = nullptr, .iov_len = 0};
+        if (auto err = ::posix_memalign(&iov.iov_base, _io_size, _max_size); 0 != err || nullptr == iov.iov_base)
+            [[unlikely]] { // LCOV_EXCL_START
+            RLOGE("Could not allocate memory for I/O: {}", strerror(err))
+            if (iov.iov_base) free(iov.iov_base);
+            return;
+        } // LCOV_EXCL_STOP
 
-    // I/O may have been interrupted, if not check the bitmap and mark us as _clean_
-    auto const final_count = s_active_resyncs.fetch_sub(1, std::memory_order_relaxed) - 1;
-    if (_metrics) _metrics->record_active_resyncs(final_count);
+        auto const resync_start = std::chrono::steady_clock::now();
+        // Record resync start - increment global and per-device counters
+        // Capture the initial size of data to resync
+        if (_metrics) {
+            auto const active_count = s_active_resyncs.fetch_add(1, std::memory_order_relaxed) + 1;
+            _metrics->record_resync_start();
+            _metrics->record_active_resyncs(active_count);
+        }
+
+        cur_state = __run(clean_mirror, dirty_mirror, &iov);
+        free(iov.iov_base);
+
+        if (_metrics) {
+            auto const final_count = s_active_resyncs.fetch_sub(1, std::memory_order_relaxed) - 1;
+            auto const resync_end = std::chrono::steady_clock::now();
+            auto const duration_seconds =
+                std::chrono::duration_cast< std::chrono::seconds >(resync_end - resync_start).count();
+            if (duration_seconds > 0) { _metrics->record_resync_complete(duration_seconds); }
+            // Record the size of data that was resynced (initial size before resync started)
+            _metrics->record_last_resync_size(initial_resync_size);
+            _metrics->record_active_resyncs(final_count);
+        }
+    }
 
     // If stopped, end now.
     if (resync_state::STOPPING == cur_state) {
-        RLOGD("Resync Task Stopped for [uuid:{}]", str_uuid)
+        RLOGD("Resync Task Stopped for [uuid:{}] to: {}", str_uuid, *dirty_mirror->disk)
         __cas_state_strong(cur_state, resync_state::IDLE);
         return;
     }
 
     // Otherwise we _should_ be active (not paused or idle), if the bitmap is clean call complete
     DEBUG_ASSERT_EQ(resync_state::ACTIVE, cur_state, "Resync stopped in unexpected state");
-    if (_metrics) {
-        auto const resync_end = std::chrono::steady_clock::now();
-        auto const duration_seconds =
-            std::chrono::duration_cast< std::chrono::seconds >(resync_end - resync_start).count();
-        if (duration_seconds > 0) { _metrics->record_resync_complete(duration_seconds); }
-        // Record the size of data that was resynced (initial size before resync started)
-        _metrics->record_last_resync_size(initial_resync_size);
-    }
+    // I/O may have been interrupted, if not check the bitmap and mark us as _clean_
     if (0 == _dirty_bitmap->dirty_pages()) complete();
-    RLOGD("Resync Task Finished for [uuid:{}]", str_uuid)
+    RLOGD("Resync Task Finished for [uuid:{}] to: {}", str_uuid, *dirty_mirror->disk)
 
     // Open up I/O Again
     __cas_state_strong(cur_state, resync_state::IDLE);
@@ -127,6 +126,7 @@ void Raid1ResyncTask::_start(std::string str_uuid, std::shared_ptr< MirrorDevice
 
 void Raid1ResyncTask::launch(std::string const& str_uuid, std::shared_ptr< MirrorDevice > clean_mirror,
                              std::shared_ptr< MirrorDevice > dirty_mirror, std::function< void() >&& complete) {
+    auto lg = std::scoped_lock< std::mutex >(_launch_lock);
     // First we must become IDLE
     auto transitioned =
         __transition_to(resync_state::IDLE, resync_state::IDLE, [](resync_state state) -> transition_result {
@@ -266,11 +266,15 @@ void Raid1ResyncTask::__pause() noexcept {
 
 // Abort any on-going resync task by moving to STOPPING and rejoin the thread
 uint32_t Raid1ResyncTask::stop() noexcept {
+    auto lg = std::scoped_lock< std::mutex >(_launch_lock);
     RLOGI("Terminating Resync Task")
     // Terminate any ongoing resync task
-    __transition_to(resync_state::PAUSE, resync_state::STOPPING, [](resync_state state) -> transition_result {
+    __transition_to(resync_state::PAUSE, resync_state::STOPPING, [this](resync_state state) -> transition_result {
         switch (state) {
-        case resync_state::IDLE:
+        case resync_state::IDLE: {
+            if (_resync_task.joinable()) return {state, transition_action::RETRY_WITH_SLEEP};
+            [[fallthrough]];
+        }
         case resync_state::STOPPING:
             return {state, transition_action::SUCCESS};
         case resync_state::ACTIVE:

--- a/src/raid/raid1/raid1_resync_task.hpp
+++ b/src/raid/raid1/raid1_resync_task.hpp
@@ -56,6 +56,7 @@ class Raid1ResyncTask {
 
     std::atomic_uint8_t _resync_state;
     std::atomic_uint32_t _outstanding_writes;
+    std::mutex _launch_lock;
     std::thread _resync_task;
 
     // State access helpers to eliminate casting noise

--- a/src/raid/raid1/tests/concurrency/CMakeLists.txt
+++ b/src/raid/raid1/tests/concurrency/CMakeLists.txt
@@ -7,5 +7,7 @@ list(APPEND RAID1_TEST_SRCS
   concurrency/api_calls_during_swap.cpp
   concurrency/multi_reader_swap.cpp
   concurrency/resync_relaunch_after_complete.cpp
+  concurrency/stop_during_unavail_wait.cpp
+  concurrency/concurrent_launch.cpp
 )
 set(RAID1_TEST_SRCS "${RAID1_TEST_SRCS}" PARENT_SCOPE)

--- a/src/raid/raid1/tests/concurrency/concurrent_launch.cpp
+++ b/src/raid/raid1/tests/concurrency/concurrent_launch.cpp
@@ -1,0 +1,67 @@
+#include "test_raid1_common.hpp"
+
+#include <atomic>
+#include <barrier>
+#include <boost/uuid/string_generator.hpp>
+#include <thread>
+
+#include "raid/raid1/bitmap.hpp"
+#include "raid/raid1/raid1_impl.hpp"
+#include "raid/raid1/raid1_resync_task.hpp"
+
+using namespace std::chrono_literals;
+using namespace ublkpp::raid1;
+
+// Regression test for: concurrent launch() calls racing on _resync_task assignment → std::terminate().
+//
+// Root cause: launch() used CAS(IDLE→IDLE) which provides no mutual exclusion. Two callers
+// (e.g. __become_degraded on the I/O thread and swap_device on the control thread) could both
+// pass the CAS simultaneously and race on the `_resync_task = std::thread{...}` assignment.
+// Assigning to a joinable std::thread calls std::terminate().
+//
+// The fix: _launch_lock mutex serializes concurrent launch() (and stop()) callers so only one
+// thread wins the CAS and assigns _resync_task at a time.
+//
+// Test strategy: use std::barrier to fire two launch() calls simultaneously from two threads.
+// An empty bitmap means resync threads complete immediately so the test doesn't block. Both
+// threads join, then stop() is called. No crash = test passes.
+TEST(Raid1Concurrency, ConcurrentLaunch) {
+    auto device_a = std::make_shared< ublkpp::TestDisk >(TestParams{.capacity = Gi, .id = "DiskA"});
+    auto device_b = std::make_shared< ublkpp::TestDisk >(TestParams{.capacity = Gi, .id = "DiskB", .is_slot_b = true});
+
+    EXPECT_CALL(*device_a, sync_iov(::testing::_, _, _, _))
+        .Times(::testing::AnyNumber())
+        .WillRepeatedly([](uint8_t, iovec* iovecs, uint32_t, off_t) -> ublkpp::io_result {
+            return static_cast< int >(iovecs->iov_len);
+        });
+    EXPECT_CALL(*device_b, sync_iov(::testing::_, _, _, _))
+        .Times(::testing::AnyNumber())
+        .WillRepeatedly([](uint8_t, iovec* iovecs, uint32_t, off_t) -> ublkpp::io_result {
+            return static_cast< int >(iovecs->iov_len);
+        });
+
+    auto uuid = boost::uuids::string_generator()(test_uuid);
+    auto mirror_a = std::make_shared< MirrorDevice >(uuid, device_a);
+    auto mirror_b = std::make_shared< MirrorDevice >(uuid, device_b);
+
+    // Empty bitmap (no dirty pages) so the resync threads exit immediately.
+    auto superbitmap_buf = make_test_superbitmap();
+    auto bitmap = std::make_shared< Bitmap >(Gi, 32 * Ki, 4 * Ki, superbitmap_buf.get());
+
+    constexpr uint32_t io_size = 4 * Ki;
+    Raid1ResyncTask task{bitmap, Bitmap::page_size(), io_size, io_size};
+
+    std::barrier sync_point{3};
+    auto t1 = std::thread([&] {
+        sync_point.arrive_and_wait();
+        task.launch(test_uuid, mirror_a, mirror_b, [] {});
+    });
+    auto t2 = std::thread([&] {
+        sync_point.arrive_and_wait();
+        task.launch(test_uuid, mirror_a, mirror_b, [] {});
+    });
+    sync_point.arrive_and_wait();
+    t1.join();
+    t2.join();
+    task.stop();
+}

--- a/src/raid/raid1/tests/concurrency/stop_during_unavail_wait.cpp
+++ b/src/raid/raid1/tests/concurrency/stop_during_unavail_wait.cpp
@@ -1,0 +1,74 @@
+#include "test_raid1_common.hpp"
+
+#include <atomic>
+#include <boost/uuid/string_generator.hpp>
+#include <thread>
+
+#include "raid/raid1/bitmap.hpp"
+#include "raid/raid1/raid1_impl.hpp"
+#include "raid/raid1/raid1_resync_task.hpp"
+
+using namespace std::chrono_literals;
+using namespace ublkpp::raid1;
+
+// Regression test for: Raid1ResyncTask::stop() hangs when task is spinning in unavail wait loop.
+//
+// Root cause: stop() checked state == ACTIVE before CASing to STOPPING. When the resync thread
+// was blocked in the unavail wait loop, state was IDLE (set at entry to _start() before the
+// unavail check), so stop() returned SUCCESS without CASing. join() then blocked forever because
+// the thread never saw STOPPING.
+//
+// The fix: stop() CASes IDLE→STOPPING (in addition to ACTIVE→STOPPING) so the unavail-wait
+// branch of _start() can detect STOPPING and exit.
+//
+// Test strategy: mark mirror_b unavail and mock its sync_iov to always return EIO so the probe
+// read fails and the thread stays in the unavail loop. Call stop() from a separate thread and
+// assert it completes within 15s (worst case: one full avail_delay sleep of 5s plus margin).
+TEST(Raid1Concurrency, StopDuringUnavailWait) {
+    auto device_a = std::make_shared< ublkpp::TestDisk >(TestParams{.capacity = Gi, .id = "DiskA"});
+    auto device_b = std::make_shared< ublkpp::TestDisk >(TestParams{.capacity = Gi, .id = "DiskB", .is_slot_b = true});
+
+    EXPECT_CALL(*device_a, sync_iov(::testing::_, _, _, _))
+        .Times(::testing::AnyNumber())
+        .WillRepeatedly([](uint8_t, iovec* iovecs, uint32_t, off_t) -> ublkpp::io_result {
+            return static_cast< int >(iovecs->iov_len);
+        });
+    // First call: superblock read during MirrorDevice construction — must succeed.
+    // Subsequent calls: probe reads during unavail loop — always fail to keep mirror_b unavail.
+    EXPECT_CALL(*device_b, sync_iov(::testing::_, _, _, _))
+        .WillOnce([](uint8_t, iovec* iovecs, uint32_t, off_t) -> ublkpp::io_result {
+            if (iovecs->iov_base) memcpy(iovecs->iov_base, &normal_superblock, ublkpp::raid1::k_page_size);
+            return static_cast< int >(iovecs->iov_len);
+        })
+        .WillRepeatedly([](uint8_t, iovec*, uint32_t, off_t) -> ublkpp::io_result {
+            return std::unexpected(std::make_error_condition(std::errc::io_error));
+        });
+
+    auto uuid = boost::uuids::string_generator()(test_uuid);
+    auto mirror_a = std::make_shared< MirrorDevice >(uuid, device_a);
+    auto mirror_b = std::make_shared< MirrorDevice >(uuid, device_b);
+    mirror_b->unavail.test_and_set(std::memory_order_release);
+
+    auto superbitmap_buf = make_test_superbitmap();
+    auto bitmap = std::make_shared< Bitmap >(Gi, 32 * Ki, 4 * Ki, superbitmap_buf.get());
+
+    constexpr uint32_t io_size = 4 * Ki;
+    Raid1ResyncTask task{bitmap, Bitmap::page_size(), io_size, io_size};
+    task.launch(test_uuid, mirror_a, mirror_b, [] {});
+
+    std::this_thread::sleep_for(50ms);
+
+    std::atomic< bool > stop_complete{false};
+    auto stop_thread = std::thread([&] {
+        task.stop();
+        stop_complete.store(true, std::memory_order_release);
+    });
+
+    auto const deadline = std::chrono::steady_clock::now() + 15s;
+    while (!stop_complete.load(std::memory_order_acquire)) {
+        ASSERT_LT(std::chrono::steady_clock::now(), deadline)
+            << "stop() hung — resync task did not detect STOPPING during unavail wait";
+        std::this_thread::sleep_for(10ms);
+    }
+    stop_thread.join();
+}


### PR DESCRIPTION
## Summary

- **Stop hang during unavail wait**: `stop()` returned `SUCCESS` for `IDLE` state without CASing to `STOPPING`, so `join()` blocked forever when the resync thread was spinning in the unavail loop. Fixed by retrying `IDLE→STOPPING` CAS in `stop()` and adding an explicit `__load_state()` check in the unavail branch of `_start()`.
- **Concurrent launch race**: `launch()` used `CAS(IDLE→IDLE)` which provides no mutual exclusion — two concurrent callers could both pass and race on `_resync_task = std::thread{...}`, triggering `std::terminate()`. Fixed with `_launch_lock` mutex in both `launch()` and `stop()`.
- **Incorrect degraded device logged**: `__become_degraded` always logged `backup_dev` in the `RLOGW`; now logs `failed_device` correctly for both degradation directions.

Includes regression tests for both concurrency bugs (`StopDuringUnavailWait`, `ConcurrentLaunch`) using `Raid1ResyncTask` directly, following the pattern established in `resync_relaunch_after_complete.cpp`.

## Test plan

- [x] `Raid1Concurrency.StopDuringUnavailWait` — marks mirror_b unavail with always-failing probe reads, calls `stop()` from a separate thread, asserts completion within 15s
- [x] `Raid1Concurrency.ConcurrentLaunch` — fires two simultaneous `launch()` calls via `std::barrier`, asserts no crash
- [x] All existing RAID1 concurrency tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)