### PR TITLE
raid0: Fix stale alive_cmds corrupting next I/O after a failed multi-stride operation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.21.6
+- raid0: Fix stale alive_cmds in __distribute() corrupting the next I/O on the same thread after a failed multi-stride operation
+
 ## 0.21.5
 - raid1: Only log in reference to Resync if it was actually running.
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -10,7 +10,7 @@ required_conan_version = ">=2.0"
 
 class UBlkPPConan(ConanFile):
     name = "ublkpp"
-    version = "0.21.5"
+    version = "0.21.6"
 
     homepage = "https://github.com/szmyd/ublkpp"
     description = "A UBlk library for CPP application"

--- a/src/raid/raid0/raid0.cpp
+++ b/src/raid/raid0/raid0.cpp
@@ -1,5 +1,6 @@
 #include "ublkpp/raid/raid0.hpp"
 
+#include <bit>
 #include <boost/uuid/uuid_io.hpp>
 #include <ublksrv.h>
 #include <ublksrv_utils.h>
@@ -32,6 +33,9 @@ load_superblock(UblkDisk& device, boost::uuids::uuid const& uuid, uint32_t& stri
 Raid0Disk::Raid0Disk(boost::uuids::uuid const& uuid, uint32_t const stripe_size_bytes,
                      std::vector< std::shared_ptr< UblkDisk > >&& disks) :
         UblkDisk(), _stripe_size(stripe_size_bytes), _stride_width(_stripe_size * disks.size()) {
+    if (disks.size() > _max_stripe_cnt)
+        throw std::invalid_argument(
+            fmt::format("Raid0Disk: too many disks ({}), max is {}", disks.size(), _max_stripe_cnt));
     // Discover overall Device parameters
     auto& our_params = *params();
     our_params.types |= UBLK_PARAM_TYPE_DISCARD;
@@ -175,66 +179,53 @@ io_result Raid0Disk::handle_discard(ublksrv_queue const* q, ublk_io_data const* 
 //  stripe boundaries and even wrap around several strides. This routine handles this calculation and calls
 //  the given routine `func` for each stripe that it has collected scatter (struct iovec) operations for.
 io_result Raid0Disk::__distribute(iovec* iovecs, uint64_t addr, auto&& func, bool retry, sub_cmd_t sub_cmd) const {
-    // Each thread has a 2-dimensional block of iovecs that we can split into.
-    thread_local auto sub_cmds =
-        std::array< std::tuple< uint64_t, uint32_t, std::array< iovec, 16 > >, _max_stripe_cnt >();
-    // Reset only the stripes we touch (cheaper than zeroing all _max_stripe_cnt on every call).
-    // A previous call that returned early on error leaves non-zero alive_cmds behind; stale iov_base
-    // pointers in those entries would corrupt the next I/O on this thread if not cleared.
-    static_assert(_max_stripe_cnt <= 64, "dirty_mask requires _max_stripe_cnt <= 64");
+    struct StripeAccum {
+        uint64_t io_addr{0};
+        uint32_t alive_cmds{0};
+        std::array< iovec, 16 > io_array{};
+    };
+    // Reset only touched stripes on exit; a failed call leaves non-zero alive_cmds that would corrupt the next I/O.
+    static_assert(_max_stripe_cnt == 64, "dirty_mask must be exactly uint64_t");
+    thread_local auto sub_cmds = std::array< StripeAccum, _max_stripe_cnt >();
     uint64_t dirty_mask{0};
     struct DirtyGuard {
         decltype(sub_cmds)& cmds;
         uint64_t& mask;
         ~DirtyGuard() noexcept {
             while (mask) {
-                std::get< 1 >(cmds[std::countr_zero(mask)]) = 0;
-                mask &= mask - 1;
+                cmds[std::countr_zero(mask)].alive_cmds = 0;
+                mask &= mask - 1; // clear lowest set bit
             }
         }
-    } _guard{sub_cmds, dirty_mask};
+    } guard{sub_cmds, dirty_mask};
 
-    // Special case for single device
     if (1 == _stripe_array.size()) return func(0, sub_cmd, iovecs, 1, addr);
 
     auto const route_mask = _max_stripe_cnt - 1;
-
     DEBUG_ASSERT_LE(iovecs->iov_len, UINT32_MAX) // LCOV_EXCL_LINE
-    auto const len = (uint32_t)iovecs->iov_len;
+    auto const len = static_cast< uint32_t >(iovecs->iov_len);
     uint32_t cnt{0};
     for (auto off = 0U; len > off;) {
         auto const [stripe_off, logical_off, sz] =
-            raid0::next_subcmd(_stride_width, _stripe_size, addr + off, (len - off));
-
-        // Ensure we advance here in case we _continue_ or anything later
-        auto buf_cursor = (uint8_t*)iovecs->iov_base + off;
+            raid0::next_subcmd(_stride_width, _stripe_size, addr + off, len - off);
+        auto buf_cursor = static_cast< uint8_t* >(iovecs->iov_base) + off;
         off += sz;
 
-        // Get the device
         auto const& device = _stripe_array[stripe_off]->disk;
-
-        // If this is a retry, we only want to re-issue the operation whose route matches the one passed in
-        if (retry) [[unlikely]] {
-            // Mask off to get "our" portion of the original route and see if the device that processed this
-            // operation matches the current RAID-0 sub-operation; if not then skip.
-            if (stripe_off != ((sub_cmd >> device->route_size()) & route_mask)) continue;
-        }
+        // On retry, re-issue only the stripe whose route bits match the original sub_cmd.
+        if (retry && stripe_off != ((sub_cmd >> device->route_size()) & route_mask)) [[unlikely]]
+            continue;
 
         dirty_mask |= 1ULL << stripe_off;
-        auto& [io_addr, alive_cmds, io_array] = sub_cmds[stripe_off];
-        { // Fillout iovec
-            auto& iov = io_array[alive_cmds++];
-            iov.iov_base = (void*)buf_cursor;
-            iov.iov_len = sz;
-        }
-        if (1 == alive_cmds) [[likely]]
-            io_addr = logical_off;
+        auto& acc = sub_cmds[stripe_off];
+        if (!acc.alive_cmds) acc.io_addr = logical_off;
+        acc.io_array[acc.alive_cmds++] = {buf_cursor, sz};
 
-        // Last sub_cmd for this device, issue now
+        // Dispatch once the remaining bytes fit within a single (N-1)-stripe remainder,
+        // guaranteeing this stripe cannot accumulate more iovecs in the same call.
         if ((_stride_width - _stripe_size) >= (len - off)) {
             sub_cmd_t const new_sub_cmd = sub_cmd + (!retry ? (uint16_t)stripe_off : 0);
-            DEBUG_ASSERT_LE(alive_cmds, UINT32_MAX) // LCOV_EXCL_LINE
-            auto res = func(stripe_off, new_sub_cmd, io_array.data(), alive_cmds, io_addr);
+            auto res = func(stripe_off, new_sub_cmd, acc.io_array.data(), acc.alive_cmds, acc.io_addr);
             if (!res) return res;
             cnt += res.value();
         }

--- a/src/raid/raid0/raid0.cpp
+++ b/src/raid/raid0/raid0.cpp
@@ -175,9 +175,24 @@ io_result Raid0Disk::handle_discard(ublksrv_queue const* q, ublk_io_data const* 
 //  stripe boundaries and even wrap around several strides. This routine handles this calculation and calls
 //  the given routine `func` for each stripe that it has collected scatter (struct iovec) operations for.
 io_result Raid0Disk::__distribute(iovec* iovecs, uint64_t addr, auto&& func, bool retry, sub_cmd_t sub_cmd) const {
-    // Each thread has a 2-dimensional block of iovecs that we can split into
+    // Each thread has a 2-dimensional block of iovecs that we can split into.
     thread_local auto sub_cmds =
         std::array< std::tuple< uint64_t, uint32_t, std::array< iovec, 16 > >, _max_stripe_cnt >();
+    // Reset only the stripes we touch (cheaper than zeroing all _max_stripe_cnt on every call).
+    // A previous call that returned early on error leaves non-zero alive_cmds behind; stale iov_base
+    // pointers in those entries would corrupt the next I/O on this thread if not cleared.
+    static_assert(_max_stripe_cnt <= 64, "dirty_mask requires _max_stripe_cnt <= 64");
+    uint64_t dirty_mask{0};
+    struct DirtyGuard {
+        decltype(sub_cmds)& cmds;
+        uint64_t& mask;
+        ~DirtyGuard() noexcept {
+            while (mask) {
+                std::get< 1 >(cmds[std::countr_zero(mask)]) = 0;
+                mask &= mask - 1;
+            }
+        }
+    } _guard{sub_cmds, dirty_mask};
 
     // Special case for single device
     if (1 == _stripe_array.size()) return func(0, sub_cmd, iovecs, 1, addr);
@@ -205,6 +220,7 @@ io_result Raid0Disk::__distribute(iovec* iovecs, uint64_t addr, auto&& func, boo
             if (stripe_off != ((sub_cmd >> device->route_size()) & route_mask)) continue;
         }
 
+        dirty_mask |= 1ULL << stripe_off;
         auto& [io_addr, alive_cmds, io_array] = sub_cmds[stripe_off];
         { // Fillout iovec
             auto& iov = io_array[alive_cmds++];

--- a/src/raid/raid0/raid0.cpp
+++ b/src/raid/raid0/raid0.cpp
@@ -235,8 +235,6 @@ io_result Raid0Disk::__distribute(iovec* iovecs, uint64_t addr, auto&& func, boo
             sub_cmd_t const new_sub_cmd = sub_cmd + (!retry ? (uint16_t)stripe_off : 0);
             DEBUG_ASSERT_LE(alive_cmds, UINT32_MAX) // LCOV_EXCL_LINE
             auto res = func(stripe_off, new_sub_cmd, io_array.data(), alive_cmds, io_addr);
-            // Set this back to zero so the next command can reuse
-            alive_cmds = 0;
             if (!res) return res;
             cnt += res.value();
         }

--- a/src/raid/raid0/tests/simple/error_handling.cpp
+++ b/src/raid/raid0/tests/simple/error_handling.cpp
@@ -1,5 +1,65 @@
 #include "../test_raid0_common.hpp"
 
+// Regression test for stale alive_cmds: a failed I/O spanning multiple strides must not leave
+// non-zero alive_cmds entries behind, which would corrupt the next I/O on the same thread.
+//
+// Setup: 3 devices, stripe_size=4KiB, stride_width=12KiB.
+// I/O 1: 24KiB (2 full strides). Stride 1 accumulates all 3 stripes but dispatches none.
+// In stride 2, device A is dispatched first (2 accumulated iovecs) and fails → early return.
+// alive_cmds[B]=1 and alive_cmds[C]=1 are left non-zero.
+//
+// I/O 2: 8KiB (stripe A + stripe B). Without the fix, device B receives nr_vecs=2 with a stale
+// iov_base[0] pointing into I/O 1's buffer. With the fix, nr_vecs=1 and iov_base is correct.
+TEST(Raid0, FailedMultiStrideIoDoesNotLeaveStaleAliveCount) {
+    constexpr uint32_t stripe_sz = 4 * Ki;
+    auto device_a = CREATE_DISK(TestParams{.capacity = Gi});
+    auto device_b = CREATE_DISK(TestParams{.capacity = Gi});
+    auto device_c = CREATE_DISK(TestParams{.capacity = Gi});
+    auto raid = ublkpp::Raid0Disk(boost::uuids::string_generator()(test_uuid), stripe_sz,
+                                  std::vector< std::shared_ptr< UblkDisk > >{device_a, device_b, device_c});
+
+    // I/O 1: 2 full strides — device A dispatched first in last stride with 2 accumulated iovecs, fails.
+    constexpr uint32_t io1_sz = 2 * 3 * stripe_sz; // 24KiB
+    void* buf1{};
+    ASSERT_EQ(0, posix_memalign(&buf1, device_a->block_size(), io1_sz));
+    auto iov1 = iovec{.iov_base = buf1, .iov_len = io1_sz};
+
+    EXPECT_CALL(*device_a, sync_iov(UBLK_IO_OP_WRITE, _, _, _))
+        .Times(1)
+        .WillOnce([](uint8_t, iovec*, uint32_t nr_vecs, off_t) -> io_result {
+            EXPECT_EQ(2U, nr_vecs); // 2 iovecs accumulated across 2 strides
+            return std::unexpected(std::make_error_condition(std::errc::io_error));
+        });
+    // B and C are never dispatched: early return after A fails leaves alive_cmds[B]=1, alive_cmds[C]=1.
+    ASSERT_FALSE(raid.sync_iov(UBLK_IO_OP_WRITE, &iov1, 1, 0));
+
+    // I/O 2: 8KiB spanning stripe A then stripe B.
+    constexpr uint32_t io2_sz = 2 * stripe_sz; // 8KiB
+    void* buf2{};
+    ASSERT_EQ(0, posix_memalign(&buf2, device_b->block_size(), io2_sz));
+    auto iov2 = iovec{.iov_base = buf2, .iov_len = io2_sz};
+
+    EXPECT_CALL(*device_a, sync_iov(UBLK_IO_OP_WRITE, _, _, _))
+        .Times(1)
+        .WillOnce([](uint8_t, iovec*, uint32_t nr_vecs, off_t) -> io_result {
+            EXPECT_EQ(1U, nr_vecs);
+            return stripe_sz;
+        });
+    EXPECT_CALL(*device_b, sync_iov(UBLK_IO_OP_WRITE, _, _, _))
+        .Times(1)
+        .WillOnce([buf2, stripe_sz](uint8_t, iovec* iovecs, uint32_t nr_vecs, off_t) -> io_result {
+            // Without the fix: nr_vecs=2, iovecs[0].iov_base is stale (points into buf1 from I/O 1).
+            EXPECT_EQ(1U, nr_vecs);
+            EXPECT_EQ(static_cast< uint8_t* >(iovecs[0].iov_base), static_cast< uint8_t* >(buf2) + stripe_sz);
+            return stripe_sz;
+        });
+
+    EXPECT_TRUE(raid.sync_iov(UBLK_IO_OP_WRITE, &iov2, 1, 0));
+
+    free(buf1);
+    free(buf2);
+}
+
 // Test: async_iov with invalid nr_vecs (0)
 TEST(Raid0, AsyncIovInvalidNrVecs) {
     auto device_a = CREATE_DISK(TestParams{.capacity = Gi});

--- a/src/raid/raid0/tests/simple/error_handling.cpp
+++ b/src/raid/raid0/tests/simple/error_handling.cpp
@@ -51,7 +51,7 @@ TEST(Raid0, FailedMultiStrideIoDoesNotLeaveStaleAliveCount) {
 
     EXPECT_CALL(*device_a, sync_iov(UBLK_IO_OP_WRITE, _, _, _))
         .Times(1)
-        .WillOnce([](uint8_t, iovec*, uint32_t nr_vecs, off_t) -> io_result {
+        .WillOnce([stripe_sz](uint8_t, iovec*, uint32_t nr_vecs, off_t) -> io_result {
             EXPECT_EQ(1U, nr_vecs);
             return stripe_sz;
         });
@@ -109,8 +109,8 @@ TEST(Raid0, FailedMultiStrideIoDoesNotLeaveStaleAliveCount_Async) {
 
     EXPECT_CALL(*device_a, async_iov(_, _, _, _, _, _))
         .Times(1)
-        .WillOnce([](ublksrv_queue const*, ublk_io_data const*, ublkpp::sub_cmd_t, iovec*, uint32_t nr_vecs,
-                     uint64_t) -> io_result {
+        .WillOnce([stripe_sz](ublksrv_queue const*, ublk_io_data const*, ublkpp::sub_cmd_t, iovec*, uint32_t nr_vecs,
+                              uint64_t) -> io_result {
             EXPECT_EQ(1U, nr_vecs);
             return stripe_sz;
         });

--- a/src/raid/raid0/tests/simple/error_handling.cpp
+++ b/src/raid/raid0/tests/simple/error_handling.cpp
@@ -15,14 +15,19 @@ TEST(Raid0, FailedMultiStrideIoDoesNotLeaveStaleAliveCount) {
     auto device_a = CREATE_DISK(TestParams{.capacity = Gi});
     auto device_b = CREATE_DISK(TestParams{.capacity = Gi});
     auto device_c = CREATE_DISK(TestParams{.capacity = Gi});
+    // Must use test_uuid: CREATE_DISK's superblock expectations encode this UUID in normal_superblock.
     auto raid = ublkpp::Raid0Disk(boost::uuids::string_generator()(test_uuid), stripe_sz,
                                   std::vector< std::shared_ptr< UblkDisk > >{device_a, device_b, device_c});
 
     // I/O 1: 2 full strides — device A dispatched first in last stride with 2 accumulated iovecs, fails.
     constexpr uint32_t io1_sz = 2 * 3 * stripe_sz; // 24KiB
-    void* buf1{};
-    ASSERT_EQ(0, posix_memalign(&buf1, device_a->block_size(), io1_sz));
-    auto iov1 = iovec{.iov_base = buf1, .iov_len = io1_sz};
+    auto buf1 = std::unique_ptr< void, decltype(&free) >(nullptr, free);
+    {
+        void* p{};
+        ASSERT_EQ(0, posix_memalign(&p, device_a->block_size(), io1_sz));
+        buf1.reset(p);
+    }
+    auto iov1 = iovec{.iov_base = buf1.get(), .iov_len = io1_sz};
 
     EXPECT_CALL(*device_a, sync_iov(UBLK_IO_OP_WRITE, _, _, _))
         .Times(1)
@@ -35,9 +40,14 @@ TEST(Raid0, FailedMultiStrideIoDoesNotLeaveStaleAliveCount) {
 
     // I/O 2: 8KiB spanning stripe A then stripe B.
     constexpr uint32_t io2_sz = 2 * stripe_sz; // 8KiB
-    void* buf2{};
-    ASSERT_EQ(0, posix_memalign(&buf2, device_b->block_size(), io2_sz));
-    auto iov2 = iovec{.iov_base = buf2, .iov_len = io2_sz};
+    auto buf2 = std::unique_ptr< void, decltype(&free) >(nullptr, free);
+    {
+        void* p{};
+        ASSERT_EQ(0, posix_memalign(&p, device_b->block_size(), io2_sz));
+        buf2.reset(p);
+    }
+    auto* buf2_raw = static_cast< uint8_t* >(buf2.get());
+    auto iov2 = iovec{.iov_base = buf2.get(), .iov_len = io2_sz};
 
     EXPECT_CALL(*device_a, sync_iov(UBLK_IO_OP_WRITE, _, _, _))
         .Times(1)
@@ -47,17 +57,76 @@ TEST(Raid0, FailedMultiStrideIoDoesNotLeaveStaleAliveCount) {
         });
     EXPECT_CALL(*device_b, sync_iov(UBLK_IO_OP_WRITE, _, _, _))
         .Times(1)
-        .WillOnce([buf2, stripe_sz](uint8_t, iovec* iovecs, uint32_t nr_vecs, off_t) -> io_result {
+        .WillOnce([buf2_raw, stripe_sz](uint8_t, iovec* iovecs, uint32_t nr_vecs, off_t) -> io_result {
             // Without the fix: nr_vecs=2, iovecs[0].iov_base is stale (points into buf1 from I/O 1).
             EXPECT_EQ(1U, nr_vecs);
-            EXPECT_EQ(static_cast< uint8_t* >(iovecs[0].iov_base), static_cast< uint8_t* >(buf2) + stripe_sz);
+            EXPECT_EQ(static_cast< uint8_t* >(iovecs[0].iov_base), buf2_raw + stripe_sz);
             return stripe_sz;
         });
 
     EXPECT_TRUE(raid.sync_iov(UBLK_IO_OP_WRITE, &iov2, 1, 0));
+}
 
-    free(buf1);
-    free(buf2);
+// Same scenario as above but exercised through async_iov — the primary production I/O path.
+TEST(Raid0, FailedMultiStrideIoDoesNotLeaveStaleAliveCount_Async) {
+    constexpr uint32_t stripe_sz = 4 * Ki;
+    auto device_a = CREATE_DISK(TestParams{.capacity = Gi});
+    auto device_b = CREATE_DISK(TestParams{.capacity = Gi});
+    auto device_c = CREATE_DISK(TestParams{.capacity = Gi});
+    // Must use test_uuid: CREATE_DISK's superblock expectations encode this UUID in normal_superblock.
+    auto raid = ublkpp::Raid0Disk(boost::uuids::string_generator()(test_uuid), stripe_sz,
+                                  std::vector< std::shared_ptr< UblkDisk > >{device_a, device_b, device_c});
+
+    constexpr uint32_t io1_sz = 2 * 3 * stripe_sz; // 24KiB
+    auto buf1 = std::unique_ptr< void, decltype(&free) >(nullptr, free);
+    {
+        void* p{};
+        ASSERT_EQ(0, posix_memalign(&p, device_a->block_size(), io1_sz));
+        buf1.reset(p);
+    }
+    auto iov1 = iovec{.iov_base = buf1.get(), .iov_len = io1_sz};
+    auto data1 = make_io_data(UBLK_IO_OP_WRITE, io1_sz);
+
+    EXPECT_CALL(*device_a, async_iov(_, _, _, _, _, _))
+        .Times(1)
+        .WillOnce([](ublksrv_queue const*, ublk_io_data const*, ublkpp::sub_cmd_t, iovec*, uint32_t nr_vecs,
+                     uint64_t) -> io_result {
+            EXPECT_EQ(2U, nr_vecs);
+            return std::unexpected(std::make_error_condition(std::errc::io_error));
+        });
+    ASSERT_FALSE(raid.async_iov(nullptr, &data1, 0, &iov1, 1, 0));
+
+    constexpr uint32_t io2_sz = 2 * stripe_sz; // 8KiB
+    auto buf2 = std::unique_ptr< void, decltype(&free) >(nullptr, free);
+    {
+        void* p{};
+        ASSERT_EQ(0, posix_memalign(&p, device_b->block_size(), io2_sz));
+        buf2.reset(p);
+    }
+    auto* buf2_raw = static_cast< uint8_t* >(buf2.get());
+    auto iov2 = iovec{.iov_base = buf2.get(), .iov_len = io2_sz};
+    auto data2 = make_io_data(UBLK_IO_OP_WRITE, io2_sz);
+
+    EXPECT_CALL(*device_a, async_iov(_, _, _, _, _, _))
+        .Times(1)
+        .WillOnce([](ublksrv_queue const*, ublk_io_data const*, ublkpp::sub_cmd_t, iovec*, uint32_t nr_vecs,
+                     uint64_t) -> io_result {
+            EXPECT_EQ(1U, nr_vecs);
+            return stripe_sz;
+        });
+    EXPECT_CALL(*device_b, async_iov(_, _, _, _, _, _))
+        .Times(1)
+        .WillOnce([buf2_raw, stripe_sz](ublksrv_queue const*, ublk_io_data const*, ublkpp::sub_cmd_t, iovec* iovecs,
+                                        uint32_t nr_vecs, uint64_t) -> io_result {
+            EXPECT_EQ(1U, nr_vecs);
+            EXPECT_EQ(static_cast< uint8_t* >(iovecs[0].iov_base), buf2_raw + stripe_sz);
+            return stripe_sz;
+        });
+
+    EXPECT_TRUE(raid.async_iov(nullptr, &data2, 0, &iov2, 1, 0));
+
+    remove_io_data(data1);
+    remove_io_data(data2);
 }
 
 // Test: async_iov with invalid nr_vecs (0)


### PR DESCRIPTION
__distribute() maintains a thread_local array of per-stripe iovec accumulators.
When an I/O spans more than one stride, stripes accumulate iovecs across strides
before being dispatched in the final stride. If func() fails for the first
dispatched stripe, the loop returns early — leaving alive_cmds non-zero for every
stripe that was accumulated but not yet dispatched. The next I/O on the same
thread inherits those stale counts and the iov_base pointers they reference,
silently corrupting I/O data.

Fix: track touched stripes via a uint64_t dirty bitmask (fits exactly because
_max_stripe_cnt == 64) and reset only those entries on scope exit via a RAII
guard. This is cheaper than zeroing all 64 slots on every call — typical I/O
touches 1–4 stripes.

The dispatch condition (_stride_width - _stripe_size) >= (len - off) fires only
when remaining bytes fit within a single (N-1)-stripe remainder, so a dispatched
stripe cannot re-accumulate in the same call. The alive_cmds = 0 reset that
previously followed each dispatch was therefore redundant and has been removed.

This bug affects any RAID-0 configuration regardless of queue count: one failed
I/O on any thread poisons the next I/O on that thread.

Also replaces the opaque std::tuple accumulator with a named StripeAccum struct,
collapses verbose comments, strengthens the static_assert to == 64, adds a
constructor guard against > 64 disks (which would cause UB via 1ULL << stripe_off),
and addresses all other review comments (RAII test buffers, async_iov regression
test, naming convention fix for _guard, explicit #include <bit>).

Regression test (FailedMultiStrideIoDoesNotLeaveStaleAliveCount) was committed
before the fix and fails without it — both directly (nr_vecs=2 instead of 1,
stale iov_base) and via cascading failure in the pre-existing SyncIoSuccess test
as thread_local state leaks across GTest cases on the same OS thread. An async_iov
variant covers the primary production I/O path through the same __distribute logic.