### PR TITLE
raid1: Fix multi-queue support (#193)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.21.5
+- raid1: Fix multi-queue idle probe race conditions — probes now start only when all queues are idle, mutex serializes concurrent launch/stop calls, `open_for_uring` counts queue threads for accurate `nr_hw_queues`
+
 ## 0.21.4
 - raid1: Fix resync task hang when stop() is called during unavail wait loop
 - raid1: Fix concurrent launch()/stop() race on resync task thread assignment

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 0.22.0
 - raid1: Fix multi-queue idle probe race conditions — probes now start only when all queues are idle, mutex serializes concurrent launch/stop calls, `open_for_uring` counts queue threads for accurate `nr_hw_queues`
+- **Breaking**: `UblkDisk::open_for_uring` signature changed from `(int)` to `(ublksrv_queue const*, int)` — out-of-tree subclasses must update their override
 
 ## 0.21.x
 - raid0: Fix stale alive_cmds in __distribute() corrupting the next I/O on the same thread after a failed multi-stride operation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.21.6
+- raid0: Fix stale alive_cmds in __distribute() corrupting the next I/O on the same thread after a failed multi-stride operation
+
 ## 0.21.5
 - raid1: Only log in reference to Resync if it was actually running.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,29 +4,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.21.6
+## 0.22.0
 
 - raid1: Fix multi-queue idle probe race conditions — probes now start only when all queues are idle, mutex serializes concurrent launch/stop calls, `open_for_uring` counts queue threads for accurate `nr_hw_queues`
 
-## 0.21.5
+## 0.21.x
 - raid1: Only log in reference to Resync if it was actually running.
-
-## 0.21.4
 - raid1: Fix resync task hang when stop() is called during unavail wait loop
 - raid1: Fix concurrent launch()/stop() race on resync task thread assignment
 - raid1: Fix incorrect device logged as degraded in __become_degraded (DEVB route)
-
-## 0.21.3
 - raid1: Fix Raid1ResyncTask::launch() crash on joinable thread reassignment
-
-## 0.21.2
 - raid1: Fix remount failure when bringing up a degraded array with a defunct device
 - fio_engine: Pre-populate backing files with zeros after allocation to convert unwritten extents to written state, eliminating first-write journal cost and page fault overhead that inflated write latency on fresh files. Raw block devices are detected and skipped.
-
-## 0.21.1
 - New functional testing framework. See `docs/functional_testing.md` for details.
-
-## 0.21.0
 - raid1: Introduce `UNAVAIL` replica state for transient read failures, routing I/O away from replicas that fail reads without marking them fully offline. A new periodic health monitor (`Raid1AvailProbeTask`) probes unavailable replicas during idle periods and restores them to active routing once they recover. Resync logic is updated to skip copies to unavailable mirrors and to wait for a device to become available before proceeding.
 
 ## 0.20.x

--- a/conanfile.py
+++ b/conanfile.py
@@ -10,7 +10,7 @@ required_conan_version = ">=2.0"
 
 class UBlkPPConan(ConanFile):
     name = "ublkpp"
-    version = "0.21.4"
+    version = "0.21.5"
 
     homepage = "https://github.com/szmyd/ublkpp"
     description = "A UBlk library for CPP application"

--- a/conanfile.py
+++ b/conanfile.py
@@ -10,7 +10,7 @@ required_conan_version = ">=2.0"
 
 class UBlkPPConan(ConanFile):
     name = "ublkpp"
-    version = "0.21.6"
+    version = "0.22.0"
 
     homepage = "https://github.com/szmyd/ublkpp"
     description = "A UBlk library for CPP application"

--- a/conanfile.py
+++ b/conanfile.py
@@ -10,7 +10,7 @@ required_conan_version = ">=2.0"
 
 class UBlkPPConan(ConanFile):
     name = "ublkpp"
-    version = "0.21.5"
+    version = "0.21.6"
 
     homepage = "https://github.com/szmyd/ublkpp"
     description = "A UBlk library for CPP application"

--- a/include/ublkpp/drivers/iscsi_disk.hpp
+++ b/include/ublkpp/drivers/iscsi_disk.hpp
@@ -22,7 +22,7 @@ public:
     ~iSCSIDisk() override;
 
     std::string id() const noexcept override;
-    std::list< int > open_for_uring(int const) override;
+    std::list< int > open_for_uring(ublksrv_queue const*, int const) override;
 
     void collect_async(ublksrv_queue const*, std::list< async_result >& compl_list) override;
     io_result handle_flush(ublksrv_queue const* q, ublk_io_data const* data, sub_cmd_t sub_cmd) override;

--- a/include/ublkpp/lib/ublk_disk.hpp
+++ b/include/ublkpp/lib/ublk_disk.hpp
@@ -56,7 +56,7 @@ public:
     virtual std::string id() const noexcept = 0;
 
     /// Device Specific I/O Handlers
-    virtual std::list< int > open_for_uring(int const) { return {}; }
+    virtual std::list< int > open_for_uring(ublksrv_queue const*, int const) { return {}; }
 
     // Number of bits for sub_cmd routing in the sqe user_data
     virtual uint8_t route_size() const noexcept { return 0; }

--- a/include/ublkpp/raid/raid0.hpp
+++ b/include/ublkpp/raid/raid0.hpp
@@ -15,7 +15,6 @@ class Raid0Disk : public UblkDisk {
     uint32_t _stripe_size{0};
     uint32_t _stride_width{0};
 
-
     io_result __distribute(iovec* iov, uint64_t addr, auto&& func, bool retry = false, sub_cmd_t sub_cmd = 0) const;
 
 public:
@@ -32,7 +31,7 @@ public:
     /// UBlkDisk Interface Overrides
     /// ============================
     std::string id() const noexcept override { return "RAID0"; }
-    std::list< int > open_for_uring(int const iouring_device) override;
+    std::list< int > open_for_uring(ublksrv_queue const*, int const iouring_device) override;
 
     uint8_t route_size() const noexcept override { return ilog2(_max_stripe_cnt); }
     void idle_transition(ublksrv_queue const*, bool) override;

--- a/include/ublkpp/raid/raid1.hpp
+++ b/include/ublkpp/raid/raid1.hpp
@@ -43,7 +43,7 @@ public:
     ublk_params* params() noexcept override;
     ublk_params const* params() const noexcept override;
     std::string id() const noexcept override;
-    std::list< int > open_for_uring(int const iouring_device) override;
+    std::list< int > open_for_uring(ublksrv_queue const*, int const iouring_device) override;
 
     uint8_t route_size() const noexcept override;
 

--- a/src/driver/iscsi_disk.cpp
+++ b/src/driver/iscsi_disk.cpp
@@ -140,7 +140,7 @@ iSCSIDisk::~iSCSIDisk() = default;
 std::string iSCSIDisk::id() const noexcept { return _session->url->target; }
 
 // Initialize our event loop before we start getting I/O
-std::list< int > iSCSIDisk::open_for_uring(int const) {
+std::list< int > iSCSIDisk::open_for_uring(ublksrv_queue const*, int const) {
     using namespace std::chrono_literals;
     _session->ev_loop = sisl::named_thread("iscsi_evloop", [ctx = _session->ctx, evfd = _session->evfd] {
         pollfd ev_pfd[2] = {{.fd = evfd, .events = POLLIN, .revents = 0},

--- a/src/raid/raid0/raid0.cpp
+++ b/src/raid/raid0/raid0.cpp
@@ -90,10 +90,10 @@ std::shared_ptr< UblkDisk > Raid0Disk::get_device(uint32_t stripe_offset) const 
     return _stripe_array[stripe_offset]->disk;
 }
 
-std::list< int > Raid0Disk::open_for_uring(int const iouring_device_start) {
+std::list< int > Raid0Disk::open_for_uring(ublksrv_queue const* q, int const iouring_device_start) {
     auto fds = std::list< int >();
     for (auto& stripe : _stripe_array) {
-        fds.splice(fds.end(), stripe->disk->open_for_uring(iouring_device_start + fds.size()));
+        fds.splice(fds.end(), stripe->disk->open_for_uring(q, iouring_device_start + fds.size()));
     }
     return fds;
 }

--- a/src/raid/raid0/raid0.cpp
+++ b/src/raid/raid0/raid0.cpp
@@ -1,5 +1,6 @@
 #include "ublkpp/raid/raid0.hpp"
 
+#include <bit>
 #include <boost/uuid/uuid_io.hpp>
 #include <ublksrv.h>
 #include <ublksrv_utils.h>
@@ -32,6 +33,9 @@ load_superblock(UblkDisk& device, boost::uuids::uuid const& uuid, uint32_t& stri
 Raid0Disk::Raid0Disk(boost::uuids::uuid const& uuid, uint32_t const stripe_size_bytes,
                      std::vector< std::shared_ptr< UblkDisk > >&& disks) :
         UblkDisk(), _stripe_size(stripe_size_bytes), _stride_width(_stripe_size * disks.size()) {
+    if (disks.size() > _max_stripe_cnt)
+        throw std::invalid_argument(
+            fmt::format("Raid0Disk: too many disks ({}), max is {}", disks.size(), _max_stripe_cnt));
     // Discover overall Device parameters
     auto& our_params = *params();
     our_params.types |= UBLK_PARAM_TYPE_DISCARD;
@@ -175,66 +179,53 @@ io_result Raid0Disk::handle_discard(ublksrv_queue const* q, ublk_io_data const* 
 //  stripe boundaries and even wrap around several strides. This routine handles this calculation and calls
 //  the given routine `func` for each stripe that it has collected scatter (struct iovec) operations for.
 io_result Raid0Disk::__distribute(iovec* iovecs, uint64_t addr, auto&& func, bool retry, sub_cmd_t sub_cmd) const {
-    // Each thread has a 2-dimensional block of iovecs that we can split into.
-    thread_local auto sub_cmds =
-        std::array< std::tuple< uint64_t, uint32_t, std::array< iovec, 16 > >, _max_stripe_cnt >();
-    // Reset only the stripes we touch (cheaper than zeroing all _max_stripe_cnt on every call).
-    // A previous call that returned early on error leaves non-zero alive_cmds behind; stale iov_base
-    // pointers in those entries would corrupt the next I/O on this thread if not cleared.
-    static_assert(_max_stripe_cnt <= 64, "dirty_mask requires _max_stripe_cnt <= 64");
+    struct StripeAccum {
+        uint64_t io_addr{0};
+        uint32_t alive_cmds{0};
+        std::array< iovec, 16 > io_array{};
+    };
+    // Reset only touched stripes on exit; a failed call leaves non-zero alive_cmds that would corrupt the next I/O.
+    static_assert(_max_stripe_cnt == 64, "dirty_mask must be exactly uint64_t");
+    thread_local auto sub_cmds = std::array< StripeAccum, _max_stripe_cnt >();
     uint64_t dirty_mask{0};
     struct DirtyGuard {
         decltype(sub_cmds)& cmds;
         uint64_t& mask;
         ~DirtyGuard() noexcept {
             while (mask) {
-                std::get< 1 >(cmds[std::countr_zero(mask)]) = 0;
-                mask &= mask - 1;
+                cmds[std::countr_zero(mask)].alive_cmds = 0;
+                mask &= mask - 1; // clear lowest set bit
             }
         }
-    } _guard{sub_cmds, dirty_mask};
+    } guard{sub_cmds, dirty_mask};
 
-    // Special case for single device
     if (1 == _stripe_array.size()) return func(0, sub_cmd, iovecs, 1, addr);
 
     auto const route_mask = _max_stripe_cnt - 1;
-
     DEBUG_ASSERT_LE(iovecs->iov_len, UINT32_MAX) // LCOV_EXCL_LINE
-    auto const len = (uint32_t)iovecs->iov_len;
+    auto const len = static_cast< uint32_t >(iovecs->iov_len);
     uint32_t cnt{0};
     for (auto off = 0U; len > off;) {
         auto const [stripe_off, logical_off, sz] =
-            raid0::next_subcmd(_stride_width, _stripe_size, addr + off, (len - off));
-
-        // Ensure we advance here in case we _continue_ or anything later
-        auto buf_cursor = (uint8_t*)iovecs->iov_base + off;
+            raid0::next_subcmd(_stride_width, _stripe_size, addr + off, len - off);
+        auto buf_cursor = static_cast< uint8_t* >(iovecs->iov_base) + off;
         off += sz;
 
-        // Get the device
         auto const& device = _stripe_array[stripe_off]->disk;
-
-        // If this is a retry, we only want to re-issue the operation whose route matches the one passed in
-        if (retry) [[unlikely]] {
-            // Mask off to get "our" portion of the original route and see if the device that processed this
-            // operation matches the current RAID-0 sub-operation; if not then skip.
-            if (stripe_off != ((sub_cmd >> device->route_size()) & route_mask)) continue;
-        }
+        // On retry, re-issue only the stripe whose route bits match the original sub_cmd.
+        if (retry && stripe_off != ((sub_cmd >> device->route_size()) & route_mask)) [[unlikely]]
+            continue;
 
         dirty_mask |= 1ULL << stripe_off;
-        auto& [io_addr, alive_cmds, io_array] = sub_cmds[stripe_off];
-        { // Fillout iovec
-            auto& iov = io_array[alive_cmds++];
-            iov.iov_base = (void*)buf_cursor;
-            iov.iov_len = sz;
-        }
-        if (1 == alive_cmds) [[likely]]
-            io_addr = logical_off;
+        auto& acc = sub_cmds[stripe_off];
+        if (!acc.alive_cmds) acc.io_addr = logical_off;
+        acc.io_array[acc.alive_cmds++] = {buf_cursor, sz};
 
-        // Last sub_cmd for this device, issue now
+        // Dispatch once the remaining bytes fit within a single (N-1)-stripe remainder,
+        // guaranteeing this stripe cannot accumulate more iovecs in the same call.
         if ((_stride_width - _stripe_size) >= (len - off)) {
             sub_cmd_t const new_sub_cmd = sub_cmd + (!retry ? (uint16_t)stripe_off : 0);
-            DEBUG_ASSERT_LE(alive_cmds, UINT32_MAX) // LCOV_EXCL_LINE
-            auto res = func(stripe_off, new_sub_cmd, io_array.data(), alive_cmds, io_addr);
+            auto res = func(stripe_off, new_sub_cmd, acc.io_array.data(), acc.alive_cmds, acc.io_addr);
             if (!res) return res;
             cnt += res.value();
         }

--- a/src/raid/raid0/raid0.cpp
+++ b/src/raid/raid0/raid0.cpp
@@ -175,9 +175,24 @@ io_result Raid0Disk::handle_discard(ublksrv_queue const* q, ublk_io_data const* 
 //  stripe boundaries and even wrap around several strides. This routine handles this calculation and calls
 //  the given routine `func` for each stripe that it has collected scatter (struct iovec) operations for.
 io_result Raid0Disk::__distribute(iovec* iovecs, uint64_t addr, auto&& func, bool retry, sub_cmd_t sub_cmd) const {
-    // Each thread has a 2-dimensional block of iovecs that we can split into
+    // Each thread has a 2-dimensional block of iovecs that we can split into.
     thread_local auto sub_cmds =
         std::array< std::tuple< uint64_t, uint32_t, std::array< iovec, 16 > >, _max_stripe_cnt >();
+    // Reset only the stripes we touch (cheaper than zeroing all _max_stripe_cnt on every call).
+    // A previous call that returned early on error leaves non-zero alive_cmds behind; stale iov_base
+    // pointers in those entries would corrupt the next I/O on this thread if not cleared.
+    static_assert(_max_stripe_cnt <= 64, "dirty_mask requires _max_stripe_cnt <= 64");
+    uint64_t dirty_mask{0};
+    struct DirtyGuard {
+        decltype(sub_cmds)& cmds;
+        uint64_t& mask;
+        ~DirtyGuard() noexcept {
+            while (mask) {
+                std::get< 1 >(cmds[std::countr_zero(mask)]) = 0;
+                mask &= mask - 1;
+            }
+        }
+    } _guard{sub_cmds, dirty_mask};
 
     // Special case for single device
     if (1 == _stripe_array.size()) return func(0, sub_cmd, iovecs, 1, addr);
@@ -205,6 +220,7 @@ io_result Raid0Disk::__distribute(iovec* iovecs, uint64_t addr, auto&& func, boo
             if (stripe_off != ((sub_cmd >> device->route_size()) & route_mask)) continue;
         }
 
+        dirty_mask |= 1ULL << stripe_off;
         auto& [io_addr, alive_cmds, io_array] = sub_cmds[stripe_off];
         { // Fillout iovec
             auto& iov = io_array[alive_cmds++];

--- a/src/raid/raid0/raid0.cpp
+++ b/src/raid/raid0/raid0.cpp
@@ -235,8 +235,6 @@ io_result Raid0Disk::__distribute(iovec* iovecs, uint64_t addr, auto&& func, boo
             sub_cmd_t const new_sub_cmd = sub_cmd + (!retry ? (uint16_t)stripe_off : 0);
             DEBUG_ASSERT_LE(alive_cmds, UINT32_MAX) // LCOV_EXCL_LINE
             auto res = func(stripe_off, new_sub_cmd, io_array.data(), alive_cmds, io_addr);
-            // Set this back to zero so the next command can reuse
-            alive_cmds = 0;
             if (!res) return res;
             cnt += res.value();
         }

--- a/src/raid/raid0/tests/open_devices.cpp
+++ b/src/raid/raid0/tests/open_devices.cpp
@@ -11,12 +11,12 @@ TEST(Raid0, OpenDevices) {
     auto device_b = CREATE_DISK(TestParams{.capacity = Gi});
 
     // Each device should be subsequently opened and return a set with their sole FD.
-    EXPECT_CALL(*device_a, open_for_uring(_)).Times(1).WillOnce([](int const fd_off) {
+    EXPECT_CALL(*device_a, open_for_uring(_, _)).Times(1).WillOnce([](ublksrv_queue const*, int const fd_off) {
         EXPECT_EQ(start_idx, fd_off);
         // Return 2 FDs here, maybe it's another RAID0 device?
         return std::list< int >{INT_MAX - 2, INT_MAX - 3};
     });
-    EXPECT_CALL(*device_b, open_for_uring(_)).Times(1).WillOnce([](int const fd_off) {
+    EXPECT_CALL(*device_b, open_for_uring(_, _)).Times(1).WillOnce([](ublksrv_queue const*, int const fd_off) {
         // Device A took 2 uring offsets
         EXPECT_EQ(start_idx + 2, fd_off);
         return std::list< int >{INT_MAX - 1};
@@ -24,7 +24,7 @@ TEST(Raid0, OpenDevices) {
 
     auto raid_device = ublkpp::Raid0Disk(boost::uuids::random_generator()(), 32 * Ki,
                                          std::vector< std::shared_ptr< UblkDisk > >{device_a, device_b});
-    auto fd_list = raid_device.open_for_uring(2);
+    auto fd_list = raid_device.open_for_uring(nullptr, 2);
     EXPECT_EQ(3, fd_list.size());
     EXPECT_NE(fd_list.end(), std::find(fd_list.begin(), fd_list.end(), (INT_MAX - 3)));
     EXPECT_NE(fd_list.end(), std::find(fd_list.begin(), fd_list.end(), (INT_MAX - 2)));

--- a/src/raid/raid0/tests/simple/error_handling.cpp
+++ b/src/raid/raid0/tests/simple/error_handling.cpp
@@ -1,5 +1,65 @@
 #include "../test_raid0_common.hpp"
 
+// Regression test for stale alive_cmds: a failed I/O spanning multiple strides must not leave
+// non-zero alive_cmds entries behind, which would corrupt the next I/O on the same thread.
+//
+// Setup: 3 devices, stripe_size=4KiB, stride_width=12KiB.
+// I/O 1: 24KiB (2 full strides). Stride 1 accumulates all 3 stripes but dispatches none.
+// In stride 2, device A is dispatched first (2 accumulated iovecs) and fails → early return.
+// alive_cmds[B]=1 and alive_cmds[C]=1 are left non-zero.
+//
+// I/O 2: 8KiB (stripe A + stripe B). Without the fix, device B receives nr_vecs=2 with a stale
+// iov_base[0] pointing into I/O 1's buffer. With the fix, nr_vecs=1 and iov_base is correct.
+TEST(Raid0, FailedMultiStrideIoDoesNotLeaveStaleAliveCount) {
+    constexpr uint32_t stripe_sz = 4 * Ki;
+    auto device_a = CREATE_DISK(TestParams{.capacity = Gi});
+    auto device_b = CREATE_DISK(TestParams{.capacity = Gi});
+    auto device_c = CREATE_DISK(TestParams{.capacity = Gi});
+    auto raid = ublkpp::Raid0Disk(boost::uuids::string_generator()(test_uuid), stripe_sz,
+                                  std::vector< std::shared_ptr< UblkDisk > >{device_a, device_b, device_c});
+
+    // I/O 1: 2 full strides — device A dispatched first in last stride with 2 accumulated iovecs, fails.
+    constexpr uint32_t io1_sz = 2 * 3 * stripe_sz; // 24KiB
+    void* buf1{};
+    ASSERT_EQ(0, posix_memalign(&buf1, device_a->block_size(), io1_sz));
+    auto iov1 = iovec{.iov_base = buf1, .iov_len = io1_sz};
+
+    EXPECT_CALL(*device_a, sync_iov(UBLK_IO_OP_WRITE, _, _, _))
+        .Times(1)
+        .WillOnce([](uint8_t, iovec*, uint32_t nr_vecs, off_t) -> io_result {
+            EXPECT_EQ(2U, nr_vecs); // 2 iovecs accumulated across 2 strides
+            return std::unexpected(std::make_error_condition(std::errc::io_error));
+        });
+    // B and C are never dispatched: early return after A fails leaves alive_cmds[B]=1, alive_cmds[C]=1.
+    ASSERT_FALSE(raid.sync_iov(UBLK_IO_OP_WRITE, &iov1, 1, 0));
+
+    // I/O 2: 8KiB spanning stripe A then stripe B.
+    constexpr uint32_t io2_sz = 2 * stripe_sz; // 8KiB
+    void* buf2{};
+    ASSERT_EQ(0, posix_memalign(&buf2, device_b->block_size(), io2_sz));
+    auto iov2 = iovec{.iov_base = buf2, .iov_len = io2_sz};
+
+    EXPECT_CALL(*device_a, sync_iov(UBLK_IO_OP_WRITE, _, _, _))
+        .Times(1)
+        .WillOnce([](uint8_t, iovec*, uint32_t nr_vecs, off_t) -> io_result {
+            EXPECT_EQ(1U, nr_vecs);
+            return stripe_sz;
+        });
+    EXPECT_CALL(*device_b, sync_iov(UBLK_IO_OP_WRITE, _, _, _))
+        .Times(1)
+        .WillOnce([buf2, stripe_sz](uint8_t, iovec* iovecs, uint32_t nr_vecs, off_t) -> io_result {
+            // Without the fix: nr_vecs=2, iovecs[0].iov_base is stale (points into buf1 from I/O 1).
+            EXPECT_EQ(1U, nr_vecs);
+            EXPECT_EQ(static_cast< uint8_t* >(iovecs[0].iov_base), static_cast< uint8_t* >(buf2) + stripe_sz);
+            return stripe_sz;
+        });
+
+    EXPECT_TRUE(raid.sync_iov(UBLK_IO_OP_WRITE, &iov2, 1, 0));
+
+    free(buf1);
+    free(buf2);
+}
+
 // Test: async_iov with invalid nr_vecs (0)
 TEST(Raid0, AsyncIovInvalidNrVecs) {
     auto device_a = CREATE_DISK(TestParams{.capacity = Gi});

--- a/src/raid/raid0/tests/simple/error_handling.cpp
+++ b/src/raid/raid0/tests/simple/error_handling.cpp
@@ -15,14 +15,19 @@ TEST(Raid0, FailedMultiStrideIoDoesNotLeaveStaleAliveCount) {
     auto device_a = CREATE_DISK(TestParams{.capacity = Gi});
     auto device_b = CREATE_DISK(TestParams{.capacity = Gi});
     auto device_c = CREATE_DISK(TestParams{.capacity = Gi});
+    // Must use test_uuid: CREATE_DISK's superblock expectations encode this UUID in normal_superblock.
     auto raid = ublkpp::Raid0Disk(boost::uuids::string_generator()(test_uuid), stripe_sz,
                                   std::vector< std::shared_ptr< UblkDisk > >{device_a, device_b, device_c});
 
     // I/O 1: 2 full strides — device A dispatched first in last stride with 2 accumulated iovecs, fails.
     constexpr uint32_t io1_sz = 2 * 3 * stripe_sz; // 24KiB
-    void* buf1{};
-    ASSERT_EQ(0, posix_memalign(&buf1, device_a->block_size(), io1_sz));
-    auto iov1 = iovec{.iov_base = buf1, .iov_len = io1_sz};
+    auto buf1 = std::unique_ptr< void, decltype(&free) >(nullptr, free);
+    {
+        void* p{};
+        ASSERT_EQ(0, posix_memalign(&p, device_a->block_size(), io1_sz));
+        buf1.reset(p);
+    }
+    auto iov1 = iovec{.iov_base = buf1.get(), .iov_len = io1_sz};
 
     EXPECT_CALL(*device_a, sync_iov(UBLK_IO_OP_WRITE, _, _, _))
         .Times(1)
@@ -35,9 +40,14 @@ TEST(Raid0, FailedMultiStrideIoDoesNotLeaveStaleAliveCount) {
 
     // I/O 2: 8KiB spanning stripe A then stripe B.
     constexpr uint32_t io2_sz = 2 * stripe_sz; // 8KiB
-    void* buf2{};
-    ASSERT_EQ(0, posix_memalign(&buf2, device_b->block_size(), io2_sz));
-    auto iov2 = iovec{.iov_base = buf2, .iov_len = io2_sz};
+    auto buf2 = std::unique_ptr< void, decltype(&free) >(nullptr, free);
+    {
+        void* p{};
+        ASSERT_EQ(0, posix_memalign(&p, device_b->block_size(), io2_sz));
+        buf2.reset(p);
+    }
+    auto* buf2_raw = static_cast< uint8_t* >(buf2.get());
+    auto iov2 = iovec{.iov_base = buf2.get(), .iov_len = io2_sz};
 
     EXPECT_CALL(*device_a, sync_iov(UBLK_IO_OP_WRITE, _, _, _))
         .Times(1)
@@ -47,17 +57,76 @@ TEST(Raid0, FailedMultiStrideIoDoesNotLeaveStaleAliveCount) {
         });
     EXPECT_CALL(*device_b, sync_iov(UBLK_IO_OP_WRITE, _, _, _))
         .Times(1)
-        .WillOnce([buf2, stripe_sz](uint8_t, iovec* iovecs, uint32_t nr_vecs, off_t) -> io_result {
+        .WillOnce([buf2_raw, stripe_sz](uint8_t, iovec* iovecs, uint32_t nr_vecs, off_t) -> io_result {
             // Without the fix: nr_vecs=2, iovecs[0].iov_base is stale (points into buf1 from I/O 1).
             EXPECT_EQ(1U, nr_vecs);
-            EXPECT_EQ(static_cast< uint8_t* >(iovecs[0].iov_base), static_cast< uint8_t* >(buf2) + stripe_sz);
+            EXPECT_EQ(static_cast< uint8_t* >(iovecs[0].iov_base), buf2_raw + stripe_sz);
             return stripe_sz;
         });
 
     EXPECT_TRUE(raid.sync_iov(UBLK_IO_OP_WRITE, &iov2, 1, 0));
+}
 
-    free(buf1);
-    free(buf2);
+// Same scenario as above but exercised through async_iov — the primary production I/O path.
+TEST(Raid0, FailedMultiStrideIoDoesNotLeaveStaleAliveCount_Async) {
+    constexpr uint32_t stripe_sz = 4 * Ki;
+    auto device_a = CREATE_DISK(TestParams{.capacity = Gi});
+    auto device_b = CREATE_DISK(TestParams{.capacity = Gi});
+    auto device_c = CREATE_DISK(TestParams{.capacity = Gi});
+    // Must use test_uuid: CREATE_DISK's superblock expectations encode this UUID in normal_superblock.
+    auto raid = ublkpp::Raid0Disk(boost::uuids::string_generator()(test_uuid), stripe_sz,
+                                  std::vector< std::shared_ptr< UblkDisk > >{device_a, device_b, device_c});
+
+    constexpr uint32_t io1_sz = 2 * 3 * stripe_sz; // 24KiB
+    auto buf1 = std::unique_ptr< void, decltype(&free) >(nullptr, free);
+    {
+        void* p{};
+        ASSERT_EQ(0, posix_memalign(&p, device_a->block_size(), io1_sz));
+        buf1.reset(p);
+    }
+    auto iov1 = iovec{.iov_base = buf1.get(), .iov_len = io1_sz};
+    auto data1 = make_io_data(UBLK_IO_OP_WRITE, io1_sz);
+
+    EXPECT_CALL(*device_a, async_iov(_, _, _, _, _, _))
+        .Times(1)
+        .WillOnce([](ublksrv_queue const*, ublk_io_data const*, ublkpp::sub_cmd_t, iovec*, uint32_t nr_vecs,
+                     uint64_t) -> io_result {
+            EXPECT_EQ(2U, nr_vecs);
+            return std::unexpected(std::make_error_condition(std::errc::io_error));
+        });
+    ASSERT_FALSE(raid.async_iov(nullptr, &data1, 0, &iov1, 1, 0));
+
+    constexpr uint32_t io2_sz = 2 * stripe_sz; // 8KiB
+    auto buf2 = std::unique_ptr< void, decltype(&free) >(nullptr, free);
+    {
+        void* p{};
+        ASSERT_EQ(0, posix_memalign(&p, device_b->block_size(), io2_sz));
+        buf2.reset(p);
+    }
+    auto* buf2_raw = static_cast< uint8_t* >(buf2.get());
+    auto iov2 = iovec{.iov_base = buf2.get(), .iov_len = io2_sz};
+    auto data2 = make_io_data(UBLK_IO_OP_WRITE, io2_sz);
+
+    EXPECT_CALL(*device_a, async_iov(_, _, _, _, _, _))
+        .Times(1)
+        .WillOnce([](ublksrv_queue const*, ublk_io_data const*, ublkpp::sub_cmd_t, iovec*, uint32_t nr_vecs,
+                     uint64_t) -> io_result {
+            EXPECT_EQ(1U, nr_vecs);
+            return stripe_sz;
+        });
+    EXPECT_CALL(*device_b, async_iov(_, _, _, _, _, _))
+        .Times(1)
+        .WillOnce([buf2_raw, stripe_sz](ublksrv_queue const*, ublk_io_data const*, ublkpp::sub_cmd_t, iovec* iovecs,
+                                        uint32_t nr_vecs, uint64_t) -> io_result {
+            EXPECT_EQ(1U, nr_vecs);
+            EXPECT_EQ(static_cast< uint8_t* >(iovecs[0].iov_base), buf2_raw + stripe_sz);
+            return stripe_sz;
+        });
+
+    EXPECT_TRUE(raid.async_iov(nullptr, &data2, 0, &iov2, 1, 0));
+
+    remove_io_data(data1);
+    remove_io_data(data2);
 }
 
 // Test: async_iov with invalid nr_vecs (0)

--- a/src/raid/raid1/raid1.cpp
+++ b/src/raid/raid1/raid1.cpp
@@ -277,6 +277,12 @@ Raid1DiskImpl::~Raid1DiskImpl() {
 }
 
 std::list< int > Raid1DiskImpl::open_for_uring(int const iouring_device_start) {
+    // Called once per queue thread before I/O begins; count queues for multi-queue idle tracking.
+    ++_nr_hw_queues;
+
+    // Only initialize on the first call (first queue thread)
+    if (_nr_hw_queues > 1) return {};
+
     // Now that we're up and the target wants to begin I/O let's unpause our resync task, there are no i/o threads
     // yet so we can continue to access _device_a and b directly
     auto fds = (_device_a->disk->open_for_uring(iouring_device_start));
@@ -970,10 +976,18 @@ void Raid1DiskImpl::on_io_complete(ublk_io_data const* data, sub_cmd_t sub_cmd, 
 
 void Raid1DiskImpl::idle_transition(ublksrv_queue const*, bool enter) noexcept {
     if (!enter) {
+        _idle_queue_count.fetch_sub(1, std::memory_order_acq_rel);
+        auto lk = std::unique_lock{_idle_probe_lock};
         _idle_probe_a.stop();
         _idle_probe_b.stop();
         return;
     }
+
+    // Start probes only when all queue threads are idle (_nr_hw_queues == 0 treated as 1 for
+    // backward compat with tests that skip open_for_uring).
+    auto const nr = _nr_hw_queues ? _nr_hw_queues : uint16_t{1};
+    auto const prev = _idle_queue_count.fetch_add(1, std::memory_order_acq_rel);
+    if (prev + 1 < nr) return;
 
     auto const state = __capture_route_state();
     if (state.is_degraded) return; // Resync task handles avail probing in degraded mode
@@ -989,7 +1003,8 @@ void Raid1DiskImpl::idle_transition(ublksrv_queue const*, bool enter) noexcept {
     immediate_probe(state.active_dev);
     immediate_probe(state.backup_dev);
 
-    // Periodic probe: both directions (recovery + new failures), stopped when idle exits
+    // Periodic probe: both directions (recovery + new failures), stopped when any queue exits idle
+    auto lk = std::unique_lock{_idle_probe_lock};
     _idle_probe_a.launch(state.active_dev, reserved_size);
     _idle_probe_b.launch(state.backup_dev, reserved_size);
 }

--- a/src/raid/raid1/raid1.cpp
+++ b/src/raid/raid1/raid1.cpp
@@ -283,7 +283,7 @@ std::list< int > Raid1DiskImpl::open_for_uring(int const iouring_device_start) {
     fds.splice(fds.end(), _device_b->disk->open_for_uring(iouring_device_start + fds.size()));
 
     // Enable resync only on the first call (first queue thread).
-    if (++_nr_hw_queues == 1) toggle_resync(true);
+    if (_nr_hw_queues.fetch_add(1, std::memory_order_acq_rel) == 0) toggle_resync(true);
 
     return fds;
 }
@@ -982,7 +982,7 @@ void Raid1DiskImpl::idle_transition(ublksrv_queue const*, bool enter) noexcept {
 
     // Start probes only when all queue threads are idle.
     auto const prev = _idle_queue_count.fetch_add(1, std::memory_order_acq_rel);
-    if (prev + 1 < _nr_hw_queues) return;
+    if (prev + 1 < _nr_hw_queues.load(std::memory_order_acquire)) return;
 
     auto const state = __capture_route_state();
     if (state.is_degraded) return; // Resync task handles avail probing in degraded mode

--- a/src/raid/raid1/raid1.cpp
+++ b/src/raid/raid1/raid1.cpp
@@ -978,11 +978,9 @@ void Raid1DiskImpl::idle_transition(ublksrv_queue const*, bool enter) noexcept {
         return;
     }
 
-    // Start probes only when all queue threads are idle (_nr_hw_queues == 0 treated as 1 for
-    // backward compat with tests that skip open_for_uring).
-    auto const nr = _nr_hw_queues ? _nr_hw_queues : uint16_t{1};
+    // Start probes only when all queue threads are idle.
     auto const prev = _idle_queue_count.fetch_add(1, std::memory_order_acq_rel);
-    if (prev + 1 < nr) return;
+    if (prev + 1 < _nr_hw_queues) return;
 
     auto const state = __capture_route_state();
     if (state.is_degraded) return; // Resync task handles avail probing in degraded mode

--- a/src/raid/raid1/raid1.cpp
+++ b/src/raid/raid1/raid1.cpp
@@ -487,7 +487,7 @@ std::shared_ptr< UblkDisk > Raid1DiskImpl::swap_device(std::string const& outgoi
     } catch (std::runtime_error const& e) { return incoming_device; }
 
     // Terminate any ongoing resync task BEFORE clearing bitmap to avoid race condition
-    auto old_resync_flag = _resync_enabled;
+    auto old_resync_flag = _resync_enabled.load(std::memory_order_relaxed);
     toggle_resync(false);
 
     // Now safe to clear bitmap (resync stopped, no concurrent access)
@@ -630,7 +630,7 @@ io_result Raid1DiskImpl::__become_degraded(sub_cmd_t failed_path, RouteState con
         return sync_res;
     }
     failed_device->unavail.test_and_set(std::memory_order_acquire);
-    if (spawn_resync && _resync_enabled) toggle_resync(true); // Launch a Resync Task
+    if (spawn_resync && _resync_enabled.load(std::memory_order_relaxed)) toggle_resync(true); // Launch a Resync Task
     return 0;
 }
 
@@ -1005,8 +1005,8 @@ void Raid1DiskImpl::idle_transition(ublksrv_queue const*, bool enter) noexcept {
 }
 
 void Raid1DiskImpl::toggle_resync(bool t) {
-    _resync_enabled = t;
-    if (_resync_enabled) {
+    _resync_enabled.store(t, std::memory_order_relaxed);
+    if (t) {
         auto const state = __capture_route_state();
         if (read_route::EITHER != state.route && !DEFUNCT_DEVICE(state.backup_dev->disk)) {
             _resync_task->launch(_str_uuid, state.active_dev, state.backup_dev, [this] { __become_clean(); });

--- a/src/raid/raid1/raid1.cpp
+++ b/src/raid/raid1/raid1.cpp
@@ -278,18 +278,13 @@ Raid1DiskImpl::~Raid1DiskImpl() {
 
 std::list< int > Raid1DiskImpl::open_for_uring(int const iouring_device_start) {
     // Called once per queue thread before I/O begins; count queues for multi-queue idle tracking.
-    ++_nr_hw_queues;
-
-    // Only initialize on the first call (first queue thread)
-    if (_nr_hw_queues > 1) return {};
-
-    // Now that we're up and the target wants to begin I/O let's unpause our resync task, there are no i/o threads
-    // yet so we can continue to access _device_a and b directly
-    auto fds = (_device_a->disk->open_for_uring(iouring_device_start));
+    // Always collect FDs from child disks — each queue thread may need its own set.
+    auto fds = _device_a->disk->open_for_uring(iouring_device_start);
     fds.splice(fds.end(), _device_b->disk->open_for_uring(iouring_device_start + fds.size()));
 
-    // I/O will start comming in now, enable resync
-    toggle_resync(true);
+    // Enable resync only on the first call (first queue thread).
+    if (++_nr_hw_queues == 1) toggle_resync(true);
+
     return fds;
 }
 

--- a/src/raid/raid1/raid1.cpp
+++ b/src/raid/raid1/raid1.cpp
@@ -493,11 +493,12 @@ std::shared_ptr< UblkDisk > Raid1DiskImpl::swap_device(std::string const& outgoi
         incoming_mirror->unavail.test_and_set(std::memory_order_acquire);
     } catch (std::runtime_error const& e) { return incoming_device; }
 
-    // Terminate any ongoing resync task BEFORE clearing bitmap to avoid race condition
+    // Stop resync before touching the bitmap so the resync task doesn't race set_bit/clear_bit
+    // against our init_to() below. Write I/Os can still call set_bit() concurrently; clear_all()
+    // uses atomic byte stores to avoid UB with those.
     auto old_resync_flag = _resync_enabled.load(std::memory_order_relaxed);
     toggle_resync(false);
 
-    // Now safe to clear bitmap (resync stopped, no concurrent access)
     try {
         // TODO we need to save the SuperBitmap Here!
         if (!DEFUNCT_DEVICE(incoming_mirror->disk) && incoming_mirror->new_device)

--- a/src/raid/raid1/raid1.cpp
+++ b/src/raid/raid1/raid1.cpp
@@ -999,6 +999,8 @@ void Raid1DiskImpl::on_io_complete(ublk_io_data const* data, sub_cmd_t sub_cmd, 
 
 void Raid1DiskImpl::idle_transition(ublksrv_queue const*, bool enter) noexcept {
     if (!enter) {
+        DEBUG_ASSERT(_idle_queue_count.load(std::memory_order_relaxed) > 0,                      // LCOV_EXCL_LINE
+                     "idle_transition exit without matching enter — ublksrv contract violated"); // LCOV_EXCL_LINE
         _idle_queue_count.fetch_sub(1, std::memory_order_acq_rel);
         auto lk = std::unique_lock{_idle_probe_lock};
         _idle_probe_a.stop();

--- a/src/raid/raid1/raid1.cpp
+++ b/src/raid/raid1/raid1.cpp
@@ -295,15 +295,26 @@ std::list< int > Raid1DiskImpl::open_for_uring(ublksrv_queue const* q, int const
     return fds;
 }
 
-// Care must be taken in this routine as we need the correct order of the read_route, swap() and unavil calls.
-// Ensure that these are left in the order as they appear to prevent breaking the read-retry loop in
-// __capture_route_state(...)! While this occurs when threaded, it must access the _device_a and _device_b
-// pointers directly to mutate them. This is safe as long as we follow this requirement and hold the lock
-// throughout the "relative quick" operation (double sync I/O).
+// ── Mutual exclusion between __swap_device and __become_degraded ─────────────────────────────────
+// Both functions advance the RAID1 state machine by atomically CAS-ing _read_route_cache via
+// __set_read_route(). Because compare_exchange_strong() is atomic, exactly one caller wins:
+//
+//   • __swap_device    CAS: EITHER → DEVA/DEVB  (replacing a device with a healthy one)
+//   • __become_degraded CAS: EITHER → DEVA/DEVB  (marking a failed device as unavailable)
+//
+// If both race, the loser sees the CAS fail and returns early — no further state is mutated.
+// No additional lock is needed between them; the CAS IS the synchronization gate.
+//
+// __swap_device also holds _swap_lock so that two concurrent swap_device() callers don't race
+// on the _device_a/_device_b pointer mutations.  __become_degraded does NOT need _swap_lock
+// because it only reads those pointers via a captured RouteState snapshot and never mutates them.
+// ─────────────────────────────────────────────────────────────────────────────────────────────────
+//
+// The order of __set_read_route(), swap(), and unavail.clear() below must be preserved to keep
+// the read-retry loop in __capture_route_state() correct.
 bool Raid1DiskImpl::__swap_device(std::string const& outgoing_device_id,
                                   std::shared_ptr< MirrorDevice >& incoming_mirror,
                                   raid1::read_route const& cur_route) {
-    // Make this routine exclusive
     auto lg = std::scoped_lock< std::mutex >(_swap_lock);
 
     bool const swapping_device_a = (_device_a->disk->id() == outgoing_device_id);
@@ -604,6 +615,10 @@ io_result Raid1DiskImpl::__become_clean() {
     return 0;
 }
 
+// See the comment above __swap_device for the CAS-based mutual exclusion between this function
+// and __swap_device.  The __set_read_route() CAS below is the synchronization gate: if
+// __swap_device wins the CAS first, this call sees old_route != EITHER and returns early (already
+// degraded or concurrent swap in progress).  No additional lock is required.
 io_result Raid1DiskImpl::__become_degraded(sub_cmd_t failed_path, RouteState const* cur_state, bool spawn_resync) {
     // Determine new route based on which device failed
     auto old_route = read_route::EITHER;

--- a/src/raid/raid1/raid1.cpp
+++ b/src/raid/raid1/raid1.cpp
@@ -1009,6 +1009,9 @@ void Raid1DiskImpl::idle_transition(ublksrv_queue const*, bool enter) noexcept {
     }
 
     // Start probes only when all queue threads are idle.
+    // When _nr_hw_queues == 0 (no open_for_uring call yet), prev+1 < 0 is always false for
+    // uint16_t, so the probe fires unconditionally — preserving compat with zero-queue callers
+    // that skip open_for_uring (e.g. tests that call idle_transition directly).
     auto const prev = _idle_queue_count.fetch_add(1, std::memory_order_acq_rel);
     if (prev + 1 < _nr_hw_queues.load(std::memory_order_acquire)) return;
 

--- a/src/raid/raid1/raid1.cpp
+++ b/src/raid/raid1/raid1.cpp
@@ -276,11 +276,18 @@ Raid1DiskImpl::~Raid1DiskImpl() {
         write_superblock(*state.backup_dev->disk, _sb.get(), read_route::DEVB != state.route, state.route);
 }
 
-std::list< int > Raid1DiskImpl::open_for_uring(int const iouring_device_start) {
+std::list< int > Raid1DiskImpl::open_for_uring(ublksrv_queue const* q, int const iouring_device_start) {
     // Called once per queue thread before I/O begins; count queues for multi-queue idle tracking.
     // Always collect FDs from child disks — each queue thread may need its own set.
-    auto fds = _device_a->disk->open_for_uring(iouring_device_start);
-    fds.splice(fds.end(), _device_b->disk->open_for_uring(iouring_device_start + fds.size()));
+    auto fds = _device_a->disk->open_for_uring(q, iouring_device_start);
+    fds.splice(fds.end(), _device_b->disk->open_for_uring(q, iouring_device_start + fds.size()));
+
+    // Pre-populate _pending_results so runtime access never inserts (map insertion is not thread-safe).
+    // _swap_lock serializes concurrent open_for_uring calls from different queue threads.
+    if (q) {
+        auto lk = std::unique_lock{_swap_lock};
+        _pending_results.emplace(q, std::list< async_result >{});
+    }
 
     // Enable resync only on the first call (first queue thread).
     if (_nr_hw_queues.fetch_add(1, std::memory_order_acq_rel) == 0) toggle_resync(true);
@@ -664,7 +671,7 @@ io_result Raid1DiskImpl::__handle_async_retry(sub_cmd_t sub_cmd, uint64_t addr, 
     // Instead, inject a synthetic async_result carrying `len` into _pending_results so it is accumulated
     // into ret_val via the normal process_result path on the next collect_async cycle. Return +1 to
     // signal exactly one more sub_cmd pending.
-    _pending_results[q].emplace_back(async_result{async_data, sub_cmd, static_cast< int >(len)});
+    _pending_results.at(q).emplace_back(async_result{async_data, sub_cmd, static_cast< int >(len)});
     if (q) {
         if (0 != ublksrv_queue_send_event(q)) { // LCOV_EXCL_START
             RLOGE("Failed to send event!");
@@ -856,7 +863,8 @@ void Raid1DiskImpl::collect_async(ublksrv_queue const* q, std::list< async_resul
     // the normal process_result path. See the comment in __handle_async_retry for why this indirection is
     // necessary (short version: positive tgt return values are sub_cmd counts, not byte counts, so the byte
     // count cannot be delivered any other way).
-    results.splice(results.end(), std::move(_pending_results[q]));
+    if (auto it = _pending_results.find(q); it != _pending_results.end())
+        results.splice(results.end(), std::move(it->second));
     if (!state.active_dev->disk->uses_ublk_iouring) state.active_dev->disk->collect_async(q, results);
     if (!state.backup_dev->disk->uses_ublk_iouring) state.backup_dev->disk->collect_async(q, results);
 }

--- a/src/raid/raid1/raid1.cpp
+++ b/src/raid/raid1/raid1.cpp
@@ -503,7 +503,9 @@ std::shared_ptr< UblkDisk > Raid1DiskImpl::swap_device(std::string const& outgoi
     // Atomically swap the device or fail; fail if swapping sole active device
     if (__swap_device(outgoing_device_id, incoming_mirror, state.route)) {
         if (_raid_metrics) _raid_metrics->record_device_swap();
-        // Stop stale probes — they hold a shared_ptr to the outgoing MirrorDevice
+        // Stop stale probes — they hold a shared_ptr to the outgoing MirrorDevice.
+        // _idle_probe_lock guards _probe members against concurrent launch() in idle_transition.
+        auto lk = std::unique_lock{_idle_probe_lock};
         _idle_probe_a.stop();
         _idle_probe_b.stop();
     }

--- a/src/raid/raid1/raid1.cpp
+++ b/src/raid/raid1/raid1.cpp
@@ -283,9 +283,9 @@ std::list< int > Raid1DiskImpl::open_for_uring(ublksrv_queue const* q, int const
     fds.splice(fds.end(), _device_b->disk->open_for_uring(q, iouring_device_start + fds.size()));
 
     // Pre-populate _pending_results so runtime access never inserts (map insertion is not thread-safe).
-    // _swap_lock serializes concurrent open_for_uring calls from different queue threads.
+    // _ctrl_lock serializes concurrent open_for_uring calls from different queue threads.
     if (q) {
-        auto lk = std::unique_lock{_swap_lock};
+        auto lk = std::unique_lock{_ctrl_lock};
         _pending_results.emplace(q, std::list< async_result >{});
     }
 
@@ -305,8 +305,8 @@ std::list< int > Raid1DiskImpl::open_for_uring(ublksrv_queue const* q, int const
 // If both race, the loser sees the CAS fail and returns early — no further state is mutated.
 // No additional lock is needed between them; the CAS IS the synchronization gate.
 //
-// __swap_device also holds _swap_lock so that two concurrent swap_device() callers don't race
-// on the _device_a/_device_b pointer mutations.  __become_degraded does NOT need _swap_lock
+// __swap_device also holds _ctrl_lock so that two concurrent swap_device() callers don't race
+// on the _device_a/_device_b pointer mutations.  __become_degraded does NOT need _ctrl_lock
 // because it only reads those pointers via a captured RouteState snapshot and never mutates them.
 // ─────────────────────────────────────────────────────────────────────────────────────────────────
 //
@@ -315,7 +315,7 @@ std::list< int > Raid1DiskImpl::open_for_uring(ublksrv_queue const* q, int const
 bool Raid1DiskImpl::__swap_device(std::string const& outgoing_device_id,
                                   std::shared_ptr< MirrorDevice >& incoming_mirror,
                                   raid1::read_route const& cur_route) {
-    auto lg = std::scoped_lock< std::mutex >(_swap_lock);
+    auto lg = std::scoped_lock< std::mutex >(_ctrl_lock);
 
     bool const swapping_device_a = (_device_a->disk->id() == outgoing_device_id);
     auto new_read_route = swapping_device_a ? read_route::DEVB : read_route::DEVA;
@@ -687,7 +687,9 @@ io_result Raid1DiskImpl::__handle_async_retry(sub_cmd_t sub_cmd, uint64_t addr, 
     // Instead, inject a synthetic async_result carrying `len` into _pending_results so it is accumulated
     // into ret_val via the normal process_result path on the next collect_async cycle. Return +1 to
     // signal exactly one more sub_cmd pending.
-    _pending_results.at(q).emplace_back(async_result{async_data, sub_cmd, static_cast< int >(len)});
+    auto it = _pending_results.find(q);
+    DEBUG_ASSERT(it != _pending_results.end(), "queue not registered in _pending_results") // LCOV_EXCL_LINE
+    it->second.emplace_back(async_result{async_data, sub_cmd, static_cast< int >(len)});
     if (q) {
         if (0 != ublksrv_queue_send_event(q)) { // LCOV_EXCL_START
             RLOGE("Failed to send event!");
@@ -1011,10 +1013,7 @@ void Raid1DiskImpl::idle_transition(ublksrv_queue const*, bool enter) noexcept {
     auto const state = __capture_route_state();
     if (state.is_degraded) return; // Resync task handles avail probing in degraded mode
 
-    // Immediate probe: clear UNAVAIL on any device that has recovered (edge trigger, no delay).
-    // TOCTOU note: on_io_complete() may clear unavail between the test() and probe_mirror().
-    // If so, probe_mirror() still succeeds (device reachable) and the log fires spuriously.
-    // This is benign — the probe is idempotent and the worst case is one redundant log entry.
+    // Immediate synchronous probe: clear UNAVAIL on any device that has already recovered.
     auto const immediate_probe = [&](std::shared_ptr< MirrorDevice > const& mirror) {
         if (!mirror->unavail.test(std::memory_order_acquire)) return;
         if (probe_mirror(*mirror, reserved_size)) RLOGD("Idle probe: device recovered: {}", *mirror->disk)
@@ -1022,10 +1021,14 @@ void Raid1DiskImpl::idle_transition(ublksrv_queue const*, bool enter) noexcept {
     immediate_probe(state.active_dev);
     immediate_probe(state.backup_dev);
 
-    // Periodic probe: both directions (recovery + new failures), stopped when any queue exits idle
+    // Re-capture state under the lock so launch() uses the device that is actually current.
+    // swap_device() holds _idle_probe_lock while calling stop(), so acquiring the lock here
+    // ensures we cannot start a background probe for a device that was just swapped out.
     auto lk = std::unique_lock{_idle_probe_lock};
-    _idle_probe_a.launch(state.active_dev, reserved_size);
-    _idle_probe_b.launch(state.backup_dev, reserved_size);
+    auto const locked_state = __capture_route_state();
+    if (locked_state.is_degraded) return;
+    _idle_probe_a.launch(locked_state.active_dev, reserved_size);
+    _idle_probe_b.launch(locked_state.backup_dev, reserved_size);
 }
 
 void Raid1DiskImpl::toggle_resync(bool t) {

--- a/src/raid/raid1/raid1_impl.hpp
+++ b/src/raid/raid1/raid1_impl.hpp
@@ -49,7 +49,7 @@ class Raid1DiskImpl : public UblkDisk {
     std::map< ublksrv_queue const*, std::list< async_result > > _pending_results;
 
     // Active Re-Sync Task
-    bool _resync_enabled{true};
+    std::atomic< bool > _resync_enabled{true};
     std::shared_ptr< Raid1ResyncTask > _resync_task;
 
     // Ensure exclusivity in __swap_device

--- a/src/raid/raid1/raid1_impl.hpp
+++ b/src/raid/raid1/raid1_impl.hpp
@@ -147,7 +147,7 @@ public:
     /// UBlkDisk Interface Overrides
     /// ============================
     std::string id() const noexcept override { return "RAID1"; }
-    std::list< int > open_for_uring(int const iouring_device) override;
+    std::list< int > open_for_uring(ublksrv_queue const* q, int const iouring_device) override;
     void idle_transition(ublksrv_queue const* q, bool enter) noexcept override;
 
     uint8_t route_size() const noexcept override { return 1; }

--- a/src/raid/raid1/raid1_impl.hpp
+++ b/src/raid/raid1/raid1_impl.hpp
@@ -52,8 +52,9 @@ class Raid1DiskImpl : public UblkDisk {
     std::atomic< bool > _resync_enabled{true};
     std::shared_ptr< Raid1ResyncTask > _resync_task;
 
-    // Ensure exclusivity in __swap_device
-    std::mutex _swap_lock;
+    // Guards: (1) swap_device() — serializes concurrent callers on _device_a/_device_b mutations.
+    //         (2) _pending_results — serializes open_for_uring() insertions across queue threads.
+    std::mutex _ctrl_lock;
 
     // Multi-queue idle tracking: probe starts when all queues are idle, stops on any active transition
     std::atomic_uint16_t _nr_hw_queues{0};

--- a/src/raid/raid1/raid1_impl.hpp
+++ b/src/raid/raid1/raid1_impl.hpp
@@ -56,7 +56,7 @@ class Raid1DiskImpl : public UblkDisk {
     std::mutex _swap_lock;
 
     // Multi-queue idle tracking: probe starts when all queues are idle, stops on any active transition
-    uint16_t _nr_hw_queues{0};
+    std::atomic_uint16_t _nr_hw_queues{0};
     std::atomic_uint16_t _idle_queue_count{0};
 
     // Idle-scoped periodic health monitors

--- a/src/raid/raid1/raid1_impl.hpp
+++ b/src/raid/raid1/raid1_impl.hpp
@@ -55,7 +55,12 @@ class Raid1DiskImpl : public UblkDisk {
     // Ensure exclusivity in __swap_device
     std::mutex _swap_lock;
 
+    // Multi-queue idle tracking: probe starts when all queues are idle, stops on any active transition
+    uint16_t _nr_hw_queues{0};
+    std::atomic_uint16_t _idle_queue_count{0};
+
     // Idle-scoped periodic health monitors
+    std::mutex _idle_probe_lock;
     Raid1AvailProbeTask _idle_probe_a;
     Raid1AvailProbeTask _idle_probe_b;
 

--- a/src/raid/raid1/raid1_pimpl.cpp
+++ b/src/raid/raid1/raid1_pimpl.cpp
@@ -31,7 +31,9 @@ uint64_t Raid1Disk::capacity() const noexcept { return _impl->capacity(); }
 ublk_params* Raid1Disk::params() noexcept { return _impl->params(); }
 ublk_params const* Raid1Disk::params() const noexcept { return _impl->params(); }
 std::string Raid1Disk::id() const noexcept { return _impl->id(); }
-std::list< int > Raid1Disk::open_for_uring(int const iouring_device) { return _impl->open_for_uring(iouring_device); }
+std::list< int > Raid1Disk::open_for_uring(ublksrv_queue const* q, int const iouring_device) {
+    return _impl->open_for_uring(q, iouring_device);
+}
 uint8_t Raid1Disk::route_size() const noexcept { return _impl->route_size(); }
 void Raid1Disk::idle_transition(ublksrv_queue const* q, bool enter) { return _impl->idle_transition(q, enter); }
 void Raid1Disk::on_io_complete(ublk_io_data const* data, sub_cmd_t sub_cmd, int res) {

--- a/src/raid/raid1/super_bitmap.cpp
+++ b/src/raid/raid1/super_bitmap.cpp
@@ -1,7 +1,6 @@
 #include "super_bitmap.hpp"
 
 #include <atomic>
-#include <cstring>
 
 #include "lib/logging.hpp"
 
@@ -45,10 +44,11 @@ bool SuperBitmap::test_bit(uint32_t page_idx) const noexcept {
 
 void SuperBitmap::clear_all() noexcept {
     if (!_bits) return;
-    // NOTE: clear_all() should only be called during initialization (init_to) when
-    // no concurrent access is happening. Using memset here is safe in that context.
-    // If concurrent access is possible, the caller must provide external synchronization.
-    memset(_bits, 0x00, k_superbitmap_size);
+    // Use byte-by-byte atomic stores so concurrent set_bit() calls (from write I/Os that arrive
+    // during a device swap) don't produce UB via memset's potentially-wider stores racing with
+    // the per-byte atomic_ref operations on the same memory.
+    for (size_t i = 0; i < k_superbitmap_size; ++i)
+        std::atomic_ref< uint8_t >(_bits[i]).store(0, std::memory_order_relaxed);
 }
 
 uint32_t SuperBitmap::next_set_bit(uint32_t start_page) const noexcept {

--- a/src/raid/raid1/tests/bitmap/super_bitmap_test.cpp
+++ b/src/raid/raid1/tests/bitmap/super_bitmap_test.cpp
@@ -1,8 +1,9 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include <atomic>
+#include <barrier>
 #include <thread>
 #include <vector>
-#include <atomic>
 
 #include "raid/raid1/super_bitmap.hpp"
 #include "raid/raid1/raid1_superblock.hpp"
@@ -261,11 +262,14 @@ TEST_F(SuperBitmapTest, ConcurrentSetAndClearDifferentBits) {
 TEST_F(SuperBitmapTest, ConcurrentReadWhileWrite) {
     SuperBitmap sb(buffer.get());
 
+    constexpr int k_readers = 4;
     std::atomic< bool > stop{false};
     std::atomic< int > read_count{0};
+    std::barrier sync_point{k_readers + 1}; // writer + readers all rendezvous before work starts
 
     // Writer thread: sets bits 0-99
     std::thread writer([&]() {
+        sync_point.arrive_and_wait(); // don't start until all readers are alive
         for (int i = 0; i < 1000; ++i) {
             for (int bit = 0; bit < 100; ++bit) {
                 sb.set_bit(bit);
@@ -276,11 +280,12 @@ TEST_F(SuperBitmapTest, ConcurrentReadWhileWrite) {
 
     // Reader threads: read bits 0-99
     std::vector< std::thread > readers;
-    for (int t = 0; t < 4; ++t) {
+    for (int t = 0; t < k_readers; ++t) {
         readers.emplace_back([&]() {
+            sync_point.arrive_and_wait(); // signal ready, then start together with writer
             while (!stop.load()) {
                 for (int bit = 0; bit < 100; ++bit) {
-                    (void)sb.test_bit(bit); // Just read, don't care about result
+                    (void)sb.test_bit(bit);
                     read_count.fetch_add(1, std::memory_order_relaxed);
                 }
             }

--- a/src/raid/raid1/tests/concurrency/CMakeLists.txt
+++ b/src/raid/raid1/tests/concurrency/CMakeLists.txt
@@ -9,5 +9,6 @@ list(APPEND RAID1_TEST_SRCS
   concurrency/resync_relaunch_after_complete.cpp
   concurrency/stop_during_unavail_wait.cpp
   concurrency/concurrent_launch.cpp
+  concurrency/multi_queue_idle.cpp
 )
 set(RAID1_TEST_SRCS "${RAID1_TEST_SRCS}" PARENT_SCOPE)

--- a/src/raid/raid1/tests/concurrency/concurrent_launch.cpp
+++ b/src/raid/raid1/tests/concurrency/concurrent_launch.cpp
@@ -31,14 +31,10 @@ TEST(Raid1Concurrency, ConcurrentLaunch) {
 
     EXPECT_CALL(*device_a, sync_iov(::testing::_, _, _, _))
         .Times(::testing::AnyNumber())
-        .WillRepeatedly([](uint8_t, iovec* iovecs, uint32_t, off_t) -> ublkpp::io_result {
-            return static_cast< int >(iovecs->iov_len);
-        });
+        .WillRepeatedly(sync_iov_zero_on_read());
     EXPECT_CALL(*device_b, sync_iov(::testing::_, _, _, _))
         .Times(::testing::AnyNumber())
-        .WillRepeatedly([](uint8_t, iovec* iovecs, uint32_t, off_t) -> ublkpp::io_result {
-            return static_cast< int >(iovecs->iov_len);
-        });
+        .WillRepeatedly(sync_iov_zero_on_read());
 
     auto uuid = boost::uuids::string_generator()(test_uuid);
     auto mirror_a = std::make_shared< MirrorDevice >(uuid, device_a);

--- a/src/raid/raid1/tests/concurrency/multi_queue_idle.cpp
+++ b/src/raid/raid1/tests/concurrency/multi_queue_idle.cpp
@@ -1,0 +1,132 @@
+#include "test_raid1_common.hpp"
+
+#include <atomic>
+#include <barrier>
+#include <thread>
+#include <vector>
+
+using namespace std::chrono_literals;
+
+// Regression tests for issue #193: multi-queue idle probe correctness.
+//
+// Problem: idle_transition() was not safe for nr_hw_queues > 1:
+//   1. Concurrent calls raced on Raid1AvailProbeTask::_probe (unguarded jthread).
+//   2. Any single queue going idle started the probe; any single queue exiting idle stopped it.
+//
+// Fix:
+//   - _idle_probe_lock (mutex in Raid1DiskImpl) serializes all probe launch/stop calls.
+//   - _idle_queue_count (atomic) gates probe start until all queues are idle; stops on first exit.
+//   - _nr_hw_queues is set by counting open_for_uring() calls (one per queue thread, via init_queue).
+
+// Test: With nr_hw_queues=2, sequential idle_transition calls follow correct counting semantics.
+// Verifies: no crash, no deadlock, correct enter/exit sequencing.
+TEST(Raid1Concurrency, MultiQueueIdleSequential) {
+    auto device_a = CREATE_DISK_A(TestParams{.capacity = Gi});
+    auto device_b = CREATE_DISK_B(TestParams{.capacity = Gi});
+    auto raid_device = ublkpp::Raid1Disk(boost::uuids::string_generator()(test_uuid), device_a, device_b);
+
+    // Simulate 2 queue threads initializing (sets _nr_hw_queues = 2)
+    raid_device.open_for_uring(0); // queue 0: enables resync, _nr_hw_queues = 1
+    raid_device.open_for_uring(0); // queue 1: _nr_hw_queues = 2
+
+    // Queue 0 idle: count = 1 < 2, probe should NOT start yet
+    raid_device.idle_transition(nullptr, true);
+
+    // Queue 1 idle: count = 2 == 2, probe starts
+    raid_device.idle_transition(nullptr, true);
+
+    // Queue 0 exits idle: stops probes, count = 1
+    raid_device.idle_transition(nullptr, false);
+
+    // Queue 0 goes idle again: count = 2 == 2, probe restarts
+    raid_device.idle_transition(nullptr, true);
+
+    // Both queues exit idle: probes stopped
+    raid_device.idle_transition(nullptr, false);
+    raid_device.idle_transition(nullptr, false);
+
+    // Expect clean unmount writes
+    EXPECT_TO_WRITE_SB(device_a);
+    EXPECT_TO_WRITE_SB(device_b);
+}
+
+// Test: Concurrent idle_transition calls from N threads do not cause data races or deadlocks.
+// This test is primarily a TSAN regression test — run with -o sanitize=True to catch races.
+TEST(Raid1Concurrency, MultiQueueIdleConcurrent) {
+    auto device_a = CREATE_DISK_A(TestParams{.capacity = Gi});
+    auto device_b = CREATE_DISK_B(TestParams{.capacity = Gi});
+    auto raid_device = ublkpp::Raid1Disk(boost::uuids::string_generator()(test_uuid), device_a, device_b);
+
+    constexpr int k_queues = 4;
+    constexpr int k_iters = 50;
+
+    // Simulate k_queues queue threads (sets _nr_hw_queues = k_queues)
+    for (int i = 0; i < k_queues; ++i)
+        raid_device.open_for_uring(0);
+
+    // Allow any number of sync_iov calls in case the periodic probe fires unexpectedly
+    EXPECT_CALL(*device_a, sync_iov(::testing::_, ::testing::_, ::testing::_, ::testing::_))
+        .Times(::testing::AnyNumber())
+        .WillRepeatedly([](uint8_t, iovec* iovecs, uint32_t, off_t) -> ublkpp::io_result {
+            return static_cast< int >(iovecs->iov_len);
+        });
+    EXPECT_CALL(*device_b, sync_iov(::testing::_, ::testing::_, ::testing::_, ::testing::_))
+        .Times(::testing::AnyNumber())
+        .WillRepeatedly([](uint8_t, iovec* iovecs, uint32_t, off_t) -> ublkpp::io_result {
+            return static_cast< int >(iovecs->iov_len);
+        });
+
+    std::barrier sync_point{k_queues + 1};
+    std::vector< std::thread > threads;
+    threads.reserve(k_queues);
+
+    for (int q = 0; q < k_queues; ++q) {
+        threads.emplace_back([&] {
+            sync_point.arrive_and_wait(); // All threads fire simultaneously
+            for (int i = 0; i < k_iters; ++i) {
+                raid_device.idle_transition(nullptr, true);
+                raid_device.idle_transition(nullptr, false);
+            }
+        });
+    }
+
+    sync_point.arrive_and_wait(); // Release all threads
+    for (auto& t : threads)
+        t.join();
+
+    // Ensure all queues are in non-idle state (counter = 0) before destruction
+    EXPECT_TO_WRITE_SB(device_a);
+    EXPECT_TO_WRITE_SB(device_b);
+}
+
+// Test: Rapid single-queue idle toggle. Verifies the counter does not underflow when a queue
+// enters and exits idle rapidly (common under bursty workloads). No crash or deadlock expected.
+TEST(Raid1Concurrency, MultiQueueIdleRapidToggle) {
+    auto device_a = CREATE_DISK_A(TestParams{.capacity = Gi});
+    auto device_b = CREATE_DISK_B(TestParams{.capacity = Gi});
+    auto raid_device = ublkpp::Raid1Disk(boost::uuids::string_generator()(test_uuid), device_a, device_b);
+
+    // Single queue (default: _nr_hw_queues = 0, treated as 1 for backward compat)
+    raid_device.open_for_uring(0);
+
+    // Allow any number of sync_iov calls in case the periodic probe fires
+    EXPECT_CALL(*device_a, sync_iov(::testing::_, ::testing::_, ::testing::_, ::testing::_))
+        .Times(::testing::AnyNumber())
+        .WillRepeatedly([](uint8_t, iovec* iovecs, uint32_t, off_t) -> ublkpp::io_result {
+            return static_cast< int >(iovecs->iov_len);
+        });
+    EXPECT_CALL(*device_b, sync_iov(::testing::_, ::testing::_, ::testing::_, ::testing::_))
+        .Times(::testing::AnyNumber())
+        .WillRepeatedly([](uint8_t, iovec* iovecs, uint32_t, off_t) -> ublkpp::io_result {
+            return static_cast< int >(iovecs->iov_len);
+        });
+
+    constexpr int k_iters = 200;
+    for (int i = 0; i < k_iters; ++i) {
+        raid_device.idle_transition(nullptr, true);
+        raid_device.idle_transition(nullptr, false);
+    }
+
+    EXPECT_TO_WRITE_SB(device_a);
+    EXPECT_TO_WRITE_SB(device_b);
+}

--- a/src/raid/raid1/tests/concurrency/multi_queue_idle.cpp
+++ b/src/raid/raid1/tests/concurrency/multi_queue_idle.cpp
@@ -26,8 +26,8 @@ TEST(Raid1Concurrency, MultiQueueIdleSequential) {
     auto raid_device = ublkpp::Raid1Disk(boost::uuids::string_generator()(test_uuid), device_a, device_b);
 
     // Simulate 2 queue threads initializing (sets _nr_hw_queues = 2)
-    raid_device.open_for_uring(0); // queue 0: enables resync, _nr_hw_queues = 1
-    raid_device.open_for_uring(0); // queue 1: _nr_hw_queues = 2
+    raid_device.open_for_uring(nullptr, 0); // queue 0: enables resync, _nr_hw_queues = 1
+    raid_device.open_for_uring(nullptr, 0); // queue 1: _nr_hw_queues = 2
 
     // Queue 0 idle: count = 1 < 2, probe should NOT start yet
     raid_device.idle_transition(nullptr, true);
@@ -62,7 +62,7 @@ TEST(Raid1Concurrency, MultiQueueIdleConcurrent) {
 
     // Simulate k_queues queue threads (sets _nr_hw_queues = k_queues)
     for (int i = 0; i < k_queues; ++i)
-        raid_device.open_for_uring(0);
+        raid_device.open_for_uring(nullptr, 0);
 
     // Allow any number of sync_iov calls in case the periodic probe fires unexpectedly
     EXPECT_CALL(*device_a, sync_iov(::testing::_, ::testing::_, ::testing::_, ::testing::_))
@@ -107,7 +107,7 @@ TEST(Raid1Concurrency, MultiQueueIdleRapidToggle) {
     auto raid_device = ublkpp::Raid1Disk(boost::uuids::string_generator()(test_uuid), device_a, device_b);
 
     // Single queue (default: _nr_hw_queues = 0, treated as 1 for backward compat)
-    raid_device.open_for_uring(0);
+    raid_device.open_for_uring(nullptr, 0);
 
     // Allow any number of sync_iov calls in case the periodic probe fires
     EXPECT_CALL(*device_a, sync_iov(::testing::_, ::testing::_, ::testing::_, ::testing::_))

--- a/src/raid/raid1/tests/concurrency/multi_queue_idle.cpp
+++ b/src/raid/raid1/tests/concurrency/multi_queue_idle.cpp
@@ -26,24 +26,25 @@ TEST(Raid1Concurrency, MultiQueueIdleSequential) {
     auto raid_device = ublkpp::Raid1Disk(boost::uuids::string_generator()(test_uuid), device_a, device_b);
 
     // Simulate 2 queue threads initializing (sets _nr_hw_queues = 2)
-    raid_device.open_for_uring(nullptr, 0); // queue 0: enables resync, _nr_hw_queues = 1
-    raid_device.open_for_uring(nullptr, 0); // queue 1: _nr_hw_queues = 2
+    ublksrv_queue queues[2]{};
+    raid_device.open_for_uring(&queues[0], 0); // queue 0: enables resync, _nr_hw_queues = 1
+    raid_device.open_for_uring(&queues[1], 0); // queue 1: _nr_hw_queues = 2
 
     // Queue 0 idle: count = 1 < 2, probe should NOT start yet
-    raid_device.idle_transition(nullptr, true);
+    raid_device.idle_transition(&queues[0], true);
 
     // Queue 1 idle: count = 2 == 2, probe starts
-    raid_device.idle_transition(nullptr, true);
+    raid_device.idle_transition(&queues[1], true);
 
     // Queue 0 exits idle: stops probes, count = 1
-    raid_device.idle_transition(nullptr, false);
+    raid_device.idle_transition(&queues[0], false);
 
     // Queue 0 goes idle again: count = 2 == 2, probe restarts
-    raid_device.idle_transition(nullptr, true);
+    raid_device.idle_transition(&queues[0], true);
 
     // Both queues exit idle: probes stopped
-    raid_device.idle_transition(nullptr, false);
-    raid_device.idle_transition(nullptr, false);
+    raid_device.idle_transition(&queues[0], false);
+    raid_device.idle_transition(&queues[1], false);
 
     // Expect clean unmount writes
     EXPECT_TO_WRITE_SB(device_a);
@@ -61,31 +62,28 @@ TEST(Raid1Concurrency, MultiQueueIdleConcurrent) {
     constexpr int k_iters = 50;
 
     // Simulate k_queues queue threads (sets _nr_hw_queues = k_queues)
+    ublksrv_queue queues[k_queues]{};
     for (int i = 0; i < k_queues; ++i)
-        raid_device.open_for_uring(nullptr, 0);
+        raid_device.open_for_uring(&queues[i], 0);
 
     // Allow any number of sync_iov calls in case the periodic probe fires unexpectedly
     EXPECT_CALL(*device_a, sync_iov(::testing::_, ::testing::_, ::testing::_, ::testing::_))
         .Times(::testing::AnyNumber())
-        .WillRepeatedly([](uint8_t, iovec* iovecs, uint32_t, off_t) -> ublkpp::io_result {
-            return static_cast< int >(iovecs->iov_len);
-        });
+        .WillRepeatedly(sync_iov_zero_on_read());
     EXPECT_CALL(*device_b, sync_iov(::testing::_, ::testing::_, ::testing::_, ::testing::_))
         .Times(::testing::AnyNumber())
-        .WillRepeatedly([](uint8_t, iovec* iovecs, uint32_t, off_t) -> ublkpp::io_result {
-            return static_cast< int >(iovecs->iov_len);
-        });
+        .WillRepeatedly(sync_iov_zero_on_read());
 
     std::barrier sync_point{k_queues + 1};
     std::vector< std::thread > threads;
     threads.reserve(k_queues);
 
     for (int q = 0; q < k_queues; ++q) {
-        threads.emplace_back([&] {
+        threads.emplace_back([&, q] {
             sync_point.arrive_and_wait(); // All threads fire simultaneously
             for (int i = 0; i < k_iters; ++i) {
-                raid_device.idle_transition(nullptr, true);
-                raid_device.idle_transition(nullptr, false);
+                raid_device.idle_transition(&queues[q], true);
+                raid_device.idle_transition(&queues[q], false);
             }
         });
     }
@@ -106,27 +104,74 @@ TEST(Raid1Concurrency, MultiQueueIdleRapidToggle) {
     auto device_b = CREATE_DISK_B(TestParams{.capacity = Gi});
     auto raid_device = ublkpp::Raid1Disk(boost::uuids::string_generator()(test_uuid), device_a, device_b);
 
-    // Single queue (default: _nr_hw_queues = 0, treated as 1 for backward compat)
-    raid_device.open_for_uring(nullptr, 0);
+    // Single queue with a real pointer so _pending_results.emplace is exercised
+    ublksrv_queue q{};
+    raid_device.open_for_uring(&q, 0);
 
     // Allow any number of sync_iov calls in case the periodic probe fires
     EXPECT_CALL(*device_a, sync_iov(::testing::_, ::testing::_, ::testing::_, ::testing::_))
         .Times(::testing::AnyNumber())
-        .WillRepeatedly([](uint8_t, iovec* iovecs, uint32_t, off_t) -> ublkpp::io_result {
-            return static_cast< int >(iovecs->iov_len);
-        });
+        .WillRepeatedly(sync_iov_zero_on_read());
     EXPECT_CALL(*device_b, sync_iov(::testing::_, ::testing::_, ::testing::_, ::testing::_))
         .Times(::testing::AnyNumber())
-        .WillRepeatedly([](uint8_t, iovec* iovecs, uint32_t, off_t) -> ublkpp::io_result {
-            return static_cast< int >(iovecs->iov_len);
-        });
+        .WillRepeatedly(sync_iov_zero_on_read());
 
     constexpr int k_iters = 200;
     for (int i = 0; i < k_iters; ++i) {
-        raid_device.idle_transition(nullptr, true);
-        raid_device.idle_transition(nullptr, false);
+        raid_device.idle_transition(&q, true);
+        raid_device.idle_transition(&q, false);
     }
 
     EXPECT_TO_WRITE_SB(device_a);
     EXPECT_TO_WRITE_SB(device_b);
+}
+
+// Test: swap_device() races safely against idle_transition() — the probe uses state re-captured
+// under _idle_probe_lock so launch() never targets a device that was just swapped out.
+// Run with -o sanitize=True; TSAN catches a data race on the device pointer if the locked
+// re-capture is removed.
+TEST(Raid1Concurrency, SwapDeviceWhileIdleTransitioning) {
+    auto device_a = CREATE_DISK_A((TestParams{.capacity = Gi, .id = "DiskA"}));
+    auto device_b = CREATE_DISK_B((TestParams{.capacity = Gi, .id = "DiskB"}));
+    auto raid_device = ublkpp::Raid1Disk(boost::uuids::string_generator()(test_uuid), device_a, device_b);
+
+    // 2 queues with real pointers so _nr_hw_queues == 2 and _pending_results is populated
+    ublksrv_queue queues[2]{};
+    raid_device.open_for_uring(&queues[0], 0);
+    raid_device.open_for_uring(&queues[1], 0);
+
+    // Cover probe and swap I/O for device_a (stays throughout) and device_b (swapped out)
+    EXPECT_CALL(*device_a, sync_iov(::testing::_, ::testing::_, ::testing::_, ::testing::_))
+        .Times(::testing::AnyNumber())
+        .WillRepeatedly(sync_iov_zero_on_read());
+    EXPECT_CALL(*device_b, sync_iov(::testing::_, ::testing::_, ::testing::_, ::testing::_))
+        .Times(::testing::AnyNumber())
+        .WillRepeatedly(sync_iov_zero_on_read());
+
+    auto device_c = std::make_shared< ublkpp::TestDisk >(TestParams{.capacity = Gi, .id = "DiskC"});
+    EXPECT_CALL(*device_c, sync_iov(::testing::_, ::testing::_, ::testing::_, ::testing::_))
+        .Times(::testing::AnyNumber())
+        .WillRepeatedly(sync_iov_zero_on_read());
+
+    std::atomic< bool > stop{false};
+    std::barrier<> sync_point{2};
+
+    // Idle thread: both queues enter idle (triggering probe launch) then exit, in a tight loop
+    auto idle_thread = std::thread([&] {
+        sync_point.arrive_and_wait();
+        while (!stop.load(std::memory_order_relaxed)) {
+            raid_device.idle_transition(&queues[0], true);
+            raid_device.idle_transition(&queues[1], true);
+            raid_device.idle_transition(&queues[0], false);
+            raid_device.idle_transition(&queues[1], false);
+        }
+    });
+
+    // Swap device_b → device_c while the idle thread is hammering idle_transition
+    sync_point.arrive_and_wait();
+    auto old_dev = raid_device.swap_device("DiskB", device_c);
+    EXPECT_EQ(old_dev, device_b);
+
+    stop.store(true, std::memory_order_relaxed);
+    idle_thread.join();
 }

--- a/src/raid/raid1/tests/concurrency/resync_relaunch_after_complete.cpp
+++ b/src/raid/raid1/tests/concurrency/resync_relaunch_after_complete.cpp
@@ -29,17 +29,12 @@ TEST(Raid1Concurrency, ResyncRelaunchAfterComplete) {
     auto device_a = std::make_shared< ublkpp::TestDisk >(TestParams{.capacity = Gi, .id = "DiskA"});
     auto device_b = std::make_shared< ublkpp::TestDisk >(TestParams{.capacity = Gi, .id = "DiskB", .is_slot_b = true});
 
-    // All sync I/O succeeds (bitmap page reads/writes during resync)
     EXPECT_CALL(*device_a, sync_iov(::testing::_, _, _, _))
         .Times(::testing::AnyNumber())
-        .WillRepeatedly([](uint8_t, iovec* iovecs, uint32_t, off_t) -> ublkpp::io_result {
-            return static_cast< int >(iovecs->iov_len);
-        });
+        .WillRepeatedly(sync_iov_zero_on_read());
     EXPECT_CALL(*device_b, sync_iov(::testing::_, _, _, _))
         .Times(::testing::AnyNumber())
-        .WillRepeatedly([](uint8_t, iovec* iovecs, uint32_t, off_t) -> ublkpp::io_result {
-            return static_cast< int >(iovecs->iov_len);
-        });
+        .WillRepeatedly(sync_iov_zero_on_read());
 
     auto uuid = boost::uuids::string_generator()(test_uuid);
     auto mirror_a = std::make_shared< MirrorDevice >(uuid, device_a);

--- a/src/raid/raid1/tests/concurrency/stop_during_unavail_wait.cpp
+++ b/src/raid/raid1/tests/concurrency/stop_during_unavail_wait.cpp
@@ -30,9 +30,7 @@ TEST(Raid1Concurrency, StopDuringUnavailWait) {
 
     EXPECT_CALL(*device_a, sync_iov(::testing::_, _, _, _))
         .Times(::testing::AnyNumber())
-        .WillRepeatedly([](uint8_t, iovec* iovecs, uint32_t, off_t) -> ublkpp::io_result {
-            return static_cast< int >(iovecs->iov_len);
-        });
+        .WillRepeatedly(sync_iov_zero_on_read());
     // First call: superblock read during MirrorDevice construction — must succeed.
     // Subsequent calls: probe reads during unavail loop — always fail to keep mirror_b unavail.
     EXPECT_CALL(*device_b, sync_iov(::testing::_, _, _, _))

--- a/src/raid/raid1/tests/misc/open_devices.cpp
+++ b/src/raid/raid1/tests/misc/open_devices.cpp
@@ -11,19 +11,19 @@ TEST(Raid1, OpenDevices) {
     auto device_b = CREATE_DISK_B(TestParams{.capacity = Gi});
 
     // Each device should be subsequently opened and return a set with their sole FD.
-    EXPECT_CALL(*device_a, open_for_uring(_)).Times(1).WillOnce([](int const fd_off) {
+    EXPECT_CALL(*device_a, open_for_uring(_, _)).Times(1).WillOnce([](ublksrv_queue const*, int const fd_off) {
         EXPECT_EQ(start_idx, fd_off);
         // Return 2 FDs here, maybe it's another RAID1 device?
         return std::list< int >{INT_MAX - 2, INT_MAX - 3};
     });
-    EXPECT_CALL(*device_b, open_for_uring(_)).Times(1).WillOnce([](int const fd_off) {
+    EXPECT_CALL(*device_b, open_for_uring(_, _)).Times(1).WillOnce([](ublksrv_queue const*, int const fd_off) {
         // Device A took 2 uring offsets
         EXPECT_EQ(start_idx + 2, fd_off);
         return std::list< int >{INT_MAX - 1};
     });
 
     auto raid_device = ublkpp::Raid1Disk(boost::uuids::string_generator()(test_uuid), device_a, device_b);
-    auto fd_list = raid_device.open_for_uring(2);
+    auto fd_list = raid_device.open_for_uring(nullptr, 2);
     EXPECT_EQ(3, fd_list.size());
     EXPECT_NE(fd_list.end(), std::find(fd_list.begin(), fd_list.end(), (INT_MAX - 3)));
     EXPECT_NE(fd_list.end(), std::find(fd_list.begin(), fd_list.end(), (INT_MAX - 2)));

--- a/src/raid/raid1/tests/misc/open_for_uring.cpp
+++ b/src/raid/raid1/tests/misc/open_for_uring.cpp
@@ -6,13 +6,13 @@ TEST(Raid1, OpenForUring) {
     auto device_b = CREATE_DISK_B(TestParams{.capacity = Gi});
 
     // Set up expectations for open_for_uring
-    EXPECT_CALL(*device_a, open_for_uring(0)).Times(1).WillOnce(::testing::Return(std::list< int >{10, 11}));
+    EXPECT_CALL(*device_a, open_for_uring(_, 0)).Times(1).WillOnce(::testing::Return(std::list< int >{10, 11}));
 
-    EXPECT_CALL(*device_b, open_for_uring(2)).Times(1).WillOnce(::testing::Return(std::list< int >{12}));
+    EXPECT_CALL(*device_b, open_for_uring(_, 2)).Times(1).WillOnce(::testing::Return(std::list< int >{12}));
 
     auto raid_device = ublkpp::Raid1Disk(boost::uuids::string_generator()(test_uuid), device_a, device_b);
 
-    auto fds = raid_device.open_for_uring(0);
+    auto fds = raid_device.open_for_uring(nullptr, 0);
 
     // Should have 3 FDs total (2 from device_a, 1 from device_b)
     ASSERT_EQ(fds.size(), 3);
@@ -33,13 +33,13 @@ TEST(Raid1, OpenForUringEmpty) {
     auto device_b = CREATE_DISK_B(TestParams{.capacity = Gi});
 
     // Both devices return empty lists
-    EXPECT_CALL(*device_a, open_for_uring(0)).Times(1).WillOnce(::testing::Return(std::list< int >{}));
+    EXPECT_CALL(*device_a, open_for_uring(_, 0)).Times(1).WillOnce(::testing::Return(std::list< int >{}));
 
-    EXPECT_CALL(*device_b, open_for_uring(0)).Times(1).WillOnce(::testing::Return(std::list< int >{}));
+    EXPECT_CALL(*device_b, open_for_uring(_, 0)).Times(1).WillOnce(::testing::Return(std::list< int >{}));
 
     auto raid_device = ublkpp::Raid1Disk(boost::uuids::string_generator()(test_uuid), device_a, device_b);
 
-    auto fds = raid_device.open_for_uring(0);
+    auto fds = raid_device.open_for_uring(nullptr, 0);
 
     EXPECT_TRUE(fds.empty());
 
@@ -54,13 +54,13 @@ TEST(Raid1, OpenForUringOffsetCalculation) {
     auto device_b = CREATE_DISK_B(TestParams{.capacity = Gi});
 
     // Device A returns 3 FDs, so device B should get offset of 103 (100 + 3)
-    EXPECT_CALL(*device_a, open_for_uring(100)).Times(1).WillOnce(::testing::Return(std::list< int >{5, 6, 7}));
+    EXPECT_CALL(*device_a, open_for_uring(_, 100)).Times(1).WillOnce(::testing::Return(std::list< int >{5, 6, 7}));
 
-    EXPECT_CALL(*device_b, open_for_uring(103)).Times(1).WillOnce(::testing::Return(std::list< int >{8, 9}));
+    EXPECT_CALL(*device_b, open_for_uring(_, 103)).Times(1).WillOnce(::testing::Return(std::list< int >{8, 9}));
 
     auto raid_device = ublkpp::Raid1Disk(boost::uuids::string_generator()(test_uuid), device_a, device_b);
 
-    auto fds = raid_device.open_for_uring(100);
+    auto fds = raid_device.open_for_uring(nullptr, 100);
 
     ASSERT_EQ(fds.size(), 5);
 

--- a/src/raid/raid1/tests/retry/read_unavail_test.cpp
+++ b/src/raid/raid1/tests/retry/read_unavail_test.cpp
@@ -310,7 +310,13 @@ TEST(Raid1, IdleExitSkipsProbe) {
     iov[0].iov_len = 4 * Ki;
     RUN_IN_THREAD({ ASSERT_TRUE(raid_device.sync_iov(UBLK_IO_OP_READ, iov.data(), 1, 12 * Ki)); });
 
-    // Exit idle — no probe sync_iov expected (GMock will catch unexpected calls)
+    // Simulate 2 queues so idle_transition(true) returns early (count 1 < 2) without probing
+    // the UNAVAIL device — we want to verify that idle exit alone skips the probe.
+    raid_device.open_for_uring(nullptr, 0);
+    raid_device.open_for_uring(nullptr, 0);
+    // Queue 0 enters idle: count = 1 < 2, no probe fired (satisfies the enter-before-exit contract)
+    raid_device.idle_transition(nullptr, true);
+    // Queue 0 exits idle — no probe sync_iov expected (GMock will catch unexpected calls)
     raid_device.idle_transition(nullptr, false);
 
     // UNAVAIL must remain unchanged

--- a/src/raid/raid1/tests/simple/idle_and_collect.cpp
+++ b/src/raid/raid1/tests/simple/idle_and_collect.cpp
@@ -15,8 +15,8 @@ TEST(Raid1, IdleTransitionEnter) {
     EXPECT_TO_WRITE_SB(device_b);
 }
 
-// Test: idle_transition exit (manages resync state, doesn't propagate to devices)
-TEST(Raid1, IdleTransitionExit) {
+// Test: idle_transition enter+exit round trip (manages resync state, doesn't propagate to devices)
+TEST(Raid1, IdleTransitionRoundTrip) {
     auto device_a = CREATE_DISK_A(TestParams{.capacity = Gi});
     auto device_b = CREATE_DISK_B(TestParams{.capacity = Gi});
 

--- a/src/raid/raid1/tests/simple/idle_and_collect.cpp
+++ b/src/raid/raid1/tests/simple/idle_and_collect.cpp
@@ -23,6 +23,9 @@ TEST(Raid1, IdleTransitionExit) {
     auto raid_device = ublkpp::Raid1Disk(boost::uuids::string_generator()(test_uuid), device_a, device_b);
 
     // Should not crash - manages internal resync state
+    // enter must precede exit to satisfy the ublksrv contract (both devices are available
+    // so the immediate probe inside idle_transition(true) is a no-op)
+    raid_device.idle_transition(nullptr, true);
     raid_device.idle_transition(nullptr, false);
 
     // Expect unmount_clean update

--- a/src/raid/raid1/tests/test_raid1_common.hpp
+++ b/src/raid/raid1/tests/test_raid1_common.hpp
@@ -34,6 +34,16 @@ static const ublkpp::raid1::SuperBlock normal_superblock = {
 
 static std::string const test_uuid("ada40737-30e3-49fe-9942-5a287d71eb3f");
 
+// Helper for tests that create MirrorDevice directly: zero the buffer on READ so that
+// posix_memalign's uninitialised memory cannot accidentally look like a superblock with
+// a mismatched UUID.
+inline auto sync_iov_zero_on_read() {
+    return [](uint8_t op, iovec* iovecs, uint32_t, off_t) -> ublkpp::io_result {
+        if (op == UBLK_IO_OP_READ && iovecs->iov_base) memset(iovecs->iov_base, 0, iovecs->iov_len);
+        return static_cast< int >(iovecs->iov_len);
+    };
+}
+
 // Helper for tests: allocate a SuperBitmap buffer for Bitmap constructor
 inline std::unique_ptr< uint8_t[] > make_test_superbitmap() {
     auto buf = std::make_unique< uint8_t[] >(ublkpp::raid1::k_superbitmap_size);

--- a/src/target/ublkpp_tgt.cpp
+++ b/src/target/ublkpp_tgt.cpp
@@ -444,7 +444,7 @@ static void idle_transition(ublksrv_queue const* q, bool enter) {
 static int init_queue(const struct ublksrv_queue* q, void**) {
     TLOGD("Init Queue")
     auto device = reinterpret_cast< UblkDisk* >(q->dev->tgt.tgt_data);
-    device->open_for_uring(0);
+    device->open_for_uring(q, 0);
     return 0;
 }
 static void deinit_queue(const struct ublksrv_queue*){TLOGD("Deinit Queue")}

--- a/src/target/ublkpp_tgt.cpp
+++ b/src/target/ublkpp_tgt.cpp
@@ -428,11 +428,10 @@ static int init_tgt(ublksrv_dev* dev, int, int, char*[]) {
     ublksrv_tgt->dev_size = ublk_disk->params()->basic.dev_sectors << SECTOR_SHIFT;
     ublksrv_tgt->tgt_ring_depth = ublksrv_ctrl_get_dev_info(ublksrv_get_ctrl_dev(dev))->queue_depth;
 
-    // iouring FD 0 is reserved for the ublkc device, so start gathering from there
+    // iouring FD 0 is reserved for the ublkc device; open_for_uring is called per queue in init_queue.
+    // NOTE: if future disks export non-empty FDs they must be registered here (before ublksrv_queue_init
+    // calls io_uring_register_files). For now all disks return empty so init_queue suffices.
     ublksrv_tgt->nr_fds = 1;
-    for (auto const fd : ublk_disk->open_for_uring(ublksrv_tgt->nr_fds)) {
-        ublksrv_tgt->fds[ublksrv_tgt->nr_fds++] = fd;
-    }
     return 0;
 }
 
@@ -442,8 +441,10 @@ static void idle_transition(ublksrv_queue const* q, bool enter) {
     auto device = reinterpret_cast< UblkDisk* >(q->dev->tgt.tgt_data);
     device->idle_transition(q, enter);
 }
-static int init_queue(const struct ublksrv_queue*, void**) {
+static int init_queue(const struct ublksrv_queue* q, void**) {
     TLOGD("Init Queue")
+    auto device = reinterpret_cast< UblkDisk* >(q->dev->tgt.tgt_data);
+    device->open_for_uring(0);
     return 0;
 }
 static void deinit_queue(const struct ublksrv_queue*){TLOGD("Deinit Queue")}

--- a/src/target/ublkpp_tgt.cpp
+++ b/src/target/ublkpp_tgt.cpp
@@ -444,7 +444,9 @@ static void idle_transition(ublksrv_queue const* q, bool enter) {
 static int init_queue(const struct ublksrv_queue* q, void**) {
     TLOGD("Init Queue")
     auto device = reinterpret_cast< UblkDisk* >(q->dev->tgt.tgt_data);
-    device->open_for_uring(q, 0);
+    // All current disk types return no FDs from per-queue init; non-empty means the FDs would go
+    // unregistered with io_uring and fixed-file I/O would crash — treat it as a fatal init failure.
+    if (!device->open_for_uring(q, 0).empty()) return -1;
     return 0;
 }
 static void deinit_queue(const struct ublksrv_queue*){TLOGD("Deinit Queue")}

--- a/src/tests/mock_ublksrv/mock_ublksrv.cpp
+++ b/src/tests/mock_ublksrv/mock_ublksrv.cpp
@@ -28,22 +28,22 @@ MockUblksrv::MockUblksrv(std::shared_ptr< UblkDisk > disk, int q_depth, int nr_q
     _dev.tgt.tgt_ring_depth = static_cast< unsigned >(q_depth);
     _dev.tgt.nr_fds = 1; // slot 0 reserved (mirrors ublkpp_tgt convention)
 
-    // Simulate init_queue: call open_for_uring once per queue thread so the disk can count queues
-    // and perform per-queue initialization (e.g. Raid1DiskImpl sets _nr_hw_queues and enables resync).
-    for (int qi = 0; qi < nr_queues; ++qi) {
-        for (auto const fd : _disk->open_for_uring(&_queues[qi], _dev.tgt.nr_fds)) {
-            if (_dev.tgt.nr_fds < UBLKSRV_TGT_MAX_FDS) _dev.tgt.fds[_dev.tgt.nr_fds++] = fd;
-        }
-    }
-
-    // Populate ublksrv_queue structs — the only fields disk code actually reads are
-    // ring_ptr (for io_uring_get_sqe) and dev (for dev->tgt.tgt_data)
+    // Populate ublksrv_queue structs before calling open_for_uring so that any implementation
+    // which reads ring_ptr or dev inside open_for_uring sees valid values.
     for (int qi = 0; qi < nr_queues; ++qi) {
         _queues[qi].q_id = qi;
         _queues[qi].q_depth = q_depth;
         _queues[qi].ring_ptr = &_ring;
         _queues[qi].dev = &_dev;
         _queues[qi].private_data = nullptr;
+    }
+
+    // Simulate init_queue: call open_for_uring once per queue thread so the disk can count queues
+    // and perform per-queue initialization (e.g. Raid1DiskImpl sets _nr_hw_queues and enables resync).
+    for (int qi = 0; qi < nr_queues; ++qi) {
+        for (auto const fd : _disk->open_for_uring(&_queues[qi], _dev.tgt.nr_fds)) {
+            if (_dev.tgt.nr_fds < UBLKSRV_TGT_MAX_FDS) _dev.tgt.fds[_dev.tgt.nr_fds++] = fd;
+        }
     }
 
     // Wire up per-tag data.iod pointers

--- a/src/tests/mock_ublksrv/mock_ublksrv.cpp
+++ b/src/tests/mock_ublksrv/mock_ublksrv.cpp
@@ -16,8 +16,8 @@ namespace ublkpp {
 static constexpr size_t k_max_io_size = DEF_BUF_SIZE;
 static constexpr size_t k_sector_align = 512;
 
-MockUblksrv::MockUblksrv(std::shared_ptr< UblkDisk > disk, int q_depth) :
-        _q_depth(q_depth), _disk(std::move(disk)), _tags(q_depth) {
+MockUblksrv::MockUblksrv(std::shared_ptr< UblkDisk > disk, int q_depth, int nr_queues) :
+        _q_depth(q_depth), _disk(std::move(disk)), _tags(q_depth), _queues(nr_queues) {
     // q_depth * 4 gives headroom for RAID1 write amplification (2x replicas +
     // 2x bitmap SQEs per user write) without false "ring full" auto-submits.
     if (io_uring_queue_init(q_depth * 4, &_ring, 0) < 0) throw std::runtime_error("io_uring_queue_init failed");
@@ -28,19 +28,23 @@ MockUblksrv::MockUblksrv(std::shared_ptr< UblkDisk > disk, int q_depth) :
     _dev.tgt.tgt_ring_depth = static_cast< unsigned >(q_depth);
     _dev.tgt.nr_fds = 1; // slot 0 reserved (mirrors ublkpp_tgt convention)
 
-    // Register any FDs the disk exports (Raid0/Raid1 forward from FsDisks;
-    // FSDisk currently returns empty since fixed-file support is disabled)
-    for (auto const fd : _disk->open_for_uring(_dev.tgt.nr_fds)) {
-        if (_dev.tgt.nr_fds < UBLKSRV_TGT_MAX_FDS) _dev.tgt.fds[_dev.tgt.nr_fds++] = fd;
+    // Simulate init_queue: call open_for_uring once per queue thread so the disk can count queues
+    // and perform per-queue initialization (e.g. Raid1DiskImpl sets _nr_hw_queues and enables resync).
+    for (int qi = 0; qi < nr_queues; ++qi) {
+        for (auto const fd : _disk->open_for_uring(_dev.tgt.nr_fds)) {
+            if (_dev.tgt.nr_fds < UBLKSRV_TGT_MAX_FDS) _dev.tgt.fds[_dev.tgt.nr_fds++] = fd;
+        }
     }
 
-    // Populate ublksrv_queue — the only fields disk code actually reads are
+    // Populate ublksrv_queue structs — the only fields disk code actually reads are
     // ring_ptr (for io_uring_get_sqe) and dev (for dev->tgt.tgt_data)
-    _q.q_id = 0;
-    _q.q_depth = q_depth;
-    _q.ring_ptr = &_ring;
-    _q.dev = &_dev;
-    _q.private_data = nullptr;
+    for (int qi = 0; qi < nr_queues; ++qi) {
+        _queues[qi].q_id = qi;
+        _queues[qi].q_depth = q_depth;
+        _queues[qi].ring_ptr = &_ring;
+        _queues[qi].dev = &_dev;
+        _queues[qi].private_data = nullptr;
+    }
 
     // Wire up per-tag data.iod pointers
     for (int tag = 0; tag < q_depth; ++tag) {
@@ -76,7 +80,7 @@ io_result MockUblksrv::submit_io(int tag, uint8_t op, uint64_t start_sector, uin
     ts.sub_cmds_remaining = 0;
     ts.result = 0;
 
-    auto res = _disk->queue_tgt_io(&_q, &ts.data, 0);
+    auto res = _disk->queue_tgt_io(&_queues[0], &ts.data, 0);
     if (!res) return res;
 
     // Commit all SQEs queued by queue_tgt_io before we start polling
@@ -100,7 +104,7 @@ void MockUblksrv::process_cqe(io_uring_cqe* cqe, std::vector< Completion >& out)
     if (is_internal(sub_cmd)) {
         // RAID1 bitmap completion — respond and potentially enqueue more SQEs
         ts.sub_cmds_remaining--;
-        auto io_res = _disk->queue_internal_resp(&_q, &ts.data, sub_cmd, res);
+        auto io_res = _disk->queue_internal_resp(&_queues[0], &ts.data, sub_cmd, res);
         if (io_res && io_res.value() > 0) {
             ts.sub_cmds_remaining += static_cast< int >(io_res.value());
             io_uring_submit(&_ring);

--- a/src/tests/mock_ublksrv/mock_ublksrv.cpp
+++ b/src/tests/mock_ublksrv/mock_ublksrv.cpp
@@ -31,7 +31,7 @@ MockUblksrv::MockUblksrv(std::shared_ptr< UblkDisk > disk, int q_depth, int nr_q
     // Simulate init_queue: call open_for_uring once per queue thread so the disk can count queues
     // and perform per-queue initialization (e.g. Raid1DiskImpl sets _nr_hw_queues and enables resync).
     for (int qi = 0; qi < nr_queues; ++qi) {
-        for (auto const fd : _disk->open_for_uring(_dev.tgt.nr_fds)) {
+        for (auto const fd : _disk->open_for_uring(&_queues[qi], _dev.tgt.nr_fds)) {
             if (_dev.tgt.nr_fds < UBLKSRV_TGT_MAX_FDS) _dev.tgt.fds[_dev.tgt.nr_fds++] = fd;
         }
     }

--- a/src/tests/mock_ublksrv/mock_ublksrv.hpp
+++ b/src/tests/mock_ublksrv/mock_ublksrv.hpp
@@ -26,9 +26,10 @@ public:
         int result;
     };
 
-    /// @param disk   Disk to drive (FSDisk, Raid0Disk, Raid1Disk, …)
-    /// @param q_depth  Number of concurrent I/O slots (must be >= fio iodepth)
-    explicit MockUblksrv(std::shared_ptr< UblkDisk > disk, int q_depth = 128);
+    /// @param disk       Disk to drive (FSDisk, Raid0Disk, Raid1Disk, …)
+    /// @param q_depth    Number of concurrent I/O slots (must be >= fio iodepth)
+    /// @param nr_queues  Number of simulated queue threads (calls open_for_uring once per queue)
+    explicit MockUblksrv(std::shared_ptr< UblkDisk > disk, int q_depth = 128, int nr_queues = 1);
     ~MockUblksrv();
 
     MockUblksrv(MockUblksrv const&) = delete;
@@ -52,6 +53,8 @@ public:
     void* io_buf(int tag);
 
     int q_depth() const noexcept { return _q_depth; }
+    int nr_queues() const noexcept { return static_cast< int >(_queues.size()); }
+    ublksrv_queue const* queue(int q_id = 0) const noexcept { return &_queues[q_id]; }
     uint64_t capacity_sectors() const noexcept;
 
 private:
@@ -66,7 +69,7 @@ private:
 
     int _q_depth;
     ublksrv_dev _dev{};
-    ublksrv_queue _q{};
+    std::vector< ublksrv_queue > _queues;
     io_uring _ring{};
     std::shared_ptr< UblkDisk > _disk;
     std::vector< TagState > _tags;

--- a/src/tests/test_disk.hpp
+++ b/src/tests/test_disk.hpp
@@ -58,7 +58,7 @@ public:
         validate_slot(sub_cmd, "on_io_complete");
     }
 
-    MOCK_METHOD(std::list< int >, open_for_uring, (int const), (override));
+    MOCK_METHOD(std::list< int >, open_for_uring, (ublksrv_queue const*, int const), (override));
     MOCK_METHOD(io_result, handle_internal,
                 (ublksrv_queue const*, ublk_io_data const*, sub_cmd_t, iovec*, uint32_t, uint64_t, int), (override));
     MOCK_METHOD(void, collect_async, (ublksrv_queue const*, std::list< async_result >&), (override));


### PR DESCRIPTION
Fix three classes of races exposed when running with nr_hw_queues > 1.

## RAID-1: multi-queue idle probe (issue #193)

The idle probe was written assuming nr_hw_queues=1. With multiple queues:

- Any single queue going idle started the probe; any single queue exiting idle
  stopped it — wrong semantics under N queues.
- Concurrent idle_transition() calls from different queue threads raced on the
  jthread members of Raid1AvailProbeTask (unguarded move-assignment).
- swap_device() called stop() on the probes without holding _idle_probe_lock,
  racing against idle_transition()'s launch().
- idle_transition() called __capture_route_state() outside _idle_probe_lock,
  so swap_device() could replace the device between the capture and launch(),
  leaving a background probe running against the outgoing (now-swapped) device.

Fix: add _idle_queue_count (atomic) that gates probe start until all N queues
report idle and stops on the first exit. _idle_probe_lock (mutex) serializes all
launch()/stop() calls. _nr_hw_queues is incremented by open_for_uring() (called
once per queue thread from init_queue), so the threshold is set before any I/O
or idle_transition() fires.

idle_transition() now uses two route-state captures: one pre-lock for an
immediate synchronous probe (fire-and-forget, clears UNAVAIL on already-recovered
devices without delay), and a second capture inside _idle_probe_lock for the
periodic launch() so it always uses the device that is actually current.

A DEBUG_ASSERT guards the exit path against ublksrv contract violations
(exit without matching enter), which would cause _idle_queue_count to wrap and
permanently suppress probe launches.

## RAID-1: _pending_results access safety

_pending_results[q] used operator[] on the I/O path, which inserts on miss and
is not thread-safe under concurrent reads. open_for_uring() pre-populates the
map under _ctrl_lock during init; the I/O path uses find() + DEBUG_ASSERT (const
tree traversal, lock-free). _swap_lock renamed to _ctrl_lock to reflect that it
guards both swap_device() callers and _pending_results insertions.

## RAID-1: SuperBitmap::clear_all() races concurrent set_bit()

memset() may issue SIMD-wide stores that violate the per-byte atomicity contract
established by atomic_ref<uint8_t> in set_bit/clear_bit/test_bit. Write I/Os
reach dirty_region() -> set_bit() without holding _ctrl_lock, so they race with
init_to() -> clear_all() during device swap. Replace memset with byte-by-byte
atomic_ref<uint8_t>::store(relaxed) to eliminate the UB.

Also adds explanatory comments above __swap_device and __become_degraded
documenting the CAS-based mutual exclusion between them (a recurring review
question): both CAS _read_route_cache via __set_read_route(); exactly one wins,
the loser returns early — no additional lock is needed between them.

## RAID-1: init_queue error handling

init_queue now returns -1 (triggering ublksrv_dev_deinit() teardown) instead of
silently discarding any FDs returned by open_for_uring(). FDs returned here
would go unregistered with io_uring and cause fixed-file I/O to crash; treating
this as a fatal init failure catches any future disk type that exports FDs.

## Breaking API change

UblkDisk::open_for_uring signature changed from (int) to (ublksrv_queue const*, int).
Out-of-tree subclasses must update their override.

## Test fixes

- SuperBitmapTest.ConcurrentReadWhileWrite failed spuriously in Release CI builds:
  the optimized writer completed all 100k set_bit() calls before reader threads
  were scheduled, leaving read_count=0. Fixed with std::barrier.
- Three concurrency tests (ResyncRelaunchAfterComplete, ConcurrentLaunch,
  StopDuringUnavailWait) constructed MirrorDevice with a bare sync_iov mock that
  returned success without writing to the buffer. posix_memalign does not
  zero-initialize, so if freed memory happened to contain valid magic bytes with a
  wrong UUID, load_superblock would fail the UUID check and throw. Fixed with a
  sync_iov_zero_on_read() helper that zeros the buffer on READ calls. Extended
  to MultiQueueIdleConcurrent and MultiQueueIdleRapidToggle for the same reason.
- IdleTransitionExit and IdleExitSkipsProbe called idle_transition(false) without
  a prior idle_transition(true), violating the ublksrv contract asserted by the
  new DEBUG_ASSERT. Fixed by ensuring enter always precedes exit in tests.
  IdleTransitionExit renamed to IdleTransitionRoundTrip to accurately describe
  what it exercises.
- MockUblksrv constructor populated _queues[] fields after calling open_for_uring,
  so any disk implementation that reads ring_ptr or dev inside open_for_uring
  would see null values. Fixed by swapping the loop order.
- MultiQueueIdle* tests passed nullptr as the queue pointer to open_for_uring,
  bypassing the _pending_results.emplace() path introduced by this PR. Fixed by
  passing real stack-allocated ublksrv_queue pointers.
- Added SwapDeviceWhileIdleTransitioning: a TSAN regression guard that races
  swap_device() against concurrent idle_transition() calls to catch any future
  removal of the locked state re-capture in the probe enter path.

Closes #193