### PR TITLE
test(raid1): add regression for IDLE→STOPPING race after resync compl…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.22.2
+- raid1: Fix `stop()` IDLE→STOPPING race — when the resync thread finishes naturally and
+  `stop()` is called before `join()`, the `IDLE+joinable` handler now returns `SUCCESS` instead
+  of `RETRY_WITH_SLEEP`, preventing an accidental `CAS(IDLE→STOPPING)` that left no thread to
+  clear the state; subsequent `launch()` call in `swap_device()` would spin forever (SDSTOR-21927)
+
 ## 0.22.1
 - raid1: Fix dequeue/resume race — `_resync_state` and `_outstanding_writes` are now packed into a single `sisl::atomic_status_counter` so the counter decrement and PAUSE→ACTIVE transition are one indivisible CAS; `__resume()` is removed (SDSTOR-21927)
 - raid1: Fix enqueue/pause race — `enqueue_write()` now always calls `__pause()` on every enqueue, not only the first; previously a concurrent second enqueuer could skip `__pause()` while the first was still establishing it, allowing resync to overwrite an in-flight write with stale data

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - raid1: Fix `stop()` IDLE→STOPPING race — when the resync thread finishes naturally and
   `stop()` is called before `join()`, the `IDLE+joinable` handler now returns `SUCCESS` instead
   of `RETRY_WITH_SLEEP`, preventing an accidental `CAS(IDLE→STOPPING)` that left no thread to
-  clear the state; subsequent `launch()` call in `swap_device()` would spin forever (SDSTOR-21927)
+  clear the state; subsequent `launch()` call in `swap_device()` would spin forever.
 
 ## 0.22.1
-- raid1: Fix dequeue/resume race — `_resync_state` and `_outstanding_writes` are now packed into a single `sisl::atomic_status_counter` so the counter decrement and PAUSE→ACTIVE transition are one indivisible CAS; `__resume()` is removed (SDSTOR-21927)
+- raid1: Fix dequeue/resume race — `_resync_state` and `_outstanding_writes` are now packed into a single `sisl::atomic_status_counter` so the counter decrement and PAUSE→ACTIVE transition are one indivisible CAS; `__resume()` is removed.
 - raid1: Fix enqueue/pause race — `enqueue_write()` now always calls `__pause()` on every enqueue, not only the first; previously a concurrent second enqueuer could skip `__pause()` while the first was still establishing it, allowing resync to overwrite an in-flight write with stale data
 - raid1: Replace GCC `__builtin_popcount`/`__builtin_clz`/`__builtin_ctz` with C++23 `std::popcount`/`std::countl_zero`/`std::countr_zero`
 - build: `libatomic` is now declared as a Conan system lib on Linux — propagated automatically to consumers, no downstream changes required

--- a/conanfile.py
+++ b/conanfile.py
@@ -10,7 +10,7 @@ required_conan_version = ">=2.0"
 
 class UBlkPPConan(ConanFile):
     name = "ublkpp"
-    version = "0.22.1"
+    version = "0.22.2"
 
     homepage = "https://github.com/szmyd/ublkpp"
     description = "A UBlk library for CPP application"

--- a/src/raid/raid1/raid1_resync_task.cpp
+++ b/src/raid/raid1/raid1_resync_task.cpp
@@ -284,6 +284,11 @@ void Raid1ResyncTask::stop() noexcept {
         std::unreachable();
     });
     if (_resync_task.joinable()) _resync_task.join();
