### PR TITLE
Feature/210 p1 custom cqe

### DIFF
--- a/include/ublkpp/lib/cqe_state.hpp
+++ b/include/ublkpp/lib/cqe_state.hpp
@@ -1,0 +1,85 @@
+#pragma once
+
+#include <coroutine>
+#include <cstdint>
+#include <deque>
+#include <utility>
+
+#include <sisl/logging/logging.h>
+#include <ublksrv.h>
+
+#include <ublkpp/lib/sub_cmd.hpp>
+
+namespace ublkpp {
+
+// Encodes tag, op, and sub_cmd into the io_uring SQE user_data for target I/O.
+// The high bit marks the entry as a target SQE so libublksrv routes the CQE to tgt_io_done.
+inline uint64_t build_tgt_sqe_data(uint64_t tag, uint64_t op, uint64_t sub_cmd) {
+    DEBUG_ASSERT_LE(tag, UINT16_MAX, "Tag too big: [{:#0x}]", tag)
+    DEBUG_ASSERT_LE(op, UINT8_MAX, "Op too big: [{:#0x}]", op)
+    DEBUG_ASSERT_LE(sub_cmd, UINT16_MAX, "SubCmd too big: [{:#0x}]", sub_cmd)
+    return tag | (op << sqe_tag_width) | (sub_cmd << (sqe_tag_width + sqe_op_width)) |
+        (static_cast< uint64_t >(0b1) << (sqe_tag_width + sqe_op_width + sqe_tgt_data_width + sqe_reserved_width));
+}
+
+struct CqeState;
+
+// Per-IO state tracking one inflight request, owned by the ublksrv-allocated io_data slot.
+//
+// Lifetime: placement-new'd in init_queue for each tag slot; explicitly ~async_io() in deinit_queue.
+// pool and completions are cleared at the start of each new I/O in __handle_io_async.
+//
+// Dispatch protocol:
+//   1. queue_tgt_io calls build_cqe_state_data → ensure(sub_cmd) per SQE; pool grows.
+//   2. tgt_io_done / handle_event: ensure(sub_cmd) finds the state, sets result, push_completion.
+//   3. push_completion resumes the CqeAwaiter-suspended coroutine if one is waiting.
+//   4. CqeAwaiter::await_resume pops one entry from completions and returns it.
+//   5. process_result inspects the state and may add to pending (retry / internal).
+struct async_io {
+    std::coroutine_handle<> waiter{};
+    std::deque< CqeState > pool{};         // stable addresses: push_back never invalidates pointers
+    std::deque< CqeState* > completions{}; // ordered queue of states ready for process_result
+    uint32_t pending{0};
+    int ret_val{0};
+
+    // Returns the CqeState for sub_cmd, creating it on first call. O(N) scan; N is small in practice.
+    CqeState* ensure(sub_cmd_t sub_cmd);
+
+    // Enqueues a completed state and resumes the coroutine if it is suspended on CqeAwaiter.
+    void push_completion(CqeState* s) {
+        completions.push_back(s);
+        if (auto h = std::exchange(waiter, {})) h.resume();
+    }
+};
+
+// Tracks a single inflight sub_cmd registered by build_cqe_state_data. Stored in async_io::pool
+// (std::deque, so push_back is pointer-stable). result is written by tgt_io_done / handle_event
+// before the state is enqueued in async_io::completions and the coroutine is resumed.
+struct CqeState {
+    async_io* owner;
+    int result{0};
+    sub_cmd_t sub_cmd{0};
+};
+
+inline CqeState* async_io::ensure(sub_cmd_t sub_cmd) {
+    for (auto& s : pool)
+        if (s.sub_cmd == sub_cmd) return &s;
+    pool.push_back(CqeState{this, 0, sub_cmd});
+    return &pool.back();
+}
+
+// Drop-in replacement for build_tgt_sqe_data for disk drivers that submit SQEs through the target.
+//
+// Before encoding user_data for an SQE, this function pre-registers the sub_cmd in the per-IO
+// CqeState pool (async_io::ensure). When the CQE arrives, tgt_io_done looks up the state by
+// sub_cmd — avoiding a shared side-channel — sets the result, and resumes the coroutine via
+// push_completion.
+//
+// The encoded bits returned are identical to build_tgt_sqe_data(tag, op, sub_cmd), so libublksrv
+// routing (tag extraction, is_target_io check) is completely unchanged.
+inline uint64_t build_cqe_state_data(ublk_io_data const* data, uint64_t tag, uint64_t op, uint64_t sub_cmd) {
+    reinterpret_cast< async_io* >(data->private_data)->ensure(static_cast< sub_cmd_t >(sub_cmd));
+    return build_tgt_sqe_data(tag, op, sub_cmd);
+}
+
+} // namespace ublkpp

