### PR TITLE
Feature/210 p4 replace queue_tgt_io loop with disk_task<int> coroutine API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,29 @@ if (CCACHE_FOUND)
     set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ccache)
 endif ()
 
+# stdexec's internal rapids-cmake/CPM uses FetchContent_Populate directly; suppress the CMP0169 warning
+if(POLICY CMP0169)
+    cmake_policy(SET CMP0169 OLD)
+endif()
+
+include(FetchContent)
+FetchContent_Declare(
+    stdexec
+    GIT_REPOSITORY https://github.com/NVIDIA/stdexec.git
+    GIT_TAG        nvhpc-25.09
+    GIT_SHALLOW    TRUE
+)
+set(STDEXEC_BUILD_TESTS      OFF CACHE BOOL "" FORCE)
+set(STDEXEC_BUILD_EXAMPLES   OFF CACHE BOOL "" FORCE)
+set(STDEXEC_ENABLE_CUDA      OFF CACHE BOOL "" FORCE)
+set(STDEXEC_ENABLE_TBB       OFF CACHE BOOL "" FORCE)
+set(STDEXEC_ENABLE_IO_URING  OFF CACHE BOOL "" FORCE)
+FetchContent_MakeAvailable(stdexec)
+
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    target_compile_options(stdexec INTERFACE -Wno-empty-body)
+endif()
+
 include_directories(BEFORE ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
 find_package(sisl REQUIRED)

--- a/include/ublkpp/drivers/fs_disk.hpp
+++ b/include/ublkpp/drivers/fs_disk.hpp
@@ -13,7 +13,7 @@ class FSDisk : public UblkDisk {
     std::filesystem::path _path;
     int _fd{-1};
     bool _block_device{false};
-    std::unique_ptr<UblkFSDiskMetrics> _metrics;
+    std::unique_ptr< UblkFSDiskMetrics > _metrics;
 
 public:
     // Constructor: creates metrics internally using parent_id
@@ -21,6 +21,9 @@ public:
     ~FSDisk() override;
 
     std::string id() const noexcept override { return _path.native(); }
+
+    bool uses_async_api() const noexcept override { return true; }
+    disk_task< int > handle_io_async(ublksrv_queue const* q, ublk_io_data const* data, sub_cmd_t sub_cmd) override;
 
     io_result handle_flush(ublksrv_queue const* q, ublk_io_data const* data, sub_cmd_t sub_cmd) override;
     io_result handle_discard(ublksrv_queue const* q, ublk_io_data const* data, sub_cmd_t sub_cmd, uint32_t len,

--- a/include/ublkpp/lib/cqe_state.hpp
+++ b/include/ublkpp/lib/cqe_state.hpp
@@ -19,10 +19,18 @@ struct CqeState;
 // Lifetime: placement-new'd in init_queue for each tag slot; explicitly ~async_io() in deinit_queue.
 // pool and completions are cleared at the start of each new I/O in __handle_io_async.
 //
-// Dispatch protocol:
+// Dispatch protocol — two paths depending on which API the disk uses:
+//
+// New API (FSDisk, RAID0 with FSDisk children — uses_async_api() == true):
+//   1. handle_io_async calls build_cqe_state_data → ensure(sub_cmd) per SQE; pool grows.
+//   2. Coroutine suspends on co_await CqeAwaitable{state}; state->waiter is installed.
+//   3. run_queue_loop decodes CqeState*, sets result + result_ready, resumes state->waiter.
+//   4. CqeAwaitable::await_resume returns state->result directly.
+//
+// Old API (RAID1, RAID10, legacy — uses_async_api() == false):
 //   1. queue_tgt_io calls build_cqe_state_data → ensure(sub_cmd) per SQE; pool grows.
-//   2. run_queue_loop: CqeState* is decoded from user_data and push_completion is called.
-//   3. push_completion resumes the CqeAwaiter-suspended coroutine if one is waiting.
+//   2. run_queue_loop decodes CqeState*, sets result + result_ready, calls push_completion.
+//   3. push_completion enqueues state and resumes the CqeAwaiter-suspended coroutine.
 //   4. CqeAwaiter::await_resume pops one entry from completions and returns it.
 //   5. process_result inspects the state and may add to pending (retry / internal).
 struct async_io {
@@ -44,18 +52,29 @@ struct async_io {
 };
 
 // Tracks a single inflight sub_cmd registered by build_cqe_state_data. Stored in async_io::pool
-// (std::deque, so push_back is pointer-stable). result is written by tgt_io_done / handle_event
-// before the state is enqueued in async_io::completions and the coroutine is resumed.
+// (std::deque, so push_back is pointer-stable). result and result_ready are written by
+// run_queue_loop before resuming waiter (new API) or calling push_completion (old API).
 struct CqeState {
     async_io* owner;
     int result{0};
+    bool result_ready{false};         // set before resuming waiter or calling push_completion
+    std::coroutine_handle<> waiter{}; // per-state direct resume (new API path only)
     sub_cmd_t sub_cmd{0};
+};
+
+// Awaitable for a specific CqeState (new API path). await_ready returns true when the CQE
+// already arrived before co_await — avoids suspension and resume overhead on fast completions.
+struct CqeAwaitable {
+    CqeState* state;
+    bool await_ready() const noexcept { return state->result_ready; }
+    void await_suspend(std::coroutine_handle<> h) noexcept { state->waiter = h; }
+    int await_resume() const noexcept { return state->result; }
 };
 
 inline CqeState* async_io::ensure(sub_cmd_t sub_cmd) {
     for (auto& s : pool)
         if (s.sub_cmd == sub_cmd) return &s;
-    pool.push_back(CqeState{this, 0, sub_cmd});
+    pool.push_back(CqeState{.owner = this, .sub_cmd = sub_cmd});
     return &pool.back();
 }
 

--- a/include/ublkpp/lib/disk_task.hpp
+++ b/include/ublkpp/lib/disk_task.hpp
@@ -1,0 +1,60 @@
+#pragma once
+
+#include <coroutine>
+#include <utility>
+
+namespace ublkpp {
+
+// Lightweight lazy coroutine task for per-disk async I/O. Composable via symmetric transfer:
+// co_await disk_task<T> in a co_io_job or another disk_task<U> suspends the caller and
+// immediately resumes the callee without going through any scheduler.
+//
+// run_queue_loop drives all resumption: CQEs install a handle in CqeState::waiter and call
+// h.resume(), which propagates back to the caller via final_suspend symmetric transfer.
+//
+// Lifetime: the coroutine frame is owned by the disk_task object. Move-only; the caller
+// must co_await (consuming the task) before the object is destroyed.
+template < typename T >
+struct disk_task {
+    struct promise_type {
+        T _value{};
+        std::coroutine_handle<> _continuation{};
+
+        disk_task get_return_object() noexcept {
+            return disk_task{std::coroutine_handle< promise_type >::from_promise(*this)};
+        }
+        std::suspend_always initial_suspend() noexcept { return {}; }
+
+        struct final_awaiter {
+            bool await_ready() noexcept { return false; }
+            std::coroutine_handle<> await_suspend(std::coroutine_handle< promise_type > h) noexcept {
+                auto cont = h.promise()._continuation;
+                return cont ? cont : std::noop_coroutine();
+            }
+            void await_resume() noexcept {}
+        };
+        final_awaiter final_suspend() noexcept { return {}; }
+
+        void return_value(T v) noexcept { _value = v; }
+        [[noreturn]] void unhandled_exception() { throw; }
+    };
+
+    std::coroutine_handle< promise_type > _coro;
+
+    explicit disk_task(std::coroutine_handle< promise_type > h) noexcept : _coro(h) {}
+    disk_task(disk_task&& o) noexcept : _coro(std::exchange(o._coro, {})) {}
+    disk_task(disk_task const&) = delete;
+    ~disk_task() {
+        if (_coro) _coro.destroy();
+    }
+
+    // Awaitable interface: allows co_await disk_task<T> from co_io_job or disk_task<U>.
+    bool await_ready() const noexcept { return false; }
+    std::coroutine_handle<> await_suspend(std::coroutine_handle<> cont) noexcept {
+        _coro.promise()._continuation = cont;
+        return _coro; // symmetric transfer: start callee immediately
+    }
+    T await_resume() noexcept { return _coro.promise()._value; }
+};
+
+} // namespace ublkpp

--- a/include/ublkpp/lib/ublk_disk.hpp
+++ b/include/ublkpp/lib/ublk_disk.hpp
@@ -6,6 +6,7 @@
 #include <string>
 
 #include "common.hpp"
+#include "disk_task.hpp"
 #include "sub_cmd.hpp"
 
 struct iovec;
@@ -52,6 +53,15 @@ public:
 
     // Internal result response
     io_result queue_internal_resp(ublksrv_queue const* q, ublk_io_data const* data, sub_cmd_t sub_cmd, int res);
+
+    // Returns true when this disk implements handle_io_async (new coroutine API).
+    // Disks whose children are all new-API return true; any legacy child forces false,
+    // ensuring process_result handles multi-SQE completions (e.g. RAID1 replicas).
+    virtual bool uses_async_api() const noexcept { return false; }
+
+    // Async entry-point: called by __handle_io_async when uses_async_api() is true.
+    // Implementations submit all SQEs upfront then co_await CqeAwaitable for each result.
+    virtual disk_task< int > handle_io_async(ublksrv_queue const* q, ublk_io_data const* data, sub_cmd_t sub_cmd);
 
     virtual std::string id() const noexcept = 0;
 

--- a/include/ublkpp/raid/raid0.hpp
+++ b/include/ublkpp/raid/raid0.hpp
@@ -33,6 +33,9 @@ public:
     std::string id() const noexcept override { return "RAID0"; }
     std::list< int > open_for_uring(ublksrv_queue const*, int const iouring_device) override;
 
+    bool uses_async_api() const noexcept override;
+    disk_task< int > handle_io_async(ublksrv_queue const* q, ublk_io_data const* data, sub_cmd_t sub_cmd) override;
+
     uint8_t route_size() const noexcept override { return ilog2(_max_stripe_cnt); }
     void idle_transition(ublksrv_queue const*, bool) override;
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -26,6 +26,7 @@ list(APPEND LIBRARY_OBJECTS
 list(APPEND LIBRARY_LINKS
     isa-l::isa-l
     ublksrv::ublksrv
+    STDEXEC::stdexec
   )
 
 if(${homeblocks_FOUND})

--- a/src/driver/fs_disk.cpp
+++ b/src/driver/fs_disk.cpp
@@ -145,6 +145,30 @@ static inline auto next_sqe(ublksrv_queue const* q) {
     return sqe;
 }
 
+disk_task< int > FSDisk::handle_io_async(ublksrv_queue const* q, ublk_io_data const* data, sub_cmd_t sub_cmd) {
+    auto* io = reinterpret_cast< async_io* >(data->private_data);
+    ublksrv_io_desc const* iod = data->iod;
+    auto const op = ublksrv_get_op(iod);
+
+    if (op == UBLK_IO_OP_FLUSH) { co_return handle_flush(q, data, sub_cmd).value_or(-EIO); }
+
+    io_result res;
+    if (op == UBLK_IO_OP_DISCARD || op == UBLK_IO_OP_WRITE_ZEROES) {
+        res = handle_discard(q, data, sub_cmd, iod->nr_sectors << SECTOR_SHIFT, iod->start_sector << SECTOR_SHIFT);
+    } else {
+        thread_local auto iov = iovec{};
+        iov.iov_base = reinterpret_cast< void* >(iod->addr);
+        iov.iov_len = iod->nr_sectors << SECTOR_SHIFT;
+        res = async_iov(q, data, sub_cmd, &iov, 1, iod->start_sector << SECTOR_SHIFT);
+    }
+
+    if (!res) co_return -static_cast< int >(res.error().value());
+    if (res.value() == 0) co_return 0; // inline completion (sync fallback on kernel <= 5.4)
+
+    io_uring_submit(q->ring_ptr);
+    co_return co_await CqeAwaitable{io->ensure(sub_cmd)};
+}
+
 io_result FSDisk::handle_flush(ublksrv_queue const*, ublk_io_data const* data, sub_cmd_t sub_cmd) {
 
     DLOGT("Flush {} : [tag:{:#0x}] ublk io [sub_cmd:{}]", _path.native(), data->tag, ublkpp::to_string(sub_cmd))

--- a/src/lib/tests/test_cqe_state.cpp
+++ b/src/lib/tests/test_cqe_state.cpp
@@ -47,9 +47,11 @@ TEST(AsyncIo, EnsureCreatesNewState) {
     ublkpp::async_io io{};
     auto* s = io.ensure(ublkpp::sub_cmd_t{1});
     ASSERT_NE(s, nullptr);
-    EXPECT_EQ(s->sub_cmd, ublkpp::sub_cmd_t{1});
-    EXPECT_EQ(s->result, 0);
     EXPECT_EQ(s->owner, &io);
+    EXPECT_EQ(s->result, 0);
+    EXPECT_FALSE(s->result_ready);
+    EXPECT_FALSE(s->waiter);
+    EXPECT_EQ(s->sub_cmd, ublkpp::sub_cmd_t{1});
 }
 
 TEST(AsyncIo, EnsureIsIdempotent) {
@@ -84,7 +86,7 @@ TEST(AsyncIo, EnsurePoolAddressStability) {
 
 TEST(AsyncIo, PushCompletionNoWaiter) {
     ublkpp::async_io io{};
-    ublkpp::CqeState s{&io, 42, ublkpp::sub_cmd_t{7}};
+    ublkpp::CqeState s{.owner = &io, .result = 42, .sub_cmd = ublkpp::sub_cmd_t{7}};
     io.push_completion(&s);
     ASSERT_EQ(io.completions.size(), 1u);
     EXPECT_EQ(io.completions.front(), &s);
@@ -93,9 +95,9 @@ TEST(AsyncIo, PushCompletionNoWaiter) {
 
 TEST(AsyncIo, PushCompletionMaintainsFIFO) {
     ublkpp::async_io io{};
-    ublkpp::CqeState s1{&io, 1, ublkpp::sub_cmd_t{1}};
-    ublkpp::CqeState s2{&io, 2, ublkpp::sub_cmd_t{2}};
-    ublkpp::CqeState s3{&io, 3, ublkpp::sub_cmd_t{3}};
+    ublkpp::CqeState s1{.owner = &io, .result = 1, .sub_cmd = ublkpp::sub_cmd_t{1}};
+    ublkpp::CqeState s2{.owner = &io, .result = 2, .sub_cmd = ublkpp::sub_cmd_t{2}};
+    ublkpp::CqeState s3{.owner = &io, .result = 3, .sub_cmd = ublkpp::sub_cmd_t{3}};
     io.push_completion(&s1);
     io.push_completion(&s2);
     io.push_completion(&s3);
@@ -106,7 +108,7 @@ TEST(AsyncIo, PushCompletionMaintainsFIFO) {
 
 TEST(AsyncIo, PushCompletionResumesAndClearsWaiter) {
     ublkpp::async_io io{};
-    ublkpp::CqeState state{&io, 99, ublkpp::sub_cmd_t{3}};
+    ublkpp::CqeState state{.owner = &io, .result = 99, .sub_cmd = ublkpp::sub_cmd_t{3}};
     suspend_into_io(&io); // starts, suspends, installs io.waiter
     ASSERT_TRUE(io.waiter);
     io.push_completion(&state); // clears waiter, pushes state, resumes coroutine
@@ -151,6 +153,57 @@ TEST(BuildCqeStateData, DifferentSubCmdsGrowPool) {
     ublkpp::build_cqe_state_data(&fake, 2);
     ublkpp::build_cqe_state_data(&fake, 3);
     EXPECT_EQ(io.pool.size(), 3u);
+}
+
+// ============================================================================
+// CqeAwaitable
+// ============================================================================
+
+// Coroutine that co_awaits a CqeAwaitable and writes the result to *out.
+static FireAndForget await_cqe_and_capture(ublkpp::CqeState* state, int* out) {
+    *out = co_await ublkpp::CqeAwaitable{state};
+}
+
+TEST(CqeAwaitable, AwaitReadyFalseWhenNotReady) {
+    ublkpp::async_io io{};
+    ublkpp::CqeState state{.owner = &io, .result_ready = false};
+    EXPECT_FALSE(ublkpp::CqeAwaitable{&state}.await_ready());
+}
+
+TEST(CqeAwaitable, AwaitReadyTrueWhenReady) {
+    ublkpp::async_io io{};
+    ublkpp::CqeState state{.owner = &io, .result_ready = true};
+    EXPECT_TRUE(ublkpp::CqeAwaitable{&state}.await_ready());
+}
+
+TEST(CqeAwaitable, AwaitResumeReturnsResult) {
+    ublkpp::async_io io{};
+    ublkpp::CqeState state{.owner = &io, .result = 42, .result_ready = true};
+    EXPECT_EQ(ublkpp::CqeAwaitable{&state}.await_resume(), 42);
+}
+
+TEST(CqeAwaitable, AwaitSuspendInstallsWaiterInState) {
+    ublkpp::async_io io{};
+    ublkpp::CqeState state{.owner = &io, .result_ready = false};
+    EXPECT_FALSE(state.waiter);
+    int captured = -1;
+    await_cqe_and_capture(&state, &captured); // suspends; installs handle in state.waiter
+    ASSERT_TRUE(state.waiter);
+    EXPECT_EQ(captured, -1); // not resumed yet
+
+    state.result = 7;
+    state.result_ready = true;
+    state.waiter.resume(); // triggers await_resume() → captured = 7
+    EXPECT_EQ(captured, 7);
+}
+
+TEST(CqeAwaitable, FastPathSkipsSuspendWhenAlreadyReady) {
+    ublkpp::async_io io{};
+    ublkpp::CqeState state{.owner = &io, .result = 55, .result_ready = true};
+    int captured = -1;
+    await_cqe_and_capture(&state, &captured); // await_ready=true → no suspension
+    EXPECT_FALSE(state.waiter);
+    EXPECT_EQ(captured, 55);
 }
 
 } // anonymous namespace

--- a/src/lib/ublk_disk.cpp
+++ b/src/lib/ublk_disk.cpp
@@ -49,6 +49,12 @@ io_result UblkDisk::handle_internal(ublksrv_queue const*, ublk_io_data const*, s
     return 0;
 }
 
+disk_task< int > UblkDisk::handle_io_async(ublksrv_queue const*, ublk_io_data const*, sub_cmd_t) {
+    // Unreachable: __handle_io_async only calls this when uses_async_api() returns true.
+    RELEASE_ASSERT(false, "handle_io_async called on disk without uses_async_api() override")
+    co_return -EIO; // LCOV_EXCL_LINE
+}
+
 io_result UblkDisk::handle_rw(ublksrv_queue const* q, ublk_io_data const* data, sub_cmd_t sub_cmd, void* buf,
                               uint32_t const len, uint64_t const addr) {
     DLOGW("Use of deprecated ::handle_rw(...)! Please convert to using ::async_iov(...)")

--- a/src/raid/raid0/raid0.cpp
+++ b/src/raid/raid0/raid0.cpp
@@ -7,6 +7,7 @@
 
 #include "raid0_impl.hpp"
 #include "lib/logging.hpp"
+#include <ublkpp/lib/cqe_state.hpp>
 
 namespace ublkpp {
 
@@ -277,6 +278,78 @@ io_result Raid0Disk::sync_iov(uint8_t op, iovec* iovecs, uint32_t nr_vecs, off_t
                                   __iovec_len(iov, iov + nr_iovs))
                             return _stripe_array[stripe_off]->disk->sync_iov(op, iov, nr_iovs, logical_off);
                         });
+}
+
+bool Raid0Disk::uses_async_api() const noexcept {
+    // Only use the new async path when all children are leaves (currently FSDisk).
+    // If any child is composite (e.g. RAID1 with primary+mirror SQEs per async_iov call),
+    // RAID0's handle_io_async only tracks the outer sub_cmd and would miss the child's internal
+    // sub_cmds. The old queue_tgt_io + CqeAwaiter path handles that correctly via process_result.
+    // When RAID1 is migrated to the async API (future phase), this interaction will need
+    // redesigning so RAID0 calls handle_io_async on children rather than async_iov.
+    return std::all_of(_stripe_array.begin(), _stripe_array.end(),
+                       [](auto const& s) { return s->disk->uses_async_api(); });
+}
+
+disk_task< int > Raid0Disk::handle_io_async(ublksrv_queue const* q, ublk_io_data const* data, sub_cmd_t sub_cmd) {
+    auto const op = ublksrv_get_op(data->iod);
+    auto* io = reinterpret_cast< async_io* >(data->private_data);
+
+    if (op == UBLK_IO_OP_FLUSH) co_return handle_flush(q, data, sub_cmd).value_or(-EIO);
+
+    bool const retry{is_retry(sub_cmd)};
+    if (!retry) sub_cmd = shift_route(sub_cmd, route_size());
+
+    // Collect sub_cmds for which async_iov queued SQEs so we can await their CQEs below.
+    std::vector< sub_cmd_t > dispatched;
+
+    if (op == UBLK_IO_OP_DISCARD || op == UBLK_IO_OP_WRITE_ZEROES) {
+        auto const route_mask = _max_stripe_cnt - 1;
+        uint32_t const len = data->iod->nr_sectors << SECTOR_SHIFT;
+        uint64_t const addr = (data->iod->start_sector << SECTOR_SHIFT) + _stride_width;
+
+        for (auto const& [stripe_off, region] : raid0::merged_subcmds(_stride_width, _stripe_size, addr, len)) {
+            auto const& [logical_off, logical_len] = region;
+            auto const& device = _stripe_array[stripe_off]->disk;
+            if (retry && (stripe_off != ((sub_cmd >> device->route_size()) & route_mask))) [[unlikely]]
+                continue;
+            sub_cmd_t const new_sub_cmd = sub_cmd + (!retry ? stripe_off : 0);
+            auto res = device->handle_discard(q, data, new_sub_cmd, logical_len, logical_off);
+            if (!res) co_return -EIO;
+            if (res.value() > 0) dispatched.push_back(new_sub_cmd);
+        }
+    } else {
+        // READ / WRITE: fan out across stripes via __distribute.
+        auto iov = iovec{.iov_base = reinterpret_cast< void* >(data->iod->addr),
+                         .iov_len = static_cast< size_t >(data->iod->nr_sectors) << SECTOR_SHIFT};
+        uint64_t const addr = (data->iod->start_sector << SECTOR_SHIFT) + _stride_width;
+
+        auto res = __distribute(
+            &iov, addr,
+            [q, data, &dispatched, this](uint32_t stripe_off, sub_cmd_t new_sub_cmd, iovec* iov, uint32_t nr_iovs,
+                                         uint64_t logical_off) {
+                auto r = _stripe_array[stripe_off]->disk->async_iov(q, data, new_sub_cmd, iov, nr_iovs, logical_off);
+                if (r && r.value() > 0) dispatched.push_back(new_sub_cmd);
+                return r;
+            },
+            retry, sub_cmd);
+
+        if (!res) co_return -EIO;
+    }
+
+    // Batch-submit all SQEs queued above. All SQEs enter the ring before the first co_await so
+    // the kernel executes them in parallel while we poll sequentially below.
+    io_uring_submit(q->ring_ptr);
+
+    // Await each stripe's CQE. CqeAwaitable::await_ready() fast-paths stripes whose CQE
+    // arrived before we reach co_await, avoiding unnecessary suspension.
+    int total = 0;
+    for (auto sc : dispatched) {
+        auto r = co_await CqeAwaitable{io->ensure(sc)};
+        if (r < 0) co_return r;
+        total += r;
+    }
+    co_return total;
 }
 
 static const uint8_t magic_bytes[16] = {0127, 0345, 072,  0211, 0254, 033,  070,  0146,

--- a/src/raid/raid0/tests/CMakeLists.txt
+++ b/src/raid/raid0/tests/CMakeLists.txt
@@ -20,6 +20,7 @@ list(APPEND RAID0_TEST_SRCS
 
 add_subdirectory (simple)
 add_subdirectory (superblock)
+add_subdirectory (async)
 
 add_library(raid0_tests OBJECT)
 target_sources(raid0_tests PRIVATE
@@ -45,3 +46,22 @@ target_link_libraries (test_raid0
   sisl::cache
 )
 add_test(NAME Raid0Test COMMAND test_raid0 -cv warning)
+
+add_executable(test_raid0_async)
+target_sources(test_raid0_async PRIVATE
+    async/raid0_async_test.cpp
+    ${RAID0_ASYNC_TEST_SRCS}
+    $<TARGET_OBJECTS:logging>
+    $<TARGET_OBJECTS:raid0>
+    $<TARGET_OBJECTS:ublk_disk>
+    $<TARGET_OBJECTS:ublk_metrics>
+)
+target_include_directories(test_raid0_async PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}
+)
+target_link_libraries(test_raid0_async
+    GTest::gmock
+    mock_ublksrv
+    sisl::cache
+)
+add_test(NAME Raid0AsyncTest COMMAND test_raid0_async -cv warning)

--- a/src/raid/raid0/tests/async/CMakeLists.txt
+++ b/src/raid/raid0/tests/async/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.11)
+
+list(APPEND RAID0_ASYNC_TEST_SRCS
+    async/read_write.cpp
+    async/flush.cpp
+    async/discard.cpp
+    async/error.cpp
+)
+set(RAID0_ASYNC_TEST_SRCS "${RAID0_ASYNC_TEST_SRCS}" PARENT_SCOPE)

--- a/src/raid/raid0/tests/async/async_raid0_common.hpp
+++ b/src/raid/raid0/tests/async/async_raid0_common.hpp
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <boost/uuid/random_generator.hpp>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <ublksrv.h>
+
+#include "ublkpp/lib/cqe_state.hpp"
+#include "ublkpp/raid/raid0.hpp"
+#include "raid/raid0/raid0_impl.hpp"
+#include "tests/mock_ublksrv/mock_ublksrv.hpp"
+#include "tests/test_disk.hpp"
+
+using ::testing::_;
+using ::testing::Return;
+using ::ublkpp::Gi;
+using ::ublkpp::io_result;
+using ::ublkpp::Ki;
+using ::ublkpp::UblkDisk;
+
+// Default async_iov action: registers the CqeState in the pool without submitting a real SQE.
+// Tests call inject_cqe() to deliver synthetic results stripe-by-stripe.
+inline auto make_async_iov_action() {
+    return [](ublksrv_queue const*, ublk_io_data const* data, ublkpp::sub_cmd_t sub_cmd, iovec*, uint32_t,
+              uint64_t) -> io_result {
+        ublkpp::build_cqe_state_data(data, static_cast< uint64_t >(sub_cmd));
+        return 1;
+    };
+}
+
+struct AsyncRaid0Fixture : public ::testing::Test {
+    static constexpr uint32_t k_stripe_size = 32 * Ki;
+    static constexpr uint64_t k_disk_cap = 1 * Gi;
+
+    std::shared_ptr< ublkpp::AsyncTestDisk > disk_a, disk_b, disk_c;
+    std::shared_ptr< ublkpp::Raid0Disk > raid;
+    std::unique_ptr< ublkpp::MockUblksrv > mock;
+
+    void SetUp() override {
+        TestParams const p{.capacity = k_disk_cap};
+        disk_a = std::make_shared< ::testing::NiceMock< ublkpp::AsyncTestDisk > >(p);
+        disk_b = std::make_shared< ::testing::NiceMock< ublkpp::AsyncTestDisk > >(p);
+        disk_c = std::make_shared< ::testing::NiceMock< ublkpp::AsyncTestDisk > >(p);
+        for (auto& d : {disk_a, disk_b, disk_c}) {
+            ON_CALL(*d, sync_iov(_, _, _, _))
+                .WillByDefault([](uint8_t op, iovec* iovecs, uint32_t, off_t) -> io_result {
+                    if (op == UBLK_IO_OP_READ && iovecs && iovecs->iov_base)
+                        memset(iovecs->iov_base, 0, iovecs->iov_len);
+                    return sizeof(ublkpp::raid0::SuperBlock);
+                });
+            ON_CALL(*d, async_iov(_, _, _, _, _, _)).WillByDefault(make_async_iov_action());
+            ON_CALL(*d, handle_flush(_, _, _)).WillByDefault(Return(0));
+            ON_CALL(*d, handle_discard(_, _, _, _, _)).WillByDefault(Return(1));
+        }
+        raid =
+            std::make_shared< ublkpp::Raid0Disk >(boost::uuids::random_generator()(), k_stripe_size,
+                                                  std::vector< std::shared_ptr< UblkDisk > >{disk_a, disk_b, disk_c});
+        mock = std::make_unique< ublkpp::MockUblksrv >(raid);
+    }
+};

--- a/src/raid/raid0/tests/async/discard.cpp
+++ b/src/raid/raid0/tests/async/discard.cpp
@@ -1,0 +1,31 @@
+#include "async_raid0_common.hpp"
+
+TEST_F(AsyncRaid0Fixture, DiscardSingleStripe) {
+    // 4KB discard at sector 0 → only disk_a.
+    // handle_discard creates CqeState via io->ensure; inject_cqe delivers the result.
+    EXPECT_CALL(*disk_a, handle_discard(_, _, _, _, _)).Times(1);
+    EXPECT_CALL(*disk_b, handle_discard(_, _, _, _, _)).Times(0);
+    EXPECT_CALL(*disk_c, handle_discard(_, _, _, _, _)).Times(0);
+
+    auto res = mock->submit_io(0, UBLK_IO_OP_DISCARD, 0, 4 * Ki / 512, nullptr);
+    ASSERT_TRUE(res);
+
+    auto completions = mock->inject_cqe(0, 0);
+    ASSERT_EQ(completions.size(), 1u);
+    EXPECT_EQ(completions[0].result, 0);
+}
+
+TEST_F(AsyncRaid0Fixture, DiscardAllStripes) {
+    // 96KB discard spanning all three stripes — merged_subcmds fans out to each.
+    EXPECT_CALL(*disk_a, handle_discard(_, _, _, _, _)).Times(1);
+    EXPECT_CALL(*disk_b, handle_discard(_, _, _, _, _)).Times(1);
+    EXPECT_CALL(*disk_c, handle_discard(_, _, _, _, _)).Times(1);
+
+    auto res = mock->submit_io(0, UBLK_IO_OP_DISCARD, 0, 96 * Ki / 512, nullptr);
+    ASSERT_TRUE(res);
+
+    EXPECT_TRUE(mock->inject_cqe(0, 0).empty()); // stripe 0
+    EXPECT_TRUE(mock->inject_cqe(0, 0).empty()); // stripe 1
+    auto completions = mock->inject_cqe(0, 0);   // stripe 2
+    ASSERT_EQ(completions.size(), 1u);
+}

--- a/src/raid/raid0/tests/async/error.cpp
+++ b/src/raid/raid0/tests/async/error.cpp
@@ -1,0 +1,31 @@
+#include "async_raid0_common.hpp"
+
+TEST_F(AsyncRaid0Fixture, PreSqeErrorPropagatesEio) {
+    // async_iov fails before any SQE is submitted → __distribute returns error → task co_returns -EIO.
+    EXPECT_CALL(*disk_a, async_iov(_, _, _, _, _, _))
+        .WillOnce(Return(std::unexpected(std::make_error_condition(std::errc::io_error))));
+
+    auto res = mock->submit_io(0, UBLK_IO_OP_READ, 0, 4 * Ki / 512, nullptr);
+    ASSERT_TRUE(res);
+    EXPECT_EQ(res.value(), 0u); // no states registered — task already done with -EIO
+
+    auto completions = mock->inject_cqe(0, 0);
+    ASSERT_EQ(completions.size(), 1u);
+    EXPECT_EQ(completions[0].result, -EIO);
+}
+
+TEST_F(AsyncRaid0Fixture, PostCqeNegativeResultPropagatesAndSkipsRemaining) {
+    // First stripe returns -EIO; task exits immediately without awaiting second stripe.
+    EXPECT_CALL(*disk_a, async_iov(_, _, _, _, _, _)).Times(1);
+    EXPECT_CALL(*disk_b, async_iov(_, _, _, _, _, _)).Times(1);
+    EXPECT_CALL(*disk_c, async_iov(_, _, _, _, _, _)).Times(0);
+
+    auto res = mock->submit_io(0, UBLK_IO_OP_READ, 0, 64 * Ki / 512, nullptr);
+    ASSERT_TRUE(res);
+    EXPECT_EQ(res.value(), 2u); // both dispatched before first co_await
+
+    // First CQE delivers error — task short-circuits and is done immediately.
+    auto completions = mock->inject_cqe(0, -EIO);
+    ASSERT_EQ(completions.size(), 1u);
+    EXPECT_EQ(completions[0].result, -EIO);
+}

--- a/src/raid/raid0/tests/async/flush.cpp
+++ b/src/raid/raid0/tests/async/flush.cpp
@@ -1,0 +1,22 @@
+#include "async_raid0_common.hpp"
+
+TEST_F(AsyncRaid0Fixture, FlushDelegatesAndCompletesSynchronously) {
+    // Raid0Disk::handle_flush fans out to all children; each child returns 0.
+    // handle_io_async co_returns synchronously — no SQEs, no inject_cqe needed.
+    EXPECT_CALL(*disk_a, handle_flush(_, _, _)).Times(1);
+    EXPECT_CALL(*disk_b, handle_flush(_, _, _)).Times(1);
+    EXPECT_CALL(*disk_c, handle_flush(_, _, _)).Times(1);
+    EXPECT_CALL(*disk_a, async_iov(_, _, _, _, _, _)).Times(0);
+    EXPECT_CALL(*disk_b, async_iov(_, _, _, _, _, _)).Times(0);
+    EXPECT_CALL(*disk_c, async_iov(_, _, _, _, _, _)).Times(0);
+
+    auto res = mock->submit_io(0, UBLK_IO_OP_FLUSH, 0, 0, nullptr);
+    ASSERT_TRUE(res);
+    EXPECT_EQ(res.value(), 0u); // no CqeStates registered
+
+    // Task completed synchronously; inject_cqe with any value returns the stored result.
+    auto completions = mock->inject_cqe(0, 0);
+    ASSERT_EQ(completions.size(), 1u);
+    EXPECT_EQ(completions[0].tag, 0);
+    EXPECT_EQ(completions[0].result, 0);
+}

--- a/src/raid/raid0/tests/async/raid0_async_test.cpp
+++ b/src/raid/raid0/tests/async/raid0_async_test.cpp
@@ -1,0 +1,20 @@
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <sisl/logging/logging.h>
+#include <sisl/options/options.h>
+
+#define ENABLED_OPTIONS logging
+
+SISL_LOGGING_INIT(ublk_raid)
+SISL_OPTIONS_ENABLE(ENABLED_OPTIONS)
+
+int main(int argc, char* argv[]) {
+    int parsed_argc = argc;
+    ::testing::InitGoogleTest(&parsed_argc, argv);
+    SISL_OPTIONS_LOAD(parsed_argc, argv, ENABLED_OPTIONS);
+    sisl::logging::SetLogger(std::string(argv[0]));
+    spdlog::set_pattern("[%D %T.%e] [%n] [%^%l%$] [%t] %v");
+    parsed_argc = 1;
+    return RUN_ALL_TESTS();
+}

--- a/src/raid/raid0/tests/async/read_write.cpp
+++ b/src/raid/raid0/tests/async/read_write.cpp
@@ -1,0 +1,86 @@
+#include "async_raid0_common.hpp"
+
+// 3-stripe layout: stripe_size=32Ki, stride_width=96Ki
+// addr passed to __distribute = (start_sector << 9) + 96Ki
+// Stripe selection: (addr % stride_width) / stripe_size
+//   sector 0   → addr=96Ki → stripe 0 (disk_a)
+//   sector 64  → addr=128Ki → stripe 1 (disk_b)
+//   sector 128 → addr=160Ki → stripe 2 (disk_c)
+
+TEST_F(AsyncRaid0Fixture, ReadSingleStripe) {
+    // 4KB at sector 0 stays within stripe 0 (disk_a) only.
+    EXPECT_CALL(*disk_a, async_iov(_, _, _, _, _, _)).Times(1);
+    EXPECT_CALL(*disk_b, async_iov(_, _, _, _, _, _)).Times(0);
+    EXPECT_CALL(*disk_c, async_iov(_, _, _, _, _, _)).Times(0);
+
+    auto res = mock->submit_io(0, UBLK_IO_OP_READ, 0, 4 * Ki / 512, nullptr);
+    ASSERT_TRUE(res);
+    EXPECT_EQ(res.value(), 1u); // 1 CqeState registered
+
+    auto completions = mock->inject_cqe(0, 4 * Ki);
+    ASSERT_EQ(completions.size(), 1u);
+    EXPECT_EQ(completions[0].tag, 0);
+    EXPECT_EQ(completions[0].result, 4 * Ki);
+}
+
+TEST_F(AsyncRaid0Fixture, ReadCrossStripe) {
+    // 64KB at sector 0 spans stripe 0 (32KB) and stripe 1 (32KB).
+    EXPECT_CALL(*disk_a, async_iov(_, _, _, _, _, _)).Times(1);
+    EXPECT_CALL(*disk_b, async_iov(_, _, _, _, _, _)).Times(1);
+    EXPECT_CALL(*disk_c, async_iov(_, _, _, _, _, _)).Times(0);
+
+    auto res = mock->submit_io(0, UBLK_IO_OP_READ, 0, 64 * Ki / 512, nullptr);
+    ASSERT_TRUE(res);
+    EXPECT_EQ(res.value(), 2u);
+
+    // First stripe completes — task suspends on second
+    EXPECT_TRUE(mock->inject_cqe(0, 32 * Ki).empty());
+    // Second stripe completes — task done
+    auto completions = mock->inject_cqe(0, 32 * Ki);
+    ASSERT_EQ(completions.size(), 1u);
+    EXPECT_EQ(completions[0].result, 64 * Ki);
+}
+
+TEST_F(AsyncRaid0Fixture, ReadAllStripes) {
+    // 96KB spans all three stripes (32KB each).
+    EXPECT_CALL(*disk_a, async_iov(_, _, _, _, _, _)).Times(1);
+    EXPECT_CALL(*disk_b, async_iov(_, _, _, _, _, _)).Times(1);
+    EXPECT_CALL(*disk_c, async_iov(_, _, _, _, _, _)).Times(1);
+
+    auto res = mock->submit_io(0, UBLK_IO_OP_READ, 0, 96 * Ki / 512, nullptr);
+    ASSERT_TRUE(res);
+    EXPECT_EQ(res.value(), 3u);
+
+    EXPECT_TRUE(mock->inject_cqe(0, 32 * Ki).empty()); // stripe 0
+    EXPECT_TRUE(mock->inject_cqe(0, 32 * Ki).empty()); // stripe 1
+    auto completions = mock->inject_cqe(0, 32 * Ki);   // stripe 2
+    ASSERT_EQ(completions.size(), 1u);
+    EXPECT_EQ(completions[0].result, 96 * Ki);
+}
+
+TEST_F(AsyncRaid0Fixture, WriteSingleStripe) {
+    EXPECT_CALL(*disk_a, async_iov(_, _, _, _, _, _)).Times(1);
+    EXPECT_CALL(*disk_b, async_iov(_, _, _, _, _, _)).Times(0);
+    EXPECT_CALL(*disk_c, async_iov(_, _, _, _, _, _)).Times(0);
+
+    auto res = mock->submit_io(0, UBLK_IO_OP_WRITE, 0, 4 * Ki / 512, nullptr);
+    ASSERT_TRUE(res);
+
+    auto completions = mock->inject_cqe(0, 4 * Ki);
+    ASSERT_EQ(completions.size(), 1u);
+    EXPECT_EQ(completions[0].result, 4 * Ki);
+}
+
+TEST_F(AsyncRaid0Fixture, WriteSecondStripe) {
+    // 4KB at sector 64 (=32KB offset) routes to stripe 1 (disk_b).
+    EXPECT_CALL(*disk_a, async_iov(_, _, _, _, _, _)).Times(0);
+    EXPECT_CALL(*disk_b, async_iov(_, _, _, _, _, _)).Times(1);
+    EXPECT_CALL(*disk_c, async_iov(_, _, _, _, _, _)).Times(0);
+
+    auto res = mock->submit_io(0, UBLK_IO_OP_WRITE, 64, 4 * Ki / 512, nullptr);
+    ASSERT_TRUE(res);
+
+    auto completions = mock->inject_cqe(0, 4 * Ki);
+    ASSERT_EQ(completions.size(), 1u);
+    EXPECT_EQ(completions[0].result, 4 * Ki);
+}

--- a/src/target/ublkpp_tgt.cpp
+++ b/src/target/ublkpp_tgt.cpp
@@ -119,8 +119,12 @@ static void run_queue_loop(ublksrv_queue const* q) {
                     // target io_uring CQE — user_data is a raw CqeState* | k_target_bit
                     auto* state = reinterpret_cast< CqeState* >(cqe->user_data & ~k_target_bit);
                     state->result = cqe->res;
+                    state->result_ready = true;
                     try {
-                        state->owner->push_completion(state);
+                        if (auto h = std::exchange(state->waiter, {}))
+                            h.resume(); // new API: direct per-state resume (disk_task path)
+                        else
+                            state->owner->push_completion(state); // old API: CqeAwaiter loop
                     } catch (std::exception const& e) {
                         TLOGE("I/O threw exception: [{}]", e.what())
                         ublksrv_complete_io(q, state->owner->tag, -EIO);
@@ -364,43 +368,44 @@ static co_io_job __handle_io_async(ublksrv_queue const* q, ublk_io_data const* d
 
     auto const op = ublksrv_get_op(data->iod);
 
-    // Record queue depth increment
     auto tgt = static_cast< ublkpp_tgt_impl* >(q->private_data);
     tgt->metrics.record_queue_depth_change(q, op, true);
 
-    // First we submit the IO to the UblkDisk device. It in turn will return the number
-    // of sub_cmds it enqueued to the io_uring queue to satisfy the request. RAID levels will
-    // cause this amplification of operations. Each sub_cmd registers a CqeState via
-    // build_cqe_state_data so tgt_io_done can route completions by sub_cmd.
-    auto io_res = device->queue_tgt_io(q, data, 0);
+    int result = -EIO;
+    if (device->uses_async_api()) {
+        // New path: disk owns the full IO lifecycle as a disk_task<int> coroutine.
+        // CQEs resume the disk_task directly via CqeState::waiter; no pending counter needed.
+        result = co_await device->handle_io_async(q, data, sub_cmd_t{0});
+    } else {
+        // Old path: preserved for RAID1, RAID10, and other legacy disks.
+        // queue_tgt_io submits SQEs; CQEs enqueue via push_completion; process_result handles
+        // replica/internal/retry sub_cmds that the disk creates internally.
+        auto io_res = device->queue_tgt_io(q, data, 0);
+        io_uring_submit(q->ring_ptr);
 
-    // Submit to io_uring before yielding to make iovecs that are thread_local stable
-    io_uring_submit(q->ring_ptr);
+        if (io_res) {
+            io->ret_val = 0;
+            io->pending = io_res.value();
+            TLOGT("I/O [tag:{:#0x}] [sub_ios:{}]", data->tag, io->pending)
+        } else
+            TLOGD("IO Failed Immediately to queue io [tag:{:#0x}], err: [{}]", data->tag, io_res.error().message())
 
-    if (io_res) {
-        io->ret_val = 0;
-        io->pending = io_res.value();
-        TLOGT("I/O [tag:{:#0x}] [sub_ios:{}]", data->tag, io->pending)
-    } else
-        TLOGD("IO Failed Immediately to queue io [tag:{:#0x}], err: [{}]", data->tag, io_res.error().message())
-
-    // For each pending sub_cmd, suspend until tgt_io_done (or handle_event) delivers a CqeState.
-    while (0 < io->pending) {
-        auto* done = co_await CqeAwaiter{io};
-        --io->pending;
-        process_result(q, data, done);
+        while (0 < io->pending) {
+            auto* done = co_await CqeAwaiter{io};
+            --io->pending;
+            process_result(q, data, done);
+        }
+        result = io->ret_val;
     }
 
-    // Record queue depth decrement
     tgt->metrics.record_queue_depth_change(q, op, false);
 
-    // Operation is complete, result is in io->ret_val
-    if (0 > io->ret_val) [[unlikely]] {
-        TLOGE("Returning error for [tag:{:#0x}] [res:{}]", data->tag, io->ret_val)
+    if (0 > result) [[unlikely]] {
+        TLOGE("Returning error for [tag:{:#0x}] [res:{}]", data->tag, result)
     } else {
-        TLOGT("I/O complete [tag:{:#0x}] [res:{}]", data->tag, io->ret_val)
+        TLOGT("I/O complete [tag:{:#0x}] [res:{}]", data->tag, result)
     }
-    ublksrv_complete_io(q, data->tag, io->ret_val);
+    ublksrv_complete_io(q, data->tag, result);
 }
 
 // I/O Handler, first entry-point to us for all I/O

--- a/src/tests/mock_ublksrv/mock_ublksrv.cpp
+++ b/src/tests/mock_ublksrv/mock_ublksrv.cpp
@@ -17,7 +17,12 @@ static constexpr size_t k_max_io_size = DEF_BUF_SIZE;
 static constexpr size_t k_sector_align = 512;
 
 MockUblksrv::MockUblksrv(std::shared_ptr< UblkDisk > disk, int q_depth, int nr_queues) :
-        _q_depth(q_depth), _disk(std::move(disk)), _tags(q_depth), _queues(nr_queues), _io_states(q_depth) {
+        _q_depth(q_depth),
+        _disk(std::move(disk)),
+        _tags(q_depth),
+        _queues(nr_queues),
+        _io_states(q_depth),
+        _async_tasks(q_depth) {
     // q_depth * 4 gives headroom for RAID1 write amplification (2x replicas +
     // 2x bitmap SQEs per user write) without false "ring full" auto-submits.
     if (io_uring_queue_init(q_depth * 4, &_ring, 0) < 0) throw std::runtime_error("io_uring_queue_init failed");
@@ -85,6 +90,15 @@ io_result MockUblksrv::submit_io(int tag, uint8_t op, uint64_t start_sector, uin
     _io_states[tag].pool.clear();
     _io_states[tag].completions.clear();
     _io_states[tag].waiter = {};
+    _async_tasks[tag].reset();
+
+    if (_disk->uses_async_api()) {
+        auto task = _disk->handle_io_async(&_queues[0], &ts.data, sub_cmd_t{0});
+        task._coro.resume(); // start lazy coroutine; runs until first co_await CqeAwaitable
+        _async_tasks[tag].emplace(std::move(task));
+        // Pool size == number of CqeStates registered (one per pending stripe SQE)
+        return io_result{_io_states[tag].pool.size()};
+    }
 
     auto res = _disk->queue_tgt_io(&_queues[0], &ts.data, 0);
     if (!res) return res;
@@ -99,13 +113,25 @@ io_result MockUblksrv::submit_io(int tag, uint8_t op, uint64_t start_sector, uin
 void MockUblksrv::process_cqe(io_uring_cqe* cqe, std::vector< Completion >& out) {
     auto* state = reinterpret_cast< CqeState* >(cqe->user_data & ~(1ULL << 63));
     int const tag = state->owner->tag;
-    auto const sub_cmd = state->sub_cmd;
     int const res = cqe->res;
 
     // Consume the CQE immediately so peek sees the next one
     io_uring_cqe_seen(&_ring, cqe);
 
+    state->result = res;
+    state->result_ready = true;
+
+    if (auto h = std::exchange(state->waiter, {})) {
+        // New async path: resume the suspended disk_task directly
+        h.resume();
+        auto& opt = _async_tasks[tag];
+        if (opt && opt->_coro.done()) out.push_back({tag, opt->_coro.promise()._value});
+        return;
+    }
+
+    // Old path: on_io_complete, accumulate result, check for completion
     auto& ts = _tags[tag];
+    auto const sub_cmd = state->sub_cmd;
     _disk->on_io_complete(&ts.data, sub_cmd, res);
 
     if (is_internal(sub_cmd)) {
@@ -122,6 +148,30 @@ void MockUblksrv::process_cqe(io_uring_cqe* cqe, std::vector< Completion >& out)
     }
 
     if (ts.sub_cmds_remaining == 0) { out.push_back({tag, ts.result}); }
+}
+
+std::vector< MockUblksrv::Completion > MockUblksrv::inject_cqe(int tag, int result) {
+    std::vector< Completion > out;
+    // Find the CqeState currently suspended in the disk_task (waiter is set)
+    CqeState* target = nullptr;
+    for (auto& s : _io_states[tag].pool) {
+        if (s.waiter) {
+            target = &s;
+            break;
+        }
+    }
+    auto& opt = _async_tasks[tag];
+    if (!target) {
+        // No suspended state — task may have completed synchronously (e.g. flush).
+        // result is ignored; return the task's value if it finished.
+        if (opt && opt->_coro.done()) out.push_back({tag, opt->_coro.promise()._value});
+        return out;
+    }
+    target->result = result;
+    target->result_ready = true;
+    if (auto h = std::exchange(target->waiter, {})) h.resume();
+    if (opt && opt->_coro.done()) out.push_back({tag, opt->_coro.promise()._value});
+    return out;
 }
 
 std::vector< MockUblksrv::Completion > MockUblksrv::poll(int min_completions, std::chrono::milliseconds timeout) {

--- a/src/tests/mock_ublksrv/mock_ublksrv.hpp
+++ b/src/tests/mock_ublksrv/mock_ublksrv.hpp
@@ -2,24 +2,28 @@
 
 #include <chrono>
 #include <memory>
+#include <optional>
 #include <vector>
 
 #include <liburing.h>
 #include <ublksrv.h>
 
 #include "ublkpp/lib/cqe_state.hpp"
+#include "ublkpp/lib/disk_task.hpp"
 #include "ublkpp/lib/sub_cmd.hpp"
 #include "ublkpp/lib/ublk_disk.hpp"
 
 namespace ublkpp {
 
-/// Drives UblkDisk::queue_tgt_io() directly with a real io_uring, bypassing
-/// ublkpp_tgt coroutines and the ublk kernel module.  Suitable for CI where
-/// the ublk module is unavailable.
-///
-/// RAID1 INTERNAL sub_cmds (bitmap page writes) are handled automatically in
-/// poll(): when a CQE with is_internal(sub_cmd) arrives, queue_internal_resp()
-/// is called so RAID1 can respond and optionally enqueue more SQEs.
+// Drives UblkDisk I/O directly with a real io_uring, bypassing ublkpp_tgt coroutines
+// and the ublk kernel module. Suitable for CI where the ublk module is unavailable.
+//
+// Supports two dispatch paths:
+//   Old path (uses_async_api() == false): calls queue_tgt_io, submits SQEs, polls CQEs.
+//   New path (uses_async_api() == true):  starts handle_io_async disk_task, uses inject_cqe
+//     to deliver synthetic results without requiring real io_uring round-trips.
+//
+// RAID1 INTERNAL sub_cmds (bitmap page writes) are handled automatically in poll().
 class MockUblksrv {
 public:
     struct Completion {
@@ -27,30 +31,32 @@ public:
         int result;
     };
 
-    /// @param disk       Disk to drive (FSDisk, Raid0Disk, Raid1Disk, …)
-    /// @param q_depth    Number of concurrent I/O slots (must be >= fio iodepth)
-    /// @param nr_queues  Number of simulated queue threads (calls open_for_uring once per queue)
+    // disk: disk to drive (FSDisk, Raid0Disk, Raid1Disk, ...)
+    // q_depth: number of concurrent I/O slots (must be >= fio iodepth)
+    // nr_queues: number of simulated queue threads (calls open_for_uring once per queue)
     explicit MockUblksrv(std::shared_ptr< UblkDisk > disk, int q_depth = 128, int nr_queues = 1);
     ~MockUblksrv();
 
     MockUblksrv(MockUblksrv const&) = delete;
     MockUblksrv& operator=(MockUblksrv const&) = delete;
 
-    /// Populate iod fields, call disk->queue_tgt_io(), then io_uring_submit.
-    /// @param tag          Slot index [0, q_depth)
-    /// @param op           UBLK_IO_OP_READ / _WRITE / _FLUSH / _DISCARD
-    /// @param start_sector Byte offset >> SECTOR_SHIFT
-    /// @param nr_sectors   Byte length >> SECTOR_SHIFT
-    /// @param buf          Sector-aligned buffer (caller owns lifetime)
-    /// @returns sub_cmd count queued, or error
+    // Old path: populate iod fields, call disk->queue_tgt_io(), then io_uring_submit.
+    // New path: start handle_io_async disk_task; task runs until first co_await CqeAwaitable.
+    // tag: slot index [0, q_depth), op: UBLK_IO_OP_READ / _WRITE / _FLUSH / _DISCARD
+    // start_sector: byte offset >> SECTOR_SHIFT, nr_sectors: byte length >> SECTOR_SHIFT
+    // buf: sector-aligned buffer (caller owns lifetime)
     io_result submit_io(int tag, uint8_t op, uint64_t start_sector, uint32_t nr_sectors, void* buf);
 
-    /// Drain io_uring CQEs until at least @p min_completions are collected or
-    /// @p timeout expires.  INTERNAL sub_cmds are handled transparently.
+    // Drain io_uring CQEs until at least min_completions are collected or timeout expires.
+    // INTERNAL sub_cmds are handled transparently (old path only).
     std::vector< Completion > poll(int min_completions, std::chrono::milliseconds timeout);
 
-    /// Per-tag sector-aligned I/O buffer (max_io_size = DEF_BUF_SIZE bytes).
-    /// Useful when caller does not supply its own buffer.
+    // New async path only. Deliver a synthetic result to the CqeState currently suspended
+    // in the disk_task for the given tag. Resumes the task; returns a completion when the
+    // task runs to completion. Call once per awaited stripe for multi-stripe IOs.
+    std::vector< Completion > inject_cqe(int tag, int result);
+
+    // Per-tag sector-aligned I/O buffer (max_io_size = DEF_BUF_SIZE bytes).
     void* io_buf(int tag);
 
     int q_depth() const noexcept { return _q_depth; }
@@ -77,6 +83,9 @@ private:
 
     // async_io pool — one per tag, mirrors what init_queue does via placement new
     std::vector< async_io > _io_states;
+
+    // disk_task handles for the async API path — one optional slot per tag
+    std::vector< std::optional< disk_task< int > > > _async_tasks;
 
     // Aligned I/O buffers — one per tag, DEF_BUF_SIZE bytes each
     std::vector< uint8_t > _io_buf_storage;

--- a/src/tests/test_disk.hpp
+++ b/src/tests/test_disk.hpp
@@ -75,6 +75,12 @@ public:
     uint8_t route_size() const noexcept override { return 0; }
 };
 
+class AsyncTestDisk : public TestDisk {
+public:
+    explicit AsyncTestDisk(TestParams const& p) : TestDisk(p) {}
+    bool uses_async_api() const noexcept override { return true; }
+};
+
 }; // namespace ublkpp
 
 inline ublk_io_data make_io_data(uint32_t op_flags, uint32_t len = 0, uint64_t start = 0) {


### PR DESCRIPTION
## Phase 4 of #210 — disk_task<int> coroutine API for FSDisk and RAID0

### Problem

`__handle_io_async` drove I/O through a hand-rolled `queue_tgt_io` + `CqeAwaiter` while-loop, tracking in-flight count in `io->pending`. This approach required disks to return a count of SQEs at call time and precluded natural coroutine composition — RAID0 fan-out was implicit in `process_result` rather than expressed as sequential awaits on per-stripe futures.

### What this PR does

Introduces `UblkDisk::handle_io_async()` / `uses_async_api()` so that disks can own their full I/O lifecycle as a coroutine, returning a `disk_task<int>` byte count when done.

**`disk_task<T>`**: lightweight lazy coroutine with symmetric transfer. `initial_suspend = suspend_always`; `final_suspend` transfers back to the caller via a stored continuation handle. Zero heap allocation beyond the frame; move-only; frame destroyed in destructor. Composable: `co_await disk_task<U>` from inside a `disk_task<T>` or `co_io_job` suspends the outer coroutine and resumes the callee immediately (no scheduler).

**`CqeAwaitable`**: per-`CqeState` awaitable. `await_ready()` checks `state->result_ready` — fast-paths completions that arrive before `co_await`, preserving kernel parallelism for RAID0 multi-stripe I/O. `await_suspend()` installs the handle in `state->waiter`; `await_resume()` returns `state->result`.

**`CqeState`** gains `result_ready` + `waiter` fields. `run_queue_loop` now branches: if `state->waiter` is set it resumes the `disk_task` directly (new path); otherwise it calls `push_completion` for the `CqeAwaiter` while-loop (old path, preserved for RAID1/RAID10).

**`__handle_io_async`** dispatches to `handle_io_async` when `uses_async_api()` is true; the existing `queue_tgt_io + CqeAwaiter` loop is preserved unchanged for legacy disks.

**`FSDisk::handle_io_async`**: submits one SQE via `async_iov`, calls `io_uring_submit`, then `co_await CqeAwaitable{state}` for the result.

**`Raid0Disk::handle_io_async`**: fans out via `__distribute` (READ/WRITE) or `merged_subcmds` (DISCARD), batch-submits all SQEs, then sequentially `co_await CqeAwaitable` per stripe. `uses_async_api()` requires all children to return true — keeps RAID0(RAID1) on the old path so `process_result` handles replica sub_cmds correctly.

Also fixes a positional `CqeState` aggregate-init bug introduced when the new fields were inserted that silently mapped `sub_cmd` into `result_ready`.

**Test infrastructure**: `MockUblksrv` extended with a two-path `submit_io` (starts the lazy coroutine and returns pool size for the async path) and a new `inject_cqe(tag, result)` method that delivers synthetic CQEs directly to suspended `disk_task` coroutines without requiring real io_uring SQEs. `AsyncTestDisk` added as a one-liner subclass of `TestDisk` returning `uses_async_api()=true`.

### What is unchanged

- RAID1, RAID10, DefunctDisk — no changes; `queue_tgt_io + CqeAwaiter` loop is intact
- `process_result`, `CqeAwaiter`, `push_completion` — retained for RAID1 backward compat
- `build_cqe_state_data`, `async_io::ensure` — unchanged

### Test plan
- [x] `test_cqe_state`: `CqeAwaitable` await_ready / await_suspend / await_resume / fast-path
- [x] `test_raid0_async`: 10 new tests — single/cross/all-stripe reads and writes, flush delegation, discard fan-out, pre-SQE error propagation, post-CQE negative result (Debug + ASAN/UBSan)
- [x] All existing RAID0 and RAID1 tests pass (Debug + ASAN/UBSan)
- [x] Coverage: `raid0.cpp` 93%, `cqe_state.hpp` 100%, `raid0.hpp` 100%