+    // If the thread finished naturally (ACTIVE→IDLE) before stop() CAS'd IDLE→STOPPING,
+    // it returned without ever seeing STOPPING and never cleared it. _launch_lock is held
+    // so no concurrent caller can observe this window; reset to IDLE so launch() isn't stuck.
+    auto stopping = resync_state::STOPPING;
+    __cas_state(stopping, resync_state::IDLE);
 }
 
 resync_state Raid1ResyncTask::__yield(std::chrono::microseconds const yield_for,

--- a/src/raid/raid1/tests/concurrency/resync_relaunch_after_complete.cpp
+++ b/src/raid/raid1/tests/concurrency/resync_relaunch_after_complete.cpp
@@ -70,3 +70,89 @@ TEST(Raid1Concurrency, ResyncRelaunchAfterComplete) {
 
     task.stop();
 }
+
+// Regression test for SDSTOR-21927 / GH #205.
+//
+// Root cause: stop() CAS's IDLE→STOPPING when the resync thread has already finished
+// (state=IDLE, thread still joinable). State gets stuck at STOPPING with no running thread
+// to advance it back. The next launch() call spins forever in __transition_to.
+//
+// This sequence occurs in swap_device():
+//   toggle_resync(false)  [stop hits IDLE+joinable → CAS IDLE→STOPPING]
+//   __swap_device()       [sets route≠EITHER, dirties bitmap]
+//   toggle_resync(true)   [launch() loops forever on STOPPING]
+//
+// Without the fix: launch() spins forever and the test fails after 2s.
+// With the fix: stop() returns SUCCESS from IDLE+joinable (no CAS), state stays IDLE,
+// and the second launch() starts the new resync normally.
+//
+// task is a shared_ptr so the detached stuck thread (in the failing case) holds a reference
+// and never accesses freed memory, avoiding UB after the test body returns.
+TEST(Raid1Concurrency, StopAndRelaunchAfterComplete) {
+    auto device_a = std::make_shared< ublkpp::TestDisk >(TestParams{.capacity = Gi, .id = "DiskA"});
+    auto device_b = std::make_shared< ublkpp::TestDisk >(TestParams{.capacity = Gi, .id = "DiskB", .is_slot_b = true});
+
+    EXPECT_CALL(*device_a, sync_iov(::testing::_, _, _, _))
+        .Times(::testing::AnyNumber())
+        .WillRepeatedly(sync_iov_zero_on_read());
+    EXPECT_CALL(*device_b, sync_iov(::testing::_, _, _, _))
+        .Times(::testing::AnyNumber())
+        .WillRepeatedly(sync_iov_zero_on_read());
+
+    auto uuid = boost::uuids::string_generator()(test_uuid);
+    auto mirror_a = std::make_shared< MirrorDevice >(uuid, device_a);
+    auto mirror_b = std::make_shared< MirrorDevice >(uuid, device_b);
+
+    auto superbitmap_buf = make_test_superbitmap();
+    auto bitmap = std::make_shared< Bitmap >(Gi, 32 * Ki, 4 * Ki, superbitmap_buf.get());
+
+    constexpr uint32_t io_size = 4 * Ki;
+    auto task = std::make_shared< Raid1ResyncTask >(bitmap, Bitmap::page_size(), io_size, io_size);
+
+    // First launch: empty bitmap → resync completes immediately.
+    std::atomic< bool > first_complete{false};
+    task->launch(test_uuid, mirror_a, mirror_b,
+                 [&first_complete] { first_complete.store(true, std::memory_order_release); });
+
+    auto deadline = std::chrono::steady_clock::now() + 2s;
+    while (!first_complete.load(std::memory_order_acquire) && std::chrono::steady_clock::now() < deadline)
+        std::this_thread::sleep_for(1ms);
+    ASSERT_TRUE(first_complete.load(std::memory_order_acquire)) << "First resync did not complete";
+
+    // Let the IDLE CAS in _start() execute before stop() runs, landing in the
+    // IDLE+joinable window that triggers the bug.
+    std::this_thread::sleep_for(5ms);
+
+    // Mirrors swap_device(): stop the old resync, then relaunch for the new device.
+    task->stop();
+
+    // Run the second launch() in a thread so we can detect if it hangs.
+    // Without the fix: stop() left state=STOPPING and launch() spins forever.
+    auto launched = std::make_shared< std::atomic< bool > >(false);
+    auto second_complete = std::make_shared< std::atomic< bool > >(false);
+    auto t = std::thread([task, launched, second_complete, mirror_a, mirror_b]() mutable {
+        task->launch(test_uuid, mirror_a, mirror_b,
+                     [second_complete] { second_complete->store(true, std::memory_order_release); });
+        launched->store(true, std::memory_order_release);
+    });
+
+    deadline = std::chrono::steady_clock::now() + 2s;
+    while (!launched->load(std::memory_order_acquire) && std::chrono::steady_clock::now() < deadline)
+        std::this_thread::sleep_for(1ms);
+
+    if (!launched->load(std::memory_order_acquire)) {
+        // launch() is stuck. Detach: shared_ptr keeps task alive so the spinning thread
+        // never touches freed memory. The test process cleans up on exit.
+        t.detach();
+        FAIL() << "launch() hung after stop()+relaunch — SDSTOR-21927 IDLE→STOPPING race in stop()";
+        return;
+    }
+    t.join();
+
+    deadline = std::chrono::steady_clock::now() + 2s;
+    while (!second_complete->load(std::memory_order_acquire) && std::chrono::steady_clock::now() < deadline)
+        std::this_thread::sleep_for(1ms);
+    EXPECT_TRUE(second_complete->load(std::memory_order_acquire)) << "Second resync did not call complete()";
+
+    task->stop();
+}

--- a/src/raid/raid1/tests/concurrency/resync_relaunch_after_complete.cpp
+++ b/src/raid/raid1/tests/concurrency/resync_relaunch_after_complete.cpp
@@ -12,7 +12,6 @@ using namespace std::chrono_literals;
 using namespace ublkpp::raid1;
 
 // Regression test for: Raid1ResyncTask::launch() crash on joinable thread reassignment.
-// SDSTOR-21864
 //
 // Root cause: stop() is only called during swap or shutdown — never between resyncs. So
 // after any completed resync, _resync_task remains joinable (join()/detach() not called).
@@ -71,7 +70,7 @@ TEST(Raid1Concurrency, ResyncRelaunchAfterComplete) {
     task.stop();
 }
 
-// Regression test for SDSTOR-21927 / GH #205.
+// Regression test for GH #205.
 //
 // Root cause: stop() CAS's IDLE→STOPPING when the resync thread has already finished
 // (state=IDLE, thread still joinable). State gets stuck at STOPPING with no running thread
@@ -144,7 +143,7 @@ TEST(Raid1Concurrency, StopAndRelaunchAfterComplete) {
         // launch() is stuck. Detach: shared_ptr keeps task alive so the spinning thread
         // never touches freed memory. The test process cleans up on exit.
         t.detach();
-        FAIL() << "launch() hung after stop()+relaunch — SDSTOR-21927 IDLE→STOPPING race in stop()";
+        FAIL() << "launch() hung after stop()+relaunch — GH #205 IDLE→STOPPING race in stop()";
         return;
     }
     t.join();


### PR DESCRIPTION
# `stop()` IDLE→STOPPING race hangs resync after partition move

_type_: 🐛 (bug)
_severity_: 🔴 (critical — resync never completes, array stuck degraded indefinitely)
_discovery_: 🧪 (CI / functional test: `partition-move-2-0-nvme cold_with_io` timeout at 12000s)

1. **`stop()` CAS's `IDLE→STOPPING` when the thread has already finished, leaving state stuck.**
   The `IDLE+joinable` branch in `stop()` covers two distinct sub-cases that cannot be
   distinguished by state alone:

   | Case | State | Thread running? | Needs `CAS(IDLE→STOPPING)`? |
   |---|---|---|---|
   | Thread in unavail-wait | `IDLE` | Yes | **Yes** — to signal exit |
   | Thread just finished | `IDLE` | No (returning) | No — but gets CAS'd anyway |

   In the unavail-wait case the resync thread is alive but stuck in `_start()`'s top loop
   because `dirty_mirror->unavail` is set; the `CAS(IDLE→ACTIVE)` never fires so state stays
   `IDLE`. The `RETRY_WITH_SLEEP` in `stop()` is *correct and necessary* here — it eventually
   drives `CAS(IDLE→STOPPING)` which the thread sees at `__load_state()` and uses to exit.

   In the "just finished" case the thread already ran `xchng_status(ACTIVE→IDLE)` and returned.
   `stop()` still CAS's `IDLE→STOPPING` (via the same `RETRY_WITH_SLEEP`), joins the already-done
   thread immediately, then returns — leaving state permanently at `STOPPING` with no thread to
   clear it. The subsequent `toggle_resync(true)` → `launch()` call spins forever in
   `__transition_to` waiting for `STOPPING→IDLE` that never comes. `swap_device()` never returns;
   the second resync is never started.

   Observed as `active+dirty+syncing` indefinitely with `ublk_dirty_pages=0` (stale from the
   first resync — `__run()` was never entered for the second resync).

   **Fix:** keep `RETRY_WITH_SLEEP` (needed for the unavail-wait case). Add a post-join
   `CAS(STOPPING→IDLE)` at the end of `stop()` after the `join()`. This CAS is a no-op when
   the thread cleared `STOPPING` itself (normal stop path), and rescues the orphaned `STOPPING`
   state when the thread was already gone before `stop()` ran.

## Notes

Closes #205.

The two-commit structure is intentional: the first commit adds the failing regression test
(`Raid1Concurrency.StopAndRelaunchAfterComplete`) and the second applies the fix. CI failure on
commit 1 proves the test catches the bug; CI green on commit 2 proves the fix resolves it.

### _Additional cleanup_

- `StopAndRelaunchAfterComplete` regression test added to `resync_relaunch_after_complete.cpp`.
  Runs the second `launch()` in a thread with a 2s deadline; detaches and `FAIL()`s cleanly if
  hung rather than blocking CI indefinitely. `task` is heap-allocated via `shared_ptr` so the
  detached thread never accesses freed memory in the failing case.
- Version bumped to `0.22.2`, CHANGELOG updated.