--- a/src/driver/fs_disk.cpp
+++ b/src/driver/fs_disk.cpp
@@ -20,6 +20,7 @@ extern "C" {
 #include "fs_disk_impl.hpp"
 #include "lib/logging.hpp"
 #include "metrics/ublk_fsdisk_metrics.hpp"
+#include <ublkpp/lib/cqe_state.hpp>
 #include "target/ublkpp_tgt_impl.hpp"
 
 namespace ublkpp {
@@ -162,7 +163,7 @@ io_result FSDisk::handle_discard(ublksrv_queue const* q, ublk_io_data const* dat
         auto sqe = next_sqe(q);
         io_uring_prep_fallocate(sqe, _fd, discard_to_fallocate(data->iod), addr, len);
 
-        sqe->user_data = build_tgt_sqe_data(data->tag, ublksrv_get_op(data->iod), sub_cmd);
+        sqe->user_data = build_cqe_state_data(data, data->tag, ublksrv_get_op(data->iod), sub_cmd);
         return 1;
     }
 
@@ -209,7 +210,7 @@ io_result FSDisk::async_iov(ublksrv_queue const* q, ublk_io_data const* data, su
     // Set ForceUnitAccess bit to bypass caches
     if (UBLK_IO_OP_READ != op && (data->iod->op_flags & UBLK_IO_F_FUA)) sqe->rw_flags |= RWF_DSYNC;
 
-    sqe->user_data = build_tgt_sqe_data(data->tag, op, sub_cmd);
+    sqe->user_data = build_cqe_state_data(data, data->tag, op, sub_cmd);
 
     // Record I/O start for individual disk metrics
     // This tracks I/O latency for this specific FSDisk instance (identified by path in metrics labels)

--- a/src/driver/fs_disk_impl.hpp
+++ b/src/driver/fs_disk_impl.hpp
@@ -49,15 +49,6 @@ inline bool block_has_unmap(struct stat const& st) {
     return 0 < max_discard;
 }
 
-// High bit indicates this is a driver (e.g. FSDisk) I/O
-inline uint64_t build_tgt_sqe_data(uint64_t tag, uint64_t op, uint64_t sub_cmd) {
-    DEBUG_ASSERT_LE(tag, UINT16_MAX, "Tag too big: [{:#0x}]", tag)
-    DEBUG_ASSERT_LE(op, UINT8_MAX, "Tag too big: [{:#0x}]", tag)
-    DEBUG_ASSERT_LE(sub_cmd, UINT16_MAX, "Tag too big: [{:#0x}]", tag)
-    return tag | (op << sqe_tag_width) | (sub_cmd << (sqe_tag_width + sqe_op_width)) |
-        (static_cast< uint64_t >(0b1) << (sqe_tag_width + sqe_op_width + sqe_tgt_data_width + sqe_reserved_width));
-}
-
 inline auto discard_to_fallocate(ublksrv_io_desc const* iod) {
     int const mode = FALLOC_FL_KEEP_SIZE;
     if (UBLK_IO_OP_DISCARD == ublksrv_get_op(iod) || (0 == (UBLK_IO_F_NOUNMAP & ublksrv_get_flags(iod)))) {

--- a/src/driver/tests/test_fs_disk_impl.cpp
+++ b/src/driver/tests/test_fs_disk_impl.cpp
@@ -28,7 +28,9 @@ namespace {
 
 TEST(BlockHasUnmap, NonExistentDevice) {
     // Test with a device that doesn't exist
+    // clang-format off
     struct stat fake_stat{};
+    // clang-format on
     bool result = ublkpp::block_has_unmap(fake_stat);
 
     // Should return false for non-existent devices

--- a/src/driver/tests/test_fs_disk_impl.cpp
+++ b/src/driver/tests/test_fs_disk_impl.cpp
@@ -15,10 +15,9 @@
 #include <sisl/options/options.h>
 #include <ublksrv.h>
 
-// Include sub_cmd.hpp first to get the constants
 #include "ublkpp/lib/sub_cmd.hpp"
-// Now include fs_disk_impl.hpp which depends on those constants
 #include "../fs_disk_impl.hpp"
+#include <ublkpp/lib/cqe_state.hpp>
 #include "ublkpp/lib/common.hpp"
 
 namespace {

--- a/src/lib/tests/CMakeLists.txt
+++ b/src/lib/tests/CMakeLists.txt
@@ -18,3 +18,15 @@ target_link_libraries (test_logging
   ublksrv::ublksrv
 )
 add_test(NAME LoggingTest COMMAND test_logging -cv warning --log_mods ublksrv:0)
+
+add_executable(test_cqe_state)
+target_sources(test_cqe_state PRIVATE
+   test_cqe_state.cpp
+  $<TARGET_OBJECTS:logging>
+)
+target_link_libraries(test_cqe_state
+  GTest::gmock
+  sisl::cache
+  ublksrv::ublksrv
+)
+add_test(NAME CqeStateTest COMMAND test_cqe_state -cv warning --log_mods ublksrv:0)

--- a/src/lib/tests/test_cqe_state.cpp
+++ b/src/lib/tests/test_cqe_state.cpp
@@ -1,0 +1,169 @@
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <coroutine>
+
+#include <sisl/logging/logging.h>
+#include <sisl/options/options.h>
+#include <ublksrv.h>
+
+#include <ublkpp/lib/cqe_state.hpp>
+
+SISL_LOGGING_INIT(ublksrv)
+
+SISL_OPTIONS_ENABLE(logging)
+
+namespace {
+
+// ============================================================================
+// Coroutine helpers for testing push_completion with a live waiter
+// ============================================================================
+
+struct FireAndForget {
+    struct promise_type {
+        FireAndForget get_return_object() { return {}; }
+        std::suspend_never initial_suspend() { return {}; }
+        std::suspend_never final_suspend() noexcept { return {}; }
+        void return_void() {}
+        void unhandled_exception() {}
+    };
+};
+
+// Suspends the coroutine and installs its handle as io->waiter.
+struct InstallWaiter {
+    ublkpp::async_io* io;
+    bool await_ready() noexcept { return false; }
+    void await_suspend(std::coroutine_handle<> h) noexcept { io->waiter = h; }
+    void await_resume() noexcept {}
+};
+
+static FireAndForget suspend_into_io(ublkpp::async_io* io) { co_await InstallWaiter{io}; }
+
+// ============================================================================
+// async_io::ensure
+// ============================================================================
+
+TEST(AsyncIo, EnsureCreatesNewState) {
+    ublkpp::async_io io{};
+    auto* s = io.ensure(ublkpp::sub_cmd_t{1});
+    ASSERT_NE(s, nullptr);
+    EXPECT_EQ(s->sub_cmd, ublkpp::sub_cmd_t{1});
+    EXPECT_EQ(s->result, 0);
+    EXPECT_EQ(s->owner, &io);
+}
+
+TEST(AsyncIo, EnsureIsIdempotent) {
+    ublkpp::async_io io{};
+    auto* s1 = io.ensure(ublkpp::sub_cmd_t{5});
+    auto* s2 = io.ensure(ublkpp::sub_cmd_t{5});
+    EXPECT_EQ(s1, s2);
+    EXPECT_EQ(io.pool.size(), 1u);
+}
+
+TEST(AsyncIo, EnsureDistinctSubCmds) {
+    ublkpp::async_io io{};
+    auto* s1 = io.ensure(ublkpp::sub_cmd_t{1});
+    auto* s2 = io.ensure(ublkpp::sub_cmd_t{2});
+    auto* s3 = io.ensure(ublkpp::sub_cmd_t{3});
+    EXPECT_NE(s1, s2);
+    EXPECT_NE(s2, s3);
+    EXPECT_EQ(io.pool.size(), 3u);
+}
+
+TEST(AsyncIo, EnsurePoolAddressStability) {
+    ublkpp::async_io io{};
+    auto* first = io.ensure(ublkpp::sub_cmd_t{0});
+    for (int i = 1; i < 64; ++i)
+        io.ensure(ublkpp::sub_cmd_t(i));
+    EXPECT_EQ(first, io.ensure(ublkpp::sub_cmd_t{0}));
+}
+
+// ============================================================================
+// async_io::push_completion
+// ============================================================================
+
+TEST(AsyncIo, PushCompletionNoWaiter) {
+    ublkpp::async_io io{};
+    ublkpp::CqeState s{&io, 42, ublkpp::sub_cmd_t{7}};
+    io.push_completion(&s);
+    ASSERT_EQ(io.completions.size(), 1u);
+    EXPECT_EQ(io.completions.front(), &s);
+    EXPECT_FALSE(io.waiter);
+}
+
+TEST(AsyncIo, PushCompletionMaintainsFIFO) {
+    ublkpp::async_io io{};
+    ublkpp::CqeState s1{&io, 1, ublkpp::sub_cmd_t{1}};
+    ublkpp::CqeState s2{&io, 2, ublkpp::sub_cmd_t{2}};
+    ublkpp::CqeState s3{&io, 3, ublkpp::sub_cmd_t{3}};
+    io.push_completion(&s1);
+    io.push_completion(&s2);
+    io.push_completion(&s3);
+    EXPECT_EQ(io.completions[0], &s1);
+    EXPECT_EQ(io.completions[1], &s2);
+    EXPECT_EQ(io.completions[2], &s3);
+}
+
+TEST(AsyncIo, PushCompletionResumesAndClearsWaiter) {
+    ublkpp::async_io io{};
+    ublkpp::CqeState state{&io, 99, ublkpp::sub_cmd_t{3}};
+    suspend_into_io(&io); // starts, suspends, installs io.waiter
+    ASSERT_TRUE(io.waiter);
+    io.push_completion(&state); // clears waiter, pushes state, resumes coroutine
+    EXPECT_FALSE(io.waiter);
+    EXPECT_EQ(io.completions.size(), 1u);
+    EXPECT_EQ(io.completions.front(), &state);
+}
+
+// ============================================================================
+// build_cqe_state_data
+// ============================================================================
+
+TEST(BuildCqeStateData, RegistersStateInPool) {
+    ublkpp::async_io io{};
+    ublk_io_data fake{};
+    fake.private_data = &io;
+    ublkpp::build_cqe_state_data(&fake, 1, 2, 3);
+    ASSERT_EQ(io.pool.size(), 1u);
+    EXPECT_EQ(io.pool.front().sub_cmd, ublkpp::sub_cmd_t{3});
+    EXPECT_EQ(io.pool.front().owner, &io);
+}
+
+TEST(BuildCqeStateData, ReturnsSameBitsAsBuildTgtSqeData) {
+    ublkpp::async_io io{};
+    ublk_io_data fake{};
+    fake.private_data = &io;
+    uint64_t tag = 42, op = 3, sub_cmd = 7;
+    EXPECT_EQ(ublkpp::build_cqe_state_data(&fake, tag, op, sub_cmd), ublkpp::build_tgt_sqe_data(tag, op, sub_cmd));
+}
+
+TEST(BuildCqeStateData, IsIdempotentForSameSubCmd) {
+    ublkpp::async_io io{};
+    ublk_io_data fake{};
+    fake.private_data = &io;
+    ublkpp::build_cqe_state_data(&fake, 1, 2, 5);
+    ublkpp::build_cqe_state_data(&fake, 1, 2, 5);
+    EXPECT_EQ(io.pool.size(), 1u);
+}
+
+TEST(BuildCqeStateData, DifferentSubCmdsGrowPool) {
+    ublkpp::async_io io{};
+    ublk_io_data fake{};
+    fake.private_data = &io;
+    ublkpp::build_cqe_state_data(&fake, 1, 2, 1);
+    ublkpp::build_cqe_state_data(&fake, 1, 2, 2);
+    ublkpp::build_cqe_state_data(&fake, 1, 2, 3);
+    EXPECT_EQ(io.pool.size(), 3u);
+}
+
+} // anonymous namespace
+
+int main(int argc, char* argv[]) {
+    int parsed_argc = argc;
+    ::testing::InitGoogleTest(&parsed_argc, argv);
+    SISL_OPTIONS_LOAD(parsed_argc, argv, logging);
+    sisl::logging::SetLogger(std::string(argv[0]));
+    spdlog::set_pattern("[%D %T.%e] [%n] [%^%l%$] [%t] %v");
+    parsed_argc = 1;
+    return RUN_ALL_TESTS();
+}

--- a/src/target/ublkpp_tgt.cpp
+++ b/src/target/ublkpp_tgt.cpp
@@ -13,6 +13,7 @@
 
 #include "ublkpp/lib/ublk_disk.hpp"
 #include "lib/logging.hpp"
+#include <ublkpp/lib/cqe_state.hpp>
 #include "ublkpp_tgt_impl.hpp"
 
 SISL_OPTION_GROUP(ublkpp_tgt,
@@ -219,75 +220,62 @@ struct co_io_job {
     operator co_handle_type() const { return coro; }
 };
 
-struct async_io {
-    co_handle_type co;
-    uint32_t sub_cmds;
-    int ret_val;
-    io_uring_cqe const* tgt_io_cqe;
-    async_result const* async_completion;
+// C++20 awaitable that suspends __handle_io_async until the next CqeState is ready.
+// await_ready returns true when completions are already queued so the coroutine avoids
+// suspension on back-to-back CQEs that arrive before the loop iterates.
+struct CqeAwaiter {
+    async_io* io;
+    bool await_ready() const noexcept { return !io->completions.empty(); }
+    void await_suspend(co_handle_type h) noexcept { io->waiter = h; }
+    CqeState* await_resume() noexcept {
+        auto* s = io->completions.front();
+        io->completions.pop_front();
+        return s;
+    }
 };
 
-// Process the result codes from the CQE or Async Completiong
-static inline int retrieve_result(sub_cmd_t cmd, async_io* io) {
-    int res{-EIO};
-    if (auto cqe = io->tgt_io_cqe; cqe) {
-        res = cqe->res;
-    } else {
-        DEBUG_ASSERT_NOTNULL(io->async_completion, "No completion to process!");
-        auto a_result = *io->async_completion;
-        res = a_result.result;
-    }
-    // Only return Errors from DEPENDENT or REPLICATE commands
-    if ((0 < res) && (is_dependent(cmd) || is_replicate(cmd))) return 0;
-    return res;
-}
-
-static void process_result(ublksrv_queue const* q, ublk_io_data const* data) {
+static void process_result(ublksrv_queue const* q, ublk_io_data const* data, CqeState* state) {
     auto device = reinterpret_cast< UblkDisk* >(q->dev->tgt.tgt_data);
-    auto ublkpp_io = reinterpret_cast< async_io* >(data->private_data);
-    --ublkpp_io->sub_cmds;
-    sub_cmd_t const old_cmd = (ublkpp_io->tgt_io_cqe ? user_data_to_tgt_data(ublkpp_io->tgt_io_cqe->user_data)
-                                                     : ublkpp_io->async_completion->sub_cmd);
+    auto io = state->owner;
+    auto old_cmd = state->sub_cmd;
 
-    // If >= 0, the sub_cmd succeeded, aggregate the repsonses from each sum_cmd into the final io result.
-    auto sub_cmd_res = retrieve_result(old_cmd, ublkpp_io);
+    // If >= 0, the sub_cmd succeeded, aggregate the responses from each sub_cmd into the final io result.
+    // Only return errors from DEPENDENT or REPLICATE commands.
+    auto sub_cmd_res = (0 < state->result && (is_dependent(old_cmd) || is_replicate(old_cmd))) ? 0 : state->result;
 
     // Record I/O completion for device latency tracking
-    // Notify the device about I/O completion for device-specific metrics
     device->on_io_complete(data, old_cmd, sub_cmd_res);
 
     // Internal commands are not part of the result like a replicate command, but we do inform the devices of the result
     if (is_internal(old_cmd)) {
         auto io_res = device->queue_internal_resp(q, data, old_cmd, sub_cmd_res);
         DEBUG_ASSERT(io_res, "HandleInternal return error!") // LCOV_EXCL_LINE
-        // Could enqueue more requeusts
-        if (io_res) ublkpp_io->sub_cmds += io_res.value();
+        // Could enqueue more requests
+        if (io_res) io->pending += io_res.value();
         sub_cmd_res = 0;
     }
 
     // Error should be returned regardless of other responses
-    if (0 > ublkpp_io->ret_val) {
-        TLOGT("I/O result ignored [tag:{:#0x}|sub_cmd:{}] [sub_cmds_remain:{}]", data->tag, to_string(old_cmd),
-              ublkpp_io->sub_cmds)
+    if (0 > io->ret_val) {
+        TLOGT("I/O result ignored [tag:{:#0x}|sub_cmd:{}] [pending:{}]", data->tag, to_string(old_cmd), io->pending)
         return;
     }
-    TLOGT("I/O result: [{}] [tag:{:#0x}|sub_cmd:{}] [sub_cmds_remain:{}]", sub_cmd_res, data->tag, to_string(old_cmd),
-          ublkpp_io->sub_cmds)
+    TLOGT("I/O result: [{}] [tag:{:#0x}|sub_cmd:{}] [pending:{}]", sub_cmd_res, data->tag, to_string(old_cmd),
+          io->pending)
 
     if (0 <= sub_cmd_res) {
-        ublkpp_io->ret_val += sub_cmd_res;
+        io->ret_val += sub_cmd_res;
         return;
     }
 
-    // Do not retry a already Retried or Dependent commands
+    // Do not retry already Retried or Dependent commands
     if (is_retry(old_cmd) || is_dependent(old_cmd)) {
-        ublkpp_io->ret_val = sub_cmd_res;
+        io->ret_val = sub_cmd_res;
         return;
     }
 
-    // If retriable, pass the original sub_cmd the sub_cmd took in addition to re-queuing the original
-    // operation. This provides the context to the RAID layers to make intelligent decisions for a retried
-    // sub_cmd.
+    // If retriable, pass the original sub_cmd in addition to re-queuing the original operation.
+    // This provides the context to the RAID layers to make intelligent decisions for a retried sub_cmd.
     auto const sub_cmd = set_flags(old_cmd, sub_cmd_flags::RETRIED);
     TLOGD("Retrying portion of I/O [res:{}] [tag:{:#0x}] [sub_cmd:{}]", sub_cmd_res, data->tag, to_string(sub_cmd))
     auto io_res = device->queue_tgt_io(q, data, sub_cmd);
@@ -298,20 +286,21 @@ static void process_result(ublksrv_queue const* q, ublk_io_data const* data) {
     if (!io_res) {
         TLOGE("Retry Failed Immediately on I/O [tag:{:#0x}] [sub_cmd:{}] [err:{}]", data->tag, to_string(sub_cmd),
               io_res.error().message())
-        ublkpp_io->ret_val = sub_cmd_res;
+        io->ret_val = sub_cmd_res;
         return;
     }
-    // New sub_cmds to wait for in the co-routine
-    ublkpp_io->sub_cmds += io_res.value();
+    // New sub_cmds to wait for in the coroutine
+    io->pending += io_res.value();
 }
 
 static co_io_job __handle_io_async(ublksrv_queue const* q, ublk_io_data const* data) {
     auto device = reinterpret_cast< UblkDisk* >(q->dev->tgt.tgt_data);
-    auto ublkpp_io = reinterpret_cast< async_io* >(data->private_data);
-    ublkpp_io->ret_val = -EIO;
-    ublkpp_io->sub_cmds = 0;
-    ublkpp_io->tgt_io_cqe = nullptr;
-    ublkpp_io->async_completion = nullptr;
+    auto io = reinterpret_cast< async_io* >(data->private_data);
+    io->pool.clear();
+    io->completions.clear();
+    io->waiter = {};
+    io->ret_val = -EIO;
+    io->pending = 0;
 
     auto const op = ublksrv_get_op(data->iod);
 
@@ -320,54 +309,56 @@ static co_io_job __handle_io_async(ublksrv_queue const* q, ublk_io_data const* d
     tgt->metrics.record_queue_depth_change(q, op, true);
 
     // First we submit the IO to the UblkDisk device. It in turn will return the number
-    // of sub_cmd's it enqueued to the io_uring queue to satisfy the request. RAID levels will
-    // cause this amplification of operations.
+    // of sub_cmds it enqueued to the io_uring queue to satisfy the request. RAID levels will
+    // cause this amplification of operations. Each sub_cmd registers a CqeState via
+    // build_cqe_state_data so tgt_io_done can route completions by sub_cmd.
     auto io_res = device->queue_tgt_io(q, data, 0);
 
     // Submit to io_uring before yielding to make iovecs that are thread_local stable
     io_uring_submit(q->ring_ptr);
 
     if (io_res) {
-        ublkpp_io->ret_val = 0;
-        ublkpp_io->sub_cmds = io_res.value();
-        TLOGT("I/O [tag:{:#0x}] [sub_ios:{}]", data->tag, ublkpp_io->sub_cmds)
+        io->ret_val = 0;
+        io->pending = io_res.value();
+        TLOGT("I/O [tag:{:#0x}] [sub_ios:{}]", data->tag, io->pending)
     } else
         TLOGD("IO Failed Immediately to queue io [tag:{:#0x}], err: [{}]", data->tag, io_res.error().message())
 
-    // For each sub_cmd enqueued, we expect a response to be processed.
-    while (0 < ublkpp_io->sub_cmds) {
-        { co_await std::suspend_always(); }
-        process_result(q, data);
+    // For each pending sub_cmd, suspend until tgt_io_done (or handle_event) delivers a CqeState.
+    while (0 < io->pending) {
+        auto* done = co_await CqeAwaiter{io};
+        --io->pending;
+        process_result(q, data, done);
     }
 
     // Record queue depth decrement
     tgt->metrics.record_queue_depth_change(q, op, false);
 
-    // Operation is complete, result is in io_res
-    if (0 > ublkpp_io->ret_val) [[unlikely]] {
-        TLOGE("Returning error for [tag:{:#0x}] [res:{}]", data->tag, ublkpp_io->ret_val)
+    // Operation is complete, result is in io->ret_val
+    if (0 > io->ret_val) [[unlikely]] {
+        TLOGE("Returning error for [tag:{:#0x}] [res:{}]", data->tag, io->ret_val)
     } else {
-        TLOGT("I/O complete [tag:{:#0x}] [res:{}]", data->tag, ublkpp_io->ret_val)
+        TLOGT("I/O complete [tag:{:#0x}] [res:{}]", data->tag, io->ret_val)
     }
-    ublksrv_complete_io(q, data->tag, ublkpp_io->ret_val);
+    ublksrv_complete_io(q, data->tag, io->ret_val);
 }
 
 // I/O Handler, first entry-point to us for all I/O
 static int handle_io_async(ublksrv_queue const* q, ublk_io_data const* data) {
-    // Construct a co-routine and set it to the private data, we call resume in `tgt_io_done` once complete
-    reinterpret_cast< async_io* >(data->private_data)->co = __handle_io_async(q, data);
+    // Fire-and-forget: co_io_job starts immediately (suspend_never), suspends at CqeAwaiter
+    (void)__handle_io_async(q, data);
     return 0;
 }
 
 // Called when the I/O we have scheduled on the ublksrv uring (e.g. FSDisk) have completed
 static void tgt_io_done(ublksrv_queue const* q, ublk_io_data const* data, io_uring_cqe const* cqe) {
-    auto tag = static_cast< int32_t >(user_data_to_tag(cqe->user_data));
-    auto io = reinterpret_cast< async_io* >(data->private_data);
-
-    RELEASE_ASSERT_EQ(data->tag, tag, "Tag mismatch!")
-    io->tgt_io_cqe = cqe;
+    RELEASE_ASSERT_EQ(data->tag, static_cast< int32_t >(user_data_to_tag(cqe->user_data)), "Tag mismatch!")
+    auto* io = reinterpret_cast< async_io* >(data->private_data);
+    auto cmd = static_cast< sub_cmd_t >(user_data_to_tgt_data(cqe->user_data));
+    auto* state = io->ensure(cmd);
+    state->result = cqe->res;
     try {
-        io->co.resume();
+        io->push_completion(state);
     } catch (std::exception const& e) {
         TLOGE("I/O threw exception: [{}]", e.what())
         ublksrv_complete_io(q, data->tag, -EIO);
@@ -383,13 +374,11 @@ static void handle_event(ublksrv_queue const* q) {
     // Clear the event from efd first, as we may cause new events by retrying failed sub_cmds
     ublksrv_queue_handled_event(q);
     for (auto& result : completed) {
+        auto* io = reinterpret_cast< async_io* >(result.io->private_data);
+        auto* state = io->ensure(result.sub_cmd);
+        state->result = result.result;
         try {
-            auto ublkpp_io = reinterpret_cast< async_io* >(result.io->private_data);
-            // We set this to indicate to the co-routine this is an async result
-            // not something to parse from io_uring
-            ublkpp_io->tgt_io_cqe = nullptr;
-            ublkpp_io->async_completion = &result;
-            ublkpp_io->co.resume();
+            io->push_completion(state);
         } catch (std::exception const& e) {
             TLOGE("Async event threw exception: [{}]", e.what())
             ublksrv_complete_io(q, result.io->tag, -EIO);
@@ -447,9 +436,17 @@ static int init_queue(const struct ublksrv_queue* q, void**) {
     // All current disk types return no FDs from per-queue init; non-empty means the FDs would go
     // unregistered with io_uring and fixed-file I/O would crash — treat it as a fatal init failure.
     if (!device->open_for_uring(q, 0).empty()) return -1;
+    // async_io contains std::deque members; ublksrv allocates raw bytes via calloc, so we must
+    // placement-new to properly construct each IO slot's async_io.
+    for (int i = 0; i < q->q_depth; ++i)
+        new (ublksrv_io_private_data(q, i)) async_io{};
     return 0;
 }
-static void deinit_queue(const struct ublksrv_queue*){TLOGD("Deinit Queue")}
+static void deinit_queue(const struct ublksrv_queue* q) {
+    TLOGD("Deinit Queue")
+    for (int i = 0; i < q->q_depth; ++i)
+        static_cast< async_io* >(ublksrv_io_private_data(q, i))->~async_io();
+}
 
 // Setup ublksrv ctrl device and initiate adding the target to the ublksrv service and handle all device traffic
 ublkpp_tgt::run_result_t ublkpp_tgt::run(boost::uuids::uuid const& vol_id, std::shared_ptr< UblkDisk > device,

--- a/src/tests/mock_ublksrv/mock_ublksrv.cpp
+++ b/src/tests/mock_ublksrv/mock_ublksrv.cpp
@@ -17,7 +17,7 @@ static constexpr size_t k_max_io_size = DEF_BUF_SIZE;
 static constexpr size_t k_sector_align = 512;
 
 MockUblksrv::MockUblksrv(std::shared_ptr< UblkDisk > disk, int q_depth, int nr_queues) :
-        _q_depth(q_depth), _disk(std::move(disk)), _tags(q_depth), _queues(nr_queues) {
+        _q_depth(q_depth), _disk(std::move(disk)), _tags(q_depth), _queues(nr_queues), _io_states(q_depth) {
     // q_depth * 4 gives headroom for RAID1 write amplification (2x replicas +
     // 2x bitmap SQEs per user write) without false "ring full" auto-submits.
     if (io_uring_queue_init(q_depth * 4, &_ring, 0) < 0) throw std::runtime_error("io_uring_queue_init failed");
@@ -46,11 +46,11 @@ MockUblksrv::MockUblksrv(std::shared_ptr< UblkDisk > disk, int q_depth, int nr_q
         }
     }
 
-    // Wire up per-tag data.iod pointers
+    // Wire up per-tag data.iod pointers and async_io backing storage
     for (int tag = 0; tag < q_depth; ++tag) {
         _tags[tag].data.tag = tag;
         _tags[tag].data.iod = &_tags[tag].iod;
-        _tags[tag].data.private_data = nullptr;
+        _tags[tag].data.private_data = &_io_states[tag];
     }
 
     // Allocate sector-aligned I/O buffers (one per tag)
@@ -79,6 +79,11 @@ io_result MockUblksrv::submit_io(int tag, uint8_t op, uint64_t start_sector, uin
     ts.iod.addr = reinterpret_cast< uint64_t >(buf);
     ts.sub_cmds_remaining = 0;
     ts.result = 0;
+
+    // Reset async_io state between IOs on the same tag slot
+    _io_states[tag].pool.clear();
+    _io_states[tag].completions.clear();
+    _io_states[tag].waiter = {};
 
     auto res = _disk->queue_tgt_io(&_queues[0], &ts.data, 0);
     if (!res) return res;

--- a/src/tests/mock_ublksrv/mock_ublksrv.hpp
+++ b/src/tests/mock_ublksrv/mock_ublksrv.hpp
@@ -7,6 +7,7 @@
 #include <liburing.h>
 #include <ublksrv.h>
 
+#include "ublkpp/lib/cqe_state.hpp"
 #include "ublkpp/lib/sub_cmd.hpp"
 #include "ublkpp/lib/ublk_disk.hpp"
 
@@ -73,6 +74,9 @@ private:
     io_uring _ring{};
     std::shared_ptr< UblkDisk > _disk;
     std::vector< TagState > _tags;
+
+    // async_io pool — one per tag, mirrors what init_queue does via placement new
+    std::vector< async_io > _io_states;
 
     // Aligned I/O buffers — one per tag, DEF_BUF_SIZE bytes each
     std::vector< uint8_t > _io_buf_storage;


### PR DESCRIPTION
## Phase 1 of #210 — Per-sub_cmd CqeState pool

### Problem

The previous `tgt_io_done` / `handle_event` dispatch relied on a shared nullable-pointer side-channel (`tgt_io_cqe` / `async_completion`) that had to be written immediately before each coroutine resume. This meant only one sub_cmd could be in-flight per IO tag at a time — the pointer was a single slot, not a queue — and callers had to carefully time writes to avoid racing the resume.

### What this PR does

Replaces the side-channel with a per-sub_cmd `CqeState` pool (`std::deque<CqeState>`) inside each `async_io` slot. `build_cqe_state_data` registers a `CqeState` in the pool via `ensure(sub_cmd)` before submitting each SQE. When the CQE arrives, `tgt_io_done` looks up the right state by sub_cmd, writes the result, and calls `push_completion` to resume the coroutine.

`CqeAwaiter` replaces the raw coroutine handle store: it suspends until `completions` is non-empty, then pops and returns the next `CqeState*`. This correctly handles back-to-back CQEs without losing completions.

The public header `include/ublkpp/lib/cqe_state.hpp` is introduced so out-of-repo disk implementations can call `build_cqe_state_data` without depending on target internals.

### What is unchanged

`user_data` encoding (`tag | op | sub_cmd | bit63`) and all `tgt_io_done` / `handle_event` routing through ublksrv are preserved. Phase 2 replaces those.

### Test plan
- [x] `test_cqe_state`: pool creation, idempotency, FIFO ordering, waiter resume
- [x] Functional FSDisk read/write/flush/discard via MockUblksrv