### PR TITLE
We logged every RAID1 shutdown indicating the resync tasked was stopped.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.21.5
+- raid1: Only log in reference to Resync if it was actually running.
+
 ## 0.21.4
 - raid1: Fix resync task hang when stop() is called during unavail wait loop
 - raid1: Fix concurrent launch()/stop() race on resync task thread assignment

--- a/conanfile.py
+++ b/conanfile.py
@@ -10,7 +10,7 @@ required_conan_version = ">=2.0"
 
 class UBlkPPConan(ConanFile):
     name = "ublkpp"
-    version = "0.21.4"
+    version = "0.21.5"
 
     homepage = "https://github.com/szmyd/ublkpp"
     description = "A UBlk library for CPP application"

--- a/src/raid/raid1/raid1_resync_task.cpp
+++ b/src/raid/raid1/raid1_resync_task.cpp
@@ -109,7 +109,7 @@ void Raid1ResyncTask::_start(std::string str_uuid, std::shared_ptr< MirrorDevice
 
     // If stopped, end now.
     if (resync_state::STOPPING == cur_state) {
-        RLOGD("Resync Task Stopped for [uuid:{}] to: {}", str_uuid, *dirty_mirror->disk)
+        RLOGI("Resync Task Stopped for [uuid:{}] to: {}", str_uuid, *dirty_mirror->disk)
         __cas_state_strong(cur_state, resync_state::IDLE);
         return;
     }
@@ -267,7 +267,6 @@ void Raid1ResyncTask::__pause() noexcept {
 // Abort any on-going resync task by moving to STOPPING and rejoin the thread
 uint32_t Raid1ResyncTask::stop() noexcept {
     auto lg = std::scoped_lock< std::mutex >(_launch_lock);
-    RLOGI("Terminating Resync Task")
     // Terminate any ongoing resync task
     __transition_to(resync_state::PAUSE, resync_state::STOPPING, [this](resync_state state) -> transition_result {
         switch (state) {


### PR DESCRIPTION
This is confusing when the array is CLEAN...only log if it is actually running and is stopped.