### PR TITLE
Feature/210 p2 own the cqe

### DIFF
--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -40,6 +40,12 @@ pipeline {
             }
         }
 
+        stage('Prepare') {
+            steps {
+                sh "bash prepare_v2.sh"
+            }
+        }
+
         stage('Build') {
             failFast true
             matrix {

--- a/3rd_party/ublksrv/conandata.yml
+++ b/3rd_party/ublksrv/conandata.yml
@@ -1,15 +1,18 @@
 sources:
-  "nbi.1.5.0":
+  "nbi.1.5.0.1":
     url: "https://github.com/ublk-org/ublksrv/archive/7fc74012e5ee8ab6d3ebda12cfeaf75d7b1b135a.tar.gz"
     sha256: "fae78a6c49eae98941aa3682bb966fc760ab6c9d3db6d06c34173897fff0906f"
   "nbi.1.4.1":
     url: "https://github.com/ublk-org/ublksrv/archive/0099e223b75f9bf5415444eac151ab65f60ba230.tar.gz"
     sha256: "784114812f9bb7ba0ac193d5fa412ab13a10a553276c51f7d188804261cf9363"
 patches:
-  "nbi.1.5.0":
+  "nbi.1.5.0.1":
     - patch_file: "patches/logging_1_5_0.patch"
       patch_description: "log to SISL"
       patch_type: "portability"
+    - patch_file: "patches/run_loop_1_5_0.patch"
+      patch_description: "expose ublksrv_handle_cmd_cqe and ublksrv_queue_update_idle for custom CQE loop"
+      patch_type: "feature"
   "nbi.1.4.1":
     - patch_file: "patches/logging.patch"
       patch_description: "log to SISL"

--- a/3rd_party/ublksrv/patches/run_loop_1_5_0.patch
+++ b/3rd_party/ublksrv/patches/run_loop_1_5_0.patch
@@ -1,0 +1,134 @@
+diff --git a/include/ublksrv.h b/include/ublksrv.h
+index edaa4e9..7e58f2a 100644
+--- a/include/ublksrv.h
++++ b/include/ublksrv.h
+@@ -1155,6 +1155,21 @@ extern int ublksrv_complete_io(const struct ublksrv_queue *q, unsigned tag, int
+  */
+ extern int ublksrv_queue_reap_events(const struct ublksrv_queue *tq);
+ 
++/**
++ * ublksrv_handle_cmd_cqe - handle one ublk command CQE (non-target IO).
++ * Caller must verify is_target_io(cqe->user_data) == 0 before calling.
++ */
++extern void ublksrv_handle_cmd_cqe(const struct ublksrv_queue *tq,
++		const struct io_uring_cqe *cqe);
++
++/**
++ * ublksrv_queue_update_idle - update idle/stopping state after draining CQEs.
++ * @ret:    return value of io_uring_submit_and_wait_timeout
++ * @reapped: number of CQEs consumed in this batch
++ */
++extern void ublksrv_queue_update_idle(const struct ublksrv_queue *tq,
++		int ret, int reapped);
++
+ /** @} */ // end of ublksrv_queue group
+ 
+ #ifdef __cplusplus
+diff --git a/lib/ublksrv.c b/lib/ublksrv.c
+index e004b22..6472ebc 100644
+--- a/lib/ublksrv.c
++++ b/lib/ublksrv.c
+@@ -467,12 +467,6 @@ static int ublksrv_setup_eventfd(struct _ublksrv_queue *q)
+ 		return -EINVAL;
+ 	}
+ 
+-	if (!q->dev->tgt.ops->handle_event) {
+-		ublk_err("ublk dev %d/%d not define ->handle_event",
+-			info->dev_id, q->q_id);
+-		return -EINVAL;
+-	}
+-
+ 	q->efd = eventfd(0, 0);
+ 	if (q->efd < 0)
+ 		return -errno;
+@@ -829,30 +823,14 @@ static inline void ublksrv_handle_tgt_cqe(struct _ublksrv_queue *q,
+ 	}
+ }
+ 
+-static void ublksrv_handle_cqe(struct io_uring *r,
+-		struct io_uring_cqe *cqe, void *data)
++static void ublksrv_handle_cmd_cqe_impl(struct _ublksrv_queue *q,
++		const struct io_uring_cqe *cqe)
+ {
+-	struct _ublksrv_queue *q = container_of(r, struct _ublksrv_queue, ring);
+ 	unsigned tag = user_data_to_tag(cqe->user_data);
+-	unsigned cmd_op = user_data_to_op(cqe->user_data);
+ 	int fetch = (cqe->res != UBLK_IO_RES_ABORT) &&
+ 		!(q->state & UBLKSRV_QUEUE_STOPPING);
+-	struct ublk_io *io;
+-
+-	ublk_dbg(UBLK_DBG_IO_CMD, "%s: res %d (qid %d tag %u cmd_op %u target %d/%x event %d) stopping %d\n",
+-			__func__, cqe->res, q->q_id, tag, cmd_op,
+-			is_target_io(cqe->user_data),
+-			user_data_to_tgt_data(cqe->user_data),
+-			is_eventfd_io(cqe->user_data),
+-			(q->state & UBLKSRV_QUEUE_STOPPING));
+-
+-	/* Don't retrieve io in case of target io */
+-	if (is_target_io(cqe->user_data)) {
+-		ublksrv_handle_tgt_cqe(q, cqe);
+-		return;
+-	}
++	struct ublk_io *io = &q->ios[tag];
+ 
+-	io = &q->ios[tag];
+ 	q->cmd_inflight--;
+ 
+ 	if (!fetch) {
+@@ -885,6 +863,29 @@ static void ublksrv_handle_cqe(struct io_uring *r,
+ 	}
+ }
+ 
++static void ublksrv_handle_cqe(struct io_uring *r,
++		struct io_uring_cqe *cqe, void *data)
++{
++	struct _ublksrv_queue *q = container_of(r, struct _ublksrv_queue, ring);
++	unsigned tag = user_data_to_tag(cqe->user_data);
++	unsigned cmd_op = user_data_to_op(cqe->user_data);
++
++	ublk_dbg(UBLK_DBG_IO_CMD, "%s: res %d (qid %d tag %u cmd_op %u target %d/%x event %d) stopping %d\n",
++			__func__, cqe->res, q->q_id, tag, cmd_op,
++			is_target_io(cqe->user_data),
++			user_data_to_tgt_data(cqe->user_data),
++			is_eventfd_io(cqe->user_data),
++			(q->state & UBLKSRV_QUEUE_STOPPING));
++
++	/* Don't retrieve io in case of target io */
++	if (is_target_io(cqe->user_data)) {
++		ublksrv_handle_tgt_cqe(q, cqe);
++		return;
++	}
++
++	ublksrv_handle_cmd_cqe_impl(q, cqe);
++}
++
+ static int ublksrv_reap_events_uring(struct io_uring *r)
+ {
+ 	struct io_uring_cqe *cqe;
+@@ -939,6 +940,26 @@ static inline void ublksrv_queue_idle_exit(struct _ublksrv_queue *q)
+ 			q->tgt_ops->idle_fn(local_to_tq(q), false);
+ 	}
+ }
++void ublksrv_handle_cmd_cqe(const struct ublksrv_queue *tq,
++		const struct io_uring_cqe *cqe)
++{
++	ublksrv_handle_cmd_cqe_impl(tq_to_local(tq), cqe);
++}
++
++void ublksrv_queue_update_idle(const struct ublksrv_queue *tq, int ret,
++		int reapped)
++{
++	struct _ublksrv_queue *q = tq_to_local(tq);
++
++	if (q->state & UBLKSRV_QUEUE_STOPPING) {
++		ublksrv_kill_eventfd(q);
++	} else {
++		if (ret == -ETIME && reapped == 0 && !io_uring_sq_ready(&q->ring))
++			ublksrv_queue_idle_enter(q);
++		else
++			ublksrv_queue_idle_exit(q);
++	}
++}
+ 
+ static void ublksrv_reset_aio_batch(struct _ublksrv_queue *q)
+ {

--- a/conanfile.py
+++ b/conanfile.py
@@ -78,7 +78,7 @@ class UBlkPPConan(ConanFile):
         self.requires("isa-l/2.30.0")
         if (self.options.get_safe("homeblocks")):
             self.requires("homeblocks/[^5.0]")
-        self.requires("ublksrv/nbi.1.5.0")
+        self.requires("ublksrv/nbi.1.5.0.1")
         if (self.options.get_safe("iscsi")):
             self.requires("libiscsi/[^1.20]")
 

--- a/prepare_v2.sh
+++ b/prepare_v2.sh
@@ -2,7 +2,7 @@ set -eu
 
 echo -n "Exporting custom recipes..."
 echo -n "ublksrv..."
-conan export 3rd_party/ublksrv --version nbi.1.5.0 >/dev/null
+conan export 3rd_party/ublksrv --version nbi.1.5.0.1 >/dev/null
 conan export 3rd_party/libiscsi --version 1.20.3 >/dev/null
 echo -n "fio..."
 conan export 3rd_party/fio --version nbi.3.28 >/dev/null

--- a/src/target/ublkpp_tgt.cpp
+++ b/src/target/ublkpp_tgt.cpp
@@ -88,7 +88,9 @@ static constexpr int k_io_idle_secs = 20;
 // sub_cmd encoding in user_data is preserved (Phase 2 — no pointer encoding yet).
 static void run_queue_loop(ublksrv_queue const* q) {
     auto* ring = q->ring_ptr;
+    // clang-format off
     struct __kernel_timespec ts{.tv_sec = k_io_idle_secs, .tv_nsec = 0};
+    // clang-format on
     auto tgt = static_cast< ublkpp_tgt_impl* >(q->private_data);
 
     while (!ublksrv_queue_is_done(q)) {

--- a/src/target/ublkpp_tgt.cpp
+++ b/src/target/ublkpp_tgt.cpp
@@ -2,6 +2,7 @@
 
 #include <coroutine>
 #include <cstring>
+#include <list>
 #include <thread>
 
 #include <boost/uuid/uuid_io.hpp>
@@ -76,6 +77,72 @@ static void set_queue_thread_affinity(ublksrv_ctrl_dev const*) {
     sched_setaffinity(0, sizeof(set), &set);
 }
 
+// bit 63 = is_target_io; bit 62 = is_eventfd_io (matches ublksrv_priv.h encoding)
+static constexpr uint64_t k_target_bit = 1ULL << 63;
+static constexpr uint64_t k_eventfd_bit = 1ULL << 62;
+// Matches UBLKSRV_IO_IDLE_SECS defined privately in ublksrv.c
+static constexpr int k_io_idle_secs = 20;
+
+// Our own CQE processing loop, replacing ublksrv_process_io.
+// Target CQEs are dispatched inline; ublk command CQEs delegate to ublksrv.
+// sub_cmd encoding in user_data is preserved (Phase 2 — no pointer encoding yet).
+static void run_queue_loop(ublksrv_queue const* q) {
+    auto* ring = q->ring_ptr;
+    struct __kernel_timespec ts{.tv_sec = k_io_idle_secs, .tv_nsec = 0};
+    auto tgt = static_cast< ublkpp_tgt_impl* >(q->private_data);
+
+    while (!ublksrv_queue_is_done(q)) {
+        io_uring_cqe* cqe{};
+        auto const ret = io_uring_submit_and_wait_timeout(ring, &cqe, 1, &ts, nullptr);
+
+        unsigned head{};
+        int count{0};
+        io_uring_for_each_cqe(ring, head, cqe) {
+            if (cqe->user_data & k_target_bit) {
+                if (cqe->user_data & k_eventfd_bit) {
+                    // eventfd notification — collect async completions (RAID1/iSCSI)
+                    auto completed = std::list< async_result >();
+                    tgt->device->collect_async(q, completed);
+                    ublksrv_queue_handled_event(q);
+                    for (auto& r : completed) {
+                        auto* io = reinterpret_cast< async_io* >(r.io->private_data);
+                        auto* state = io->ensure(r.sub_cmd);
+                        state->result = r.result;
+                        try {
+                            io->push_completion(state);
+                        } catch (std::exception const& e) {
+                            TLOGE("Async event threw exception: [{}]", e.what())
+                            ublksrv_complete_io(q, r.io->tag, -EIO);
+                        }
+                    }
+                } else {
+                    // target io_uring CQE — route by sub_cmd to CqeState
+                    auto* data =
+                        reinterpret_cast< ublk_io_data* >(ublksrv_io_private_data(q, user_data_to_tag(cqe->user_data)));
+                    RELEASE_ASSERT_EQ(data->tag, static_cast< int32_t >(user_data_to_tag(cqe->user_data)),
+                                      "Tag mismatch!")
+                    auto* io = reinterpret_cast< async_io* >(data->private_data);
+                    auto cmd = static_cast< sub_cmd_t >(user_data_to_tgt_data(cqe->user_data));
+                    auto* state = io->ensure(cmd);
+                    state->result = cqe->res;
+                    try {
+                        io->push_completion(state);
+                    } catch (std::exception const& e) {
+                        TLOGE("I/O threw exception: [{}]", e.what())
+                        ublksrv_complete_io(q, data->tag, -EIO);
+                    }
+                }
+            } else {
+                // ublk command CQE (FETCH/COMMIT) — delegate to libublksrv
+                ublksrv_handle_cmd_cqe(q, cqe);
+            }
+            ++count;
+        }
+        io_uring_cq_advance(ring, count);
+        ublksrv_queue_update_idle(q, ret, count);
+    }
+}
+
 static void* ublksrv_queue_handler(std::shared_ptr< ublkpp_tgt_impl > target, int q_id, sem_t* queue_sem) {
     // Find our /dev/ublk-control file descriptor
     auto cdev = ublksrv_get_ctrl_dev(target->ublk_dev);
@@ -100,9 +167,7 @@ static void* ublksrv_queue_handler(std::shared_ptr< ublkpp_tgt_impl > target, in
     }
 
     TLOGD("tid {}: ublk dev queue {} started", ublksrv_gettid(), q->q_id)
-    do {
-        if (ublksrv_process_io(q) < 0) break;
-    } while (1);
+    run_queue_loop(q);
     TLOGD("ublk dev queue {} exited", q->q_id)
     ublksrv_queue_deinit(q);
     return NULL;
@@ -350,42 +415,6 @@ static int handle_io_async(ublksrv_queue const* q, ublk_io_data const* data) {
     return 0;
 }
 
-// Called when the I/O we have scheduled on the ublksrv uring (e.g. FSDisk) have completed
-static void tgt_io_done(ublksrv_queue const* q, ublk_io_data const* data, io_uring_cqe const* cqe) {
-    RELEASE_ASSERT_EQ(data->tag, static_cast< int32_t >(user_data_to_tag(cqe->user_data)), "Tag mismatch!")
-    auto* io = reinterpret_cast< async_io* >(data->private_data);
-    auto cmd = static_cast< sub_cmd_t >(user_data_to_tgt_data(cqe->user_data));
-    auto* state = io->ensure(cmd);
-    state->result = cqe->res;
-    try {
-        io->push_completion(state);
-    } catch (std::exception const& e) {
-        TLOGE("I/O threw exception: [{}]", e.what())
-        ublksrv_complete_io(q, data->tag, -EIO);
-    }
-}
-
-// Called when some async UblkDisk has called send_event to notify of a sub_cmd completion
-static void handle_event(ublksrv_queue const* q) {
-    auto tgt = static_cast< ublkpp_tgt_impl* >(q->private_data);
-    auto completed = std::list< async_result >();
-    tgt->device->collect_async(q, completed);
-
-    // Clear the event from efd first, as we may cause new events by retrying failed sub_cmds
-    ublksrv_queue_handled_event(q);
-    for (auto& result : completed) {
-        auto* io = reinterpret_cast< async_io* >(result.io->private_data);
-        auto* state = io->ensure(result.sub_cmd);
-        state->result = result.result;
-        try {
-            io->push_completion(state);
-        } catch (std::exception const& e) {
-            TLOGE("Async event threw exception: [{}]", e.what())
-            ublksrv_complete_io(q, result.io->tag, -EIO);
-        }
-    }
-}
-
 static void handle_io_background(const struct ublksrv_queue*, int nr_queued_io) {
     TLOGT("HandleIOBackground: {}", nr_queued_io)
 }
@@ -462,10 +491,8 @@ ublkpp_tgt::run_result_t ublkpp_tgt::run(boost::uuids::uuid const& vol_id, std::
 
     tgt->tgt_type = std::make_unique< ublksrv_tgt_type >(ublksrv_tgt_type{
         .handle_io_async = handle_io_async,
-        .tgt_io_done = tgt_io_done,
-        .handle_event = device->uses_ublk_iouring
-            ? nullptr
-            : handle_event, // Device specific, determines *if* ublksrv_complete_io() will be called by device
+        .tgt_io_done = nullptr,  // handled inline in run_queue_loop
+        .handle_event = nullptr, // handled inline in run_queue_loop
         .handle_io_background = handle_io_background,
         .usage_for_add = nullptr, // Not Implemented
         .init_tgt = init_tgt,
@@ -475,8 +502,11 @@ ublkpp_tgt::run_result_t ublkpp_tgt::run(boost::uuids::uuid const& vol_id, std::
         .idle_fn = idle_transition, // Called when I/O has stopped
         .type = 0,                  // Deprecated *DO NOT USE*
         .ublk_flags = ublk_flags,
-        .ublksrv_flags = (device->uses_ublk_iouring ? 0U : (unsigned)UBLKSRV_F_NEED_EVENTFD), // See handle_event
-        .pad = 0,                                                                             // Currently Clear
+        .ublksrv_flags =
+            (device->uses_ublk_iouring
+                 ? 0U
+                 : (unsigned)UBLKSRV_F_NEED_EVENTFD), // eventfd set up by ublksrv, handled inline in run_queue_loop
+        .pad = 0,                                     // Currently Clear
         .name = "ublkpp",
         .recovery_tgt = nullptr, // Deprecated *DO NOT USE*
         .init_queue = init_queue,


### PR DESCRIPTION
## Phase 2 of #210 — Own the CQE processing loop

### Problem

`ublksrv_process_io` routes target CQEs through `tgt_io_done` and `handle_event` function pointers registered on `tgt_type`. This indirection exists solely to let the target intercept completions — but it means the dispatch path goes through ublksrv even though ublksrv adds no value there. More importantly, it prevents Phase 3: storing a raw `CqeState*` in `user_data` requires decoding it ourselves, which is impossible if ublksrv owns the loop.

### What this PR does

Patches ublksrv (version `nbi.1.5.0.1`) to expose two new public functions:

```c
void ublksrv_handle_cmd_cqe(const struct ublksrv_queue*, const struct io_uring_cqe*);
void ublksrv_queue_update_idle(const struct ublksrv_queue*, int ret, int reapped);
```

With those available, `run_queue_loop` replaces `ublksrv_process_io` entirely. It iterates the raw `io_uring` ring directly: target CQEs (bit 63 set) are dispatched inline, eventfd CQEs (bit 62 set) collect async results via `collect_async`, and ublk command CQEs (FETCH/COMMIT) delegate to `ublksrv_handle_cmd_cqe`. `tgt_io_done` and `handle_event` are set to `nullptr` on `tgt_type` — they are no longer called.

The sub_cmd→CqeState routing inside the target CQE branch is identical to Phase 1; only the outer dispatch mechanism changes.

MockUblksrv gains a proper `async_io` backing store per tag slot so `build_cqe_state_data` can dereference `private_data` safely in tests without the real ublksrv init path.

### What is unchanged

`user_data` encoding (`tag | op | sub_cmd | bit63`) and the per-sub_cmd pool lookup are preserved. Phase 3 replaces those.

### Test plan
- [x] All 13 existing tests pass (Debug + ASAN)
- [x] Functional FSDisk tests exercise `run_queue_loop` dispatch via MockUblksrv