### PR TITLE
Feature/210 p5 raid1 async api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,20 +5,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## 0.22.2
-- raid1: Fix `stop()` IDLE→STOPPING race — when the resync thread finishes naturally and
+- raid1: Fix `stop()` IDLE→STOPPING race - when the resync thread finishes naturally and
   `stop()` is called before `join()`, the `IDLE+joinable` handler now returns `SUCCESS` instead
   of `RETRY_WITH_SLEEP`, preventing an accidental `CAS(IDLE→STOPPING)` that left no thread to
   clear the state; subsequent `launch()` call in `swap_device()` would spin forever.
 
 ## 0.22.1
-- raid1: Fix dequeue/resume race — `_resync_state` and `_outstanding_writes` are now packed into a single `sisl::atomic_status_counter` so the counter decrement and PAUSE→ACTIVE transition are one indivisible CAS; `__resume()` is removed.
-- raid1: Fix enqueue/pause race — `enqueue_write()` now always calls `__pause()` on every enqueue, not only the first; previously a concurrent second enqueuer could skip `__pause()` while the first was still establishing it, allowing resync to overwrite an in-flight write with stale data
+- raid1: Fix dequeue/resume race - `_resync_state` and `_outstanding_writes` are now packed into a single `sisl::atomic_status_counter` so the counter decrement and PAUSE→ACTIVE transition are one indivisible CAS; `__resume()` is removed.
+- raid1: Fix enqueue/pause race - `enqueue_write()` now always calls `__pause()` on every enqueue, not only the first; previously a concurrent second enqueuer could skip `__pause()` while the first was still establishing it, allowing resync to overwrite an in-flight write with stale data
 - raid1: Replace GCC `__builtin_popcount`/`__builtin_clz`/`__builtin_ctz` with C++23 `std::popcount`/`std::countl_zero`/`std::countr_zero`
-- build: `libatomic` is now declared as a Conan system lib on Linux — propagated automatically to consumers, no downstream changes required
+- build: `libatomic` is now declared as a Conan system lib on Linux - propagated automatically to consumers, no downstream changes required
 
 ## 0.22.0
-- raid1: Fix multi-queue idle probe race conditions — probes now start only when all queues are idle, mutex serializes concurrent launch/stop calls, `open_for_uring` counts queue threads for accurate `nr_hw_queues`
-- **Breaking**: `UblkDisk::open_for_uring` signature changed from `(int)` to `(ublksrv_queue const*, int)` — out-of-tree subclasses must update their override
+- raid1: Fix multi-queue idle probe race conditions - probes now start only when all queues are idle, mutex serializes concurrent launch/stop calls, `open_for_uring` counts queue threads for accurate `nr_hw_queues`
+- **Breaking**: `UblkDisk::open_for_uring` signature changed from `(int)` to `(ublksrv_queue const*, int)` - out-of-tree subclasses must update their override
 
 ## 0.21.6
 - raid0: Fix stale alive_cmds in __distribute() corrupting the next I/O on the same thread after a failed multi-stride operation

--- a/include/ublkpp/lib/disk_task.hpp
+++ b/include/ublkpp/lib/disk_task.hpp
@@ -5,6 +5,9 @@
 
 namespace ublkpp {
 
+template < typename T >
+struct StartedTaskAwaitable;
+
 // Lightweight lazy coroutine task for per-disk async I/O. Composable via symmetric transfer:
 // co_await disk_task<T> in a co_io_job or another disk_task<U> suspends the caller and
 // immediately resumes the callee without going through any scheduler.
@@ -49,12 +52,30 @@ struct disk_task {
     }
 
     // Awaitable interface: allows co_await disk_task<T> from co_io_job or disk_task<U>.
+    // Uses symmetric transfer to start the callee without returning to the scheduler.
     bool await_ready() const noexcept { return false; }
     std::coroutine_handle<> await_suspend(std::coroutine_handle<> cont) noexcept {
         _coro.promise()._continuation = cont;
         return _coro; // symmetric transfer: start callee immediately
     }
     T await_resume() noexcept { return _coro.promise()._value; }
+
+    // Returns an awaitable for a task already started via _coro.resume().
+    // await_ready() fast-paths synchronous completions.
+    StartedTaskAwaitable< T > started() noexcept { return {*this}; }
+};
+
+// Awaitable for a disk_task<T> that was already started via _coro.resume(). Used when the caller
+// eagerly starts all child tasks (to submit SQEs in parallel) before suspending on results.
+// await_ready() fast-paths tasks that completed synchronously before the co_await.
+// Thread-safe: queue thread is single-threaded so no CQE can arrive between await_ready and
+// await_suspend - the child cannot complete between the two calls.
+template < typename T >
+struct StartedTaskAwaitable {
+    disk_task< T >& task;
+    bool await_ready() const noexcept { return task._coro.done(); }
+    void await_suspend(std::coroutine_handle<> cont) noexcept { task._coro.promise()._continuation = cont; }
+    T await_resume() const noexcept { return task._coro.promise()._value; }
 };
 
 } // namespace ublkpp

--- a/include/ublkpp/lib/ublk_disk.hpp
+++ b/include/ublkpp/lib/ublk_disk.hpp
@@ -63,6 +63,14 @@ public:
     // Implementations submit all SQEs upfront then co_await CqeAwaitable for each result.
     virtual disk_task< int > handle_io_async(ublksrv_queue const* q, ublk_io_data const* data, sub_cmd_t sub_cmd);
 
+    // Async I/O with explicit scatter-gather list and address. Called when the operation targets
+    // a sub-range or offset that differs from what ublk_io_data describes - the caller owns the
+    // buffer layout and address computation. Composite disks override to apply their own
+    // coordination before delegating to children. Default: async_iov/handle_discard +
+    // io_uring_submit + co_await CqeAwaitable. For DISCARD, iovecs[0].iov_len is the length.
+    virtual disk_task< int > handle_iov_async(ublksrv_queue const* q, ublk_io_data const* data, sub_cmd_t sub_cmd,
+                                              iovec* iovecs, uint32_t nr_vecs, uint64_t addr);
+
     virtual std::string id() const noexcept = 0;
 
     /// Device Specific I/O Handlers

--- a/include/ublkpp/raid/raid1.hpp
+++ b/include/ublkpp/raid/raid1.hpp
@@ -45,6 +45,11 @@ public:
     std::string id() const noexcept override;
     std::list< int > open_for_uring(ublksrv_queue const*, int const iouring_device) override;
 
+    bool uses_async_api() const noexcept override;
+    disk_task< int > handle_io_async(ublksrv_queue const* q, ublk_io_data const* data, sub_cmd_t sub_cmd) override;
+    disk_task< int > handle_iov_async(ublksrv_queue const* q, ublk_io_data const* data, sub_cmd_t sub_cmd,
+                                      iovec* iovecs, uint32_t nr_vecs, uint64_t addr) override;
+
     uint8_t route_size() const noexcept override;
 
     void idle_transition(ublksrv_queue const*, bool) override;

--- a/src/lib/ublk_disk.cpp
+++ b/src/lib/ublk_disk.cpp
@@ -4,6 +4,7 @@
 #include <ublk_cmd.h>
 
 #include "logging.hpp"
+#include "ublkpp/lib/cqe_state.hpp"
 
 namespace ublkpp {
 
@@ -53,6 +54,28 @@ disk_task< int > UblkDisk::handle_io_async(ublksrv_queue const*, ublk_io_data co
     // Unreachable: __handle_io_async only calls this when uses_async_api() returns true.
     RELEASE_ASSERT(false, "handle_io_async called on disk without uses_async_api() override")
     co_return -EIO; // LCOV_EXCL_LINE
+}
+
+// Default: call async_iov or handle_discard (both are pure virtual, so any concrete leaf disk
+// gets this behaviour automatically), then submit and await the CQE.
+disk_task< int > UblkDisk::handle_iov_async(ublksrv_queue const* q, ublk_io_data const* data, sub_cmd_t sub_cmd,
+                                            iovec* iovecs, uint32_t nr_vecs, uint64_t addr) {
+    auto* io = reinterpret_cast< async_io* >(data->private_data);
+    auto const op = ublksrv_get_op(data->iod);
+
+    io_result res;
+    if (op == UBLK_IO_OP_DISCARD || op == UBLK_IO_OP_WRITE_ZEROES) {
+        uint32_t const len = (nr_vecs > 0) ? static_cast< uint32_t >(iovecs[0].iov_len) : 0;
+        res = handle_discard(q, data, sub_cmd, len, addr);
+    } else {
+        res = async_iov(q, data, sub_cmd, iovecs, nr_vecs, addr);
+    }
+
+    if (!res) co_return -static_cast< int >(res.error().value());
+    if (res.value() == 0) co_return 0;
+
+    io_uring_submit(q->ring_ptr);
+    co_return co_await CqeAwaitable{io->ensure(sub_cmd)};
 }
 
 io_result UblkDisk::handle_rw(ublksrv_queue const* q, ublk_io_data const* data, sub_cmd_t sub_cmd, void* buf,

--- a/src/raid/raid0/raid0.cpp
+++ b/src/raid/raid0/raid0.cpp
@@ -7,7 +7,6 @@
 
 #include "raid0_impl.hpp"
 #include "lib/logging.hpp"
-#include <ublkpp/lib/cqe_state.hpp>
 
 namespace ublkpp {
 
@@ -176,25 +175,29 @@ io_result Raid0Disk::handle_discard(ublksrv_queue const* q, ublk_io_data const* 
 
 /// This is the primary I/O handler call for RAID0
 //
-//  RAID0 is primary responsible for splitting an I/O request across several stripes. These operations can cross
+//  RAID0 is primarily responsible for splitting an I/O request across several stripes. These operations can cross
 //  stripe boundaries and even wrap around several strides. This routine handles this calculation and calls
 //  the given routine `func` for each stripe that it has collected scatter (struct iovec) operations for.
 io_result Raid0Disk::__distribute(iovec* iovecs, uint64_t addr, auto&& func, bool retry, sub_cmd_t sub_cmd) const {
+    // We gather all the pieces of each I/O intended to dispatch using this structure
     struct StripeAccum {
-        uint64_t io_addr{0};
-        uint32_t alive_cmds{0};
-        std::array< iovec, 16 > io_array{};
+        uint64_t io_addr{0};                // Starting address
+        uint32_t nr_vecs{0};                // How many iovecs are valid
+        std::array< iovec, 16 > io_array{}; // The scatter-list
     };
-    // Reset only touched stripes on exit; a failed call leaves non-zero alive_cmds that would corrupt the next I/O.
     static_assert(_max_stripe_cnt == 64, "dirty_mask must be exactly uint64_t");
+
+    // Then when allocated (once) an array of accumulators for the thread (1-thread per i/o queue)
     thread_local auto sub_cmds = std::array< StripeAccum, _max_stripe_cnt >();
+
+    // Reset only touched stripes on exit; a failed call leaves non-zero nr_vecs that would corrupt the next I/O.
     uint64_t dirty_mask{0};
     struct DirtyGuard {
         decltype(sub_cmds)& cmds;
         uint64_t& mask;
         ~DirtyGuard() noexcept {
             while (mask) {
-                cmds[std::countr_zero(mask)].alive_cmds = 0;
+                cmds[std::countr_zero(mask)].nr_vecs = 0;
                 mask &= mask - 1; // clear lowest set bit
             }
         }
@@ -219,14 +222,14 @@ io_result Raid0Disk::__distribute(iovec* iovecs, uint64_t addr, auto&& func, boo
 
         dirty_mask |= 1ULL << stripe_off;
         auto& acc = sub_cmds[stripe_off];
-        if (!acc.alive_cmds) acc.io_addr = logical_off;
-        acc.io_array[acc.alive_cmds++] = {buf_cursor, sz};
+        if (!acc.nr_vecs) acc.io_addr = logical_off;
+        acc.io_array[acc.nr_vecs++] = {buf_cursor, sz};
 
         // Dispatch once the remaining bytes fit within a single (N-1)-stripe remainder,
         // guaranteeing this stripe cannot accumulate more iovecs in the same call.
         if ((_stride_width - _stripe_size) >= (len - off)) {
             sub_cmd_t const new_sub_cmd = sub_cmd + (!retry ? (uint16_t)stripe_off : 0);
-            auto res = func(stripe_off, new_sub_cmd, acc.io_array.data(), acc.alive_cmds, acc.io_addr);
+            auto res = func(stripe_off, new_sub_cmd, acc.io_array.data(), acc.nr_vecs, acc.io_addr);
             if (!res) return res;
             cnt += res.value();
         }
@@ -281,27 +284,25 @@ io_result Raid0Disk::sync_iov(uint8_t op, iovec* iovecs, uint32_t nr_vecs, off_t
 }
 
 bool Raid0Disk::uses_async_api() const noexcept {
-    // Only use the new async path when all children are leaves (currently FSDisk).
-    // If any child is composite (e.g. RAID1 with primary+mirror SQEs per async_iov call),
-    // RAID0's handle_io_async only tracks the outer sub_cmd and would miss the child's internal
-    // sub_cmds. The old queue_tgt_io + CqeAwaiter path handles that correctly via process_result.
-    // When RAID1 is migrated to the async API (future phase), this interaction will need
-    // redesigning so RAID0 calls handle_io_async on children rather than async_iov.
+    // Use the new async path when all children implement uses_async_api().
+    // handle_io_async delegates per-stripe I/O to handle_iov_async on each child,
+    // which owns its full lifecycle (SQE submission + CQE awaiting) as a disk_task<int>.
     return std::all_of(_stripe_array.begin(), _stripe_array.end(),
                        [](auto const& s) { return s->disk->uses_async_api(); });
 }
 
 disk_task< int > Raid0Disk::handle_io_async(ublksrv_queue const* q, ublk_io_data const* data, sub_cmd_t sub_cmd) {
     auto const op = ublksrv_get_op(data->iod);
-    auto* io = reinterpret_cast< async_io* >(data->private_data);
 
     if (op == UBLK_IO_OP_FLUSH) co_return handle_flush(q, data, sub_cmd).value_or(-EIO);
 
     bool const retry{is_retry(sub_cmd)};
     if (!retry) sub_cmd = shift_route(sub_cmd, route_size());
 
-    // Collect sub_cmds for which async_iov queued SQEs so we can await their CQEs below.
-    std::vector< sub_cmd_t > dispatched;
+    // Eagerly start each child task so all SQEs are in-flight before the first co_await,
+    // preserving kernel parallelism. All tasks must be drained even on error to avoid
+    // dangling waiter handles in CqeState.
+    std::vector< disk_task< int > > stripe_tasks;
 
     if (op == UBLK_IO_OP_DISCARD || op == UBLK_IO_OP_WRITE_ZEROES) {
         auto const route_mask = _max_stripe_cnt - 1;
@@ -314,9 +315,13 @@ disk_task< int > Raid0Disk::handle_io_async(ublksrv_queue const* q, ublk_io_data
             if (retry && (stripe_off != ((sub_cmd >> device->route_size()) & route_mask))) [[unlikely]]
                 continue;
             sub_cmd_t const new_sub_cmd = sub_cmd + (!retry ? stripe_off : 0);
-            auto res = device->handle_discard(q, data, new_sub_cmd, logical_len, logical_off);
-            if (!res) co_return -EIO;
-            if (res.value() > 0) dispatched.push_back(new_sub_cmd);
+            // stripe_iov is a loop-local variable; _coro.resume() runs handle_discard
+            // synchronously (reading iov_len) before the task suspends, so the stack variable
+            // is safe to pass by pointer.
+            auto stripe_iov = iovec{.iov_base = nullptr, .iov_len = logical_len};
+            auto task = device->handle_iov_async(q, data, new_sub_cmd, &stripe_iov, 1, logical_off);
+            task._coro.resume();
+            stripe_tasks.push_back(std::move(task));
         }
     } else {
         // READ / WRITE: fan out across stripes via __distribute.
@@ -326,26 +331,23 @@ disk_task< int > Raid0Disk::handle_io_async(ublksrv_queue const* q, ublk_io_data
 
         auto res = __distribute(
             &iov, addr,
-            [q, data, &dispatched, this](uint32_t stripe_off, sub_cmd_t new_sub_cmd, iovec* iov, uint32_t nr_iovs,
-                                         uint64_t logical_off) {
-                auto r = _stripe_array[stripe_off]->disk->async_iov(q, data, new_sub_cmd, iov, nr_iovs, logical_off);
-                if (r && r.value() > 0) dispatched.push_back(new_sub_cmd);
-                return r;
+            [q, data, &stripe_tasks, this](uint32_t stripe_off, sub_cmd_t new_sub_cmd, iovec* iov, uint32_t nr_iovs,
+                                           uint64_t logical_off) -> io_result {
+                auto task =
+                    _stripe_array[stripe_off]->disk->handle_iov_async(q, data, new_sub_cmd, iov, nr_iovs, logical_off);
+                task._coro.resume();
+                stripe_tasks.push_back(std::move(task));
+                return 1;
             },
             retry, sub_cmd);
 
         if (!res) co_return -EIO;
     }
 
-    // Batch-submit all SQEs queued above. All SQEs enter the ring before the first co_await so
-    // the kernel executes them in parallel while we poll sequentially below.
-    io_uring_submit(q->ring_ptr);
-
-    // Await each stripe's CQE. CqeAwaitable::await_ready() fast-paths stripes whose CQE
-    // arrived before we reach co_await, avoiding unnecessary suspension.
+    // Await each stripe task. started() fast-paths tasks that completed synchronously.
     int total = 0;
-    for (auto sc : dispatched) {
-        auto r = co_await CqeAwaitable{io->ensure(sc)};
+    for (auto& t : stripe_tasks) {
+        auto r = co_await t.started();
         if (r < 0) co_return r;
         total += r;
     }

--- a/src/raid/raid1/raid1.cpp
+++ b/src/raid/raid1/raid1.cpp
@@ -1,5 +1,6 @@
 #include "ublkpp/raid/raid1.hpp"
 
+#include <optional>
 #include <set>
 
 #include <boost/uuid/random_generator.hpp>
@@ -119,7 +120,7 @@ void Raid1DiskImpl::__init_params(std::shared_ptr< UblkDisk > const& dev_a, std:
     // Now find the what size we should actually set based on the smallest provided device
     for (auto device_array = std::set< std::shared_ptr< UblkDisk > >{dev_a, dev_b}; auto const& device : device_array) {
         if (!device->direct_io) {
-            RLOGW("Device {} does not support O_DIRECT — RAID-1 will use buffered I/O (backend caching not bypassed!)",
+            RLOGW("Device {} does not support O_DIRECT - RAID-1 will use buffered I/O (backend caching not bypassed!)",
                   device)
             direct_io = false; // LCOV_EXCL_LINE
         }
@@ -199,7 +200,7 @@ void Raid1DiskImpl::__init_bitmap_and_degraded_route() {
         bool const a_is_defunct = DEFUNCT_DEVICE(_device_a->disk);
         // Route reads to whichever physical slot is live
         _read_route_cache.store(a_is_defunct ? read_route::DEVB : read_route::DEVA, std::memory_order_release);
-        // Load bitmap from the live slot; don't bump age — we may get the original disk back via swap
+        // Load bitmap from the live slot; don't bump age - we may get the original disk back via swap
         _dirty_bitmap->load_from(*(a_is_defunct ? _device_b : _device_a)->disk);
     } else if (_device_a->new_device xor _device_b->new_device) {
         // Bump the bitmap age
@@ -278,7 +279,7 @@ Raid1DiskImpl::~Raid1DiskImpl() {
 
 std::list< int > Raid1DiskImpl::open_for_uring(ublksrv_queue const* q, int const iouring_device_start) {
     // Called once per queue thread before I/O begins; count queues for multi-queue idle tracking.
-    // Always collect FDs from child disks — each queue thread may need its own set.
+    // Always collect FDs from child disks - each queue thread may need its own set.
     auto fds = _device_a->disk->open_for_uring(q, iouring_device_start);
     fds.splice(fds.end(), _device_b->disk->open_for_uring(q, iouring_device_start + fds.size()));
 
@@ -302,7 +303,7 @@ std::list< int > Raid1DiskImpl::open_for_uring(ublksrv_queue const* q, int const
 //   • __swap_device    CAS: EITHER → DEVA/DEVB  (replacing a device with a healthy one)
 //   • __become_degraded CAS: EITHER → DEVA/DEVB  (marking a failed device as unavailable)
 //
-// If both race, the loser sees the CAS fail and returns early — no further state is mutated.
+// If both race, the loser sees the CAS fail and returns early - no further state is mutated.
 // No additional lock is needed between them; the CAS IS the synchronization gate.
 //
 // __swap_device also holds _ctrl_lock so that two concurrent swap_device() callers don't race
@@ -459,7 +460,7 @@ static inline RouteSelection __route_to_device(RouteState const& state, raid1::r
 std::shared_ptr< UblkDisk > Raid1DiskImpl::swap_device(std::string const& outgoing_device_id,
                                                        std::shared_ptr< UblkDisk > incoming_device) {
     if (!incoming_device->direct_io) {
-        RLOGW("Replacement device {} does not support O_DIRECT — RAID-1 will use buffered I/O (backend caching not "
+        RLOGW("Replacement device {} does not support O_DIRECT - RAID-1 will use buffered I/O (backend caching not "
               "bypassed!)",
               incoming_device)
     }
@@ -523,7 +524,7 @@ std::shared_ptr< UblkDisk > Raid1DiskImpl::swap_device(std::string const& outgoi
     // Atomically swap the device or fail; fail if swapping sole active device
     if (__swap_device(outgoing_device_id, incoming_mirror, state.route)) {
         if (_raid_metrics) _raid_metrics->record_device_swap();
-        // Stop stale probes — they hold a shared_ptr to the outgoing MirrorDevice.
+        // Stop stale probes - they hold a shared_ptr to the outgoing MirrorDevice.
         // _idle_probe_lock guards _probe members against concurrent launch() in idle_transition.
         auto lk = std::unique_lock{_idle_probe_lock};
         _idle_probe_a.stop();
@@ -811,14 +812,14 @@ io_result Raid1DiskImpl::__failover_read(sub_cmd_t sub_cmd, auto&& func, uint64_
     }
 
     // In degraded mode, if the load-balancer picked the backup (dirty) device, verify the region is
-    // clean before using it — otherwise fall back to the active route
+    // clean before using it - otherwise fall back to the active route
     if (state->is_degraded && route != state->route && _dirty_bitmap->is_dirty(addr, len)) route = state->route;
 
     // We've already attempted this device...we don't want to re-attempt
     if (retry && (last_read == route)) return std::unexpected(std::make_error_condition(std::errc::io_error));
 
     // Route away from unavail devices; recovery is handled by the idle probe.
-    // In degraded mode unavail is set on the backup device as part of degradation — routing is
+    // In degraded mode unavail is set on the backup device as part of degradation - routing is
     // already handled by the is_degraded block above, so skip this check there.
     if (!state->is_degraded && __route_to_device(*state, route).device->unavail.test(std::memory_order_acquire)) {
         route = (route == read_route::DEVA) ? read_route::DEVB : read_route::DEVA;
@@ -876,7 +877,7 @@ io_result Raid1DiskImpl::handle_internal(ublksrv_queue const*, ublk_io_data cons
 
 void Raid1DiskImpl::collect_async(ublksrv_queue const* q, std::list< async_result >& results) {
     auto const state = __capture_route_state();
-    // _pending_results[q] holds synthetic completions injected by __handle_async_retry — not backend CQEs.
+    // _pending_results[q] holds synthetic completions injected by __handle_async_retry - not backend CQEs.
     // Each entry represents a degraded write where the PRIMARY leg failed but the write succeeded on the
     // surviving leg. The `result` field carries the byte count that must be accumulated into ret_val via
     // the normal process_result path. See the comment in __handle_async_retry for why this indirection is
@@ -931,6 +932,149 @@ io_result Raid1DiskImpl::async_iov(ublksrv_queue const* q, ublk_io_data const* d
             return d.async_iov(q, data, scmd, iovecs, nr_vecs, a);
         },
         addr, len, q, data);
+}
+
+disk_task< int > Raid1DiskImpl::__failover_read_async(ublksrv_queue const* q, ublk_io_data const* data,
+                                                      sub_cmd_t sub_cmd, iovec* iovecs, uint32_t nr_vecs, uint64_t addr,
+                                                      uint32_t len) {
+    thread_local raid1::read_route last_read = raid1::read_route::DEVB;
+    auto const state = __capture_route_state(sub_cmd);
+
+    // Pick device (load balancer)
+    auto route = read_route::DEVA;
+    if (state.is_degraded && state.backup_dev->unavail.test(std::memory_order_acquire)) {
+        route = state.route;
+    } else {
+        route = (last_read == read_route::DEVB) ? read_route::DEVA : read_route::DEVB;
+    }
+
+    // In degraded mode, avoid reading backup if the region is dirty
+    if (state.is_degraded && route != state.route && _dirty_bitmap->is_dirty(addr, len)) route = state.route;
+
+    // In healthy mode, avoid unavail devices
+    if (!state.is_degraded && __route_to_device(state, route).device->unavail.test(std::memory_order_acquire)) {
+        route = (route == read_route::DEVA) ? read_route::DEVB : read_route::DEVA;
+        RLOGD("Skipping unavail device, routing to alternate")
+    }
+
+    last_read = route;
+    auto const [primary_dev, primary_sub] = __route_to_device(state, route);
+
+    auto primary_task =
+        primary_dev->disk->handle_iov_async(q, data, primary_sub, iovecs, nr_vecs, addr + reserved_size);
+    primary_task._coro.resume();
+    auto const r = co_await primary_task.started();
+    primary_dev->disk->on_io_complete(data, primary_sub, r);
+
+    if (r >= 0) {
+        primary_dev->unavail.clear(std::memory_order_release);
+        co_return r;
+    }
+    if (!primary_dev->unavail.test_and_set(std::memory_order_acquire))
+        RLOGW("Device marked unavailable due to read failure: {}", *primary_dev->disk)
+
+    // Failover to the other device
+    auto const other_route = (route == read_route::DEVA) ? read_route::DEVB : read_route::DEVA;
+    auto const [failover_dev, failover_sub] = __route_to_device(state, other_route);
+
+    auto failover_task =
+        failover_dev->disk->handle_iov_async(q, data, failover_sub, iovecs, nr_vecs, addr + reserved_size);
+    failover_task._coro.resume();
+    auto const r2 = co_await failover_task.started();
+    failover_dev->disk->on_io_complete(data, failover_sub, r2);
+
+    co_return r2 >= 0 ? r2 : -EIO;
+}
+
+disk_task< int > Raid1DiskImpl::handle_io_async(ublksrv_queue const* q, ublk_io_data const* data, sub_cmd_t sub_cmd) {
+    iovec iov{reinterpret_cast< void* >(data->iod->addr), static_cast< size_t >(data->iod->nr_sectors) << SECTOR_SHIFT};
+    co_return co_await handle_iov_async(q, data, sub_cmd, &iov, 1,
+                                        static_cast< uint64_t >(data->iod->start_sector) << SECTOR_SHIFT);
+}
+
+disk_task< int > Raid1DiskImpl::handle_iov_async(ublksrv_queue const* q, ublk_io_data const* data, sub_cmd_t sub_cmd,
+                                                 iovec* iovecs, uint32_t nr_vecs, uint64_t addr) {
+    auto const op = ublksrv_get_op(data->iod);
+    auto const len = static_cast< uint32_t >(__iovec_len(iovecs, iovecs + nr_vecs));
+
+    if (op == UBLK_IO_OP_FLUSH) co_return handle_flush(q, data, sub_cmd).value_or(-EIO);
+
+    RLOGT("Received {}: [tag:{:#0x}] [lba:{:#0x}|len:{:#0x}] [sub_cmd:{}] [uuid:{}]",
+          op == UBLK_IO_OP_READ ? "READ" : "WRITE", data->tag, addr >> params()->basic.logical_bs_shift, len,
+          ublkpp::to_string(sub_cmd), _str_uuid)
+
+    sub_cmd = shift_route(sub_cmd, route_size());
+
+    if (op == UBLK_IO_OP_READ) co_return co_await __failover_read_async(q, data, sub_cmd, iovecs, nr_vecs, addr, len);
+
+    // Write / Discard / WriteZeroes: replicate to both devices
+    auto const state = __capture_route_state(sub_cmd);
+    auto const is_discard = (op == UBLK_IO_OP_DISCARD || op == UBLK_IO_OP_WRITE_ZEROES);
+    auto const backup_unavail = state.backup_dev->unavail.test(std::memory_order_acquire);
+    auto const is_dirty_region = _dirty_bitmap->is_dirty(addr, len);
+    auto const chunk_size = be32toh(_sb->fields.bitmap.chunk_size);
+    auto const totally_aligned = ((chunk_size <= len) && (0 == len % chunk_size) && (0 == addr % chunk_size));
+
+    enum class BackupMode { SKIP, REPLICATE, OPTIMISTIC };
+    auto const bm = [&]() -> BackupMode {
+        if (!state.is_degraded) return BackupMode::REPLICATE;
+        if (backup_unavail) return BackupMode::SKIP;
+        if (is_dirty_region) {
+            if (!totally_aligned || is_discard) return BackupMode::SKIP;
+            return BackupMode::OPTIMISTIC;
+        }
+        return BackupMode::REPLICATE;
+    }();
+
+    _resync_task->enqueue_write();
+    auto active_task =
+        state.active_dev->disk->handle_iov_async(q, data, state.active_subcmd, iovecs, nr_vecs, addr + reserved_size);
+    active_task._coro.resume();
+
+    std::optional< disk_task< int > > backup_task;
+    if (bm != BackupMode::SKIP) {
+        _resync_task->enqueue_write();
+        backup_task.emplace(state.backup_dev->disk->handle_iov_async(q, data, state.backup_subcmd, iovecs, nr_vecs,
+                                                                     addr + reserved_size));
+        backup_task->_coro.resume();
+    }
+
+    auto const active_res = co_await active_task.started();
+    state.active_dev->disk->on_io_complete(data, state.active_subcmd, active_res);
+    _resync_task->dequeue_write();
+
+    if (active_res < 0) {
+        _dirty_bitmap->dirty_region(addr, len);
+        __become_degraded(state.active_subcmd, &state);
+        if (backup_task) {
+            auto const backup_res = co_await backup_task->started();
+            state.backup_dev->disk->on_io_complete(data, state.backup_subcmd, backup_res);
+            _resync_task->dequeue_write();
+            co_return backup_res >= 0 ? backup_res : -EIO;
+        }
+        co_return -EIO;
+    }
+
+    if (bm == BackupMode::SKIP) {
+        _dirty_bitmap->dirty_region(addr, len);
+        co_return active_res;
+    }
+
+    auto const backup_res = co_await backup_task->started();
+    state.backup_dev->disk->on_io_complete(data, state.backup_subcmd, backup_res);
+    _resync_task->dequeue_write();
+
+    if (backup_res < 0) {
+        _dirty_bitmap->dirty_region(addr, len);
+        if (!state.is_degraded) {
+            if (auto d = __become_degraded(state.backup_subcmd, &state); !d) co_return -EIO;
+        }
+    } else if (bm == BackupMode::OPTIMISTIC) {
+        state.backup_dev->unavail.clear(std::memory_order_release);
+        _resync_task->clean_region(addr, len, *state.active_dev);
+    }
+
+    co_return active_res;
 }
 
 io_result Raid1DiskImpl::sync_iov(uint8_t op, iovec* iovecs, uint32_t nr_vecs, off_t addr) noexcept {
@@ -1001,7 +1145,7 @@ void Raid1DiskImpl::on_io_complete(ublk_io_data const* data, sub_cmd_t sub_cmd, 
 void Raid1DiskImpl::idle_transition(ublksrv_queue const*, bool enter) noexcept {
     if (!enter) {
         DEBUG_ASSERT(_idle_queue_count.load(std::memory_order_relaxed) > 0,                      // LCOV_EXCL_LINE
-                     "idle_transition exit without matching enter — ublksrv contract violated"); // LCOV_EXCL_LINE
+                     "idle_transition exit without matching enter - ublksrv contract violated"); // LCOV_EXCL_LINE
         _idle_queue_count.fetch_sub(1, std::memory_order_acq_rel);
         auto lk = std::unique_lock{_idle_probe_lock};
         _idle_probe_a.stop();
@@ -1011,7 +1155,7 @@ void Raid1DiskImpl::idle_transition(ublksrv_queue const*, bool enter) noexcept {
 
     // Start probes only when all queue threads are idle.
     // When _nr_hw_queues == 0 (no open_for_uring call yet), prev+1 < 0 is always false for
-    // uint16_t, so the probe fires unconditionally — preserving compat with zero-queue callers
+    // uint16_t, so the probe fires unconditionally - preserving compat with zero-queue callers
     // that skip open_for_uring (e.g. tests that call idle_transition directly).
     auto const prev = _idle_queue_count.fetch_add(1, std::memory_order_acq_rel);
     if (prev + 1 < _nr_hw_queues.load(std::memory_order_acquire)) return;

--- a/src/raid/raid1/raid1_impl.hpp
+++ b/src/raid/raid1/raid1_impl.hpp
@@ -52,8 +52,8 @@ class Raid1DiskImpl : public UblkDisk {
     std::atomic< bool > _resync_enabled{true};
     std::shared_ptr< Raid1ResyncTask > _resync_task;
 
-    // Guards: (1) swap_device() — serializes concurrent callers on _device_a/_device_b mutations.
-    //         (2) _pending_results — serializes open_for_uring() insertions across queue threads.
+    // Guards: (1) swap_device() - serializes concurrent callers on _device_a/_device_b mutations.
+    //         (2) _pending_results - serializes open_for_uring() insertions across queue threads.
     std::mutex _ctrl_lock;
 
     // Multi-queue idle tracking: probe starts when all queues are idle, stops on any active transition
@@ -74,6 +74,8 @@ class Raid1DiskImpl : public UblkDisk {
                                    ublk_io_data const* async_data);
     io_result __replicate(sub_cmd_t sub_cmd, auto&& func, uint64_t addr, uint32_t len, ublksrv_queue const* q = nullptr,
                           ublk_io_data const* async_data = nullptr, RouteState* state = nullptr);
+    disk_task< int > __failover_read_async(ublksrv_queue const* q, ublk_io_data const* data, sub_cmd_t sub_cmd,
+                                           iovec* iovecs, uint32_t nr_vecs, uint64_t addr, uint32_t len);
     bool __swap_device(std::string const& outgoing_device_id, std::shared_ptr< MirrorDevice >& incoming_mirror,
                        raid1::read_route const& cur_route);
 
@@ -130,6 +132,11 @@ public:
     void idle_transition(ublksrv_queue const* q, bool enter) noexcept override;
 
     uint8_t route_size() const noexcept override { return 1; }
+
+    bool uses_async_api() const noexcept override { return true; }
+    disk_task< int > handle_io_async(ublksrv_queue const* q, ublk_io_data const* data, sub_cmd_t sub_cmd) override;
+    disk_task< int > handle_iov_async(ublksrv_queue const* q, ublk_io_data const* data, sub_cmd_t sub_cmd,
+                                      iovec* iovecs, uint32_t nr_vecs, uint64_t addr) override;
 
     void on_io_complete(ublk_io_data const* data, sub_cmd_t sub_cmd, int res) override;
 

--- a/src/raid/raid1/raid1_pimpl.cpp
+++ b/src/raid/raid1/raid1_pimpl.cpp
@@ -36,6 +36,14 @@ std::list< int > Raid1Disk::open_for_uring(ublksrv_queue const* q, int const iou
 }
 uint8_t Raid1Disk::route_size() const noexcept { return _impl->route_size(); }
 void Raid1Disk::idle_transition(ublksrv_queue const* q, bool enter) { return _impl->idle_transition(q, enter); }
+bool Raid1Disk::uses_async_api() const noexcept { return _impl->uses_async_api(); }
+disk_task< int > Raid1Disk::handle_io_async(ublksrv_queue const* q, ublk_io_data const* data, sub_cmd_t sub_cmd) {
+    return _impl->handle_io_async(q, data, sub_cmd);
+}
+disk_task< int > Raid1Disk::handle_iov_async(ublksrv_queue const* q, ublk_io_data const* data, sub_cmd_t sub_cmd,
+                                             iovec* iovecs, uint32_t nr_vecs, uint64_t addr) {
+    return _impl->handle_iov_async(q, data, sub_cmd, iovecs, nr_vecs, addr);
+}
 void Raid1Disk::on_io_complete(ublk_io_data const* data, sub_cmd_t sub_cmd, int res) {
     return _impl->on_io_complete(data, sub_cmd, res);
 }

--- a/src/raid/raid1/tests/CMakeLists.txt
+++ b/src/raid/raid1/tests/CMakeLists.txt
@@ -9,6 +9,7 @@ list(APPEND RAID1_TEST_SRCS
   raid1_test.cpp
 )
 
+add_subdirectory (async)
 add_subdirectory (bitmap)
 add_subdirectory (concurrency)
 add_subdirectory (failures)
@@ -17,6 +18,28 @@ add_subdirectory (retry)
 add_subdirectory (simple)
 add_subdirectory (superblock)
 add_subdirectory (syncio)
+
+add_executable(test_raid1_async)
+target_sources(test_raid1_async PRIVATE
+    async/raid1_async_test.cpp
+    ${RAID1_ASYNC_TEST_SRCS}
+    $<TARGET_OBJECTS:logging>
+    $<TARGET_OBJECTS:raid1>
+    $<TARGET_OBJECTS:ublk_disk>
+    $<TARGET_OBJECTS:ublk_metrics>
+)
+target_include_directories(test_raid1_async PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}
+)
+target_link_libraries(test_raid1_async
+    GTest::gmock
+    mock_ublksrv
+    isa-l::isa-l
+    sisl::cache
+    ublksrv::ublksrv
+    $<$<PLATFORM_ID:Linux>:atomic>
+)
+add_test(NAME Raid1AsyncTest COMMAND test_raid1_async -cv warning)
 
 add_executable(test_raid1)
 target_sources(test_raid1 PRIVATE

--- a/src/raid/raid1/tests/async/CMakeLists.txt
+++ b/src/raid/raid1/tests/async/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.11)
+
+list(APPEND RAID1_ASYNC_TEST_SRCS
+    async/read_write.cpp
+    async/failover.cpp
+    async/flush.cpp
+    async/discard.cpp
+)
+set(RAID1_ASYNC_TEST_SRCS "${RAID1_ASYNC_TEST_SRCS}" PARENT_SCOPE)

--- a/src/raid/raid1/tests/async/async_raid1_common.hpp
+++ b/src/raid/raid1/tests/async/async_raid1_common.hpp
@@ -1,0 +1,95 @@
+#pragma once
+
+#include <boost/uuid/random_generator.hpp>
+#include <boost/uuid/string_generator.hpp>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <ublksrv.h>
+
+#include "ublkpp/lib/cqe_state.hpp"
+#include "ublkpp/raid/raid1.hpp"
+#include "raid/raid1/raid1_superblock.hpp"
+#include "tests/mock_ublksrv/mock_ublksrv.hpp"
+#include "tests/test_disk.hpp"
+
+using ::testing::_;
+using ::testing::AnyNumber;
+using ::testing::Return;
+using ::ublkpp::Gi;
+using ::ublkpp::io_result;
+using ::ublkpp::Ki;
+using ::ublkpp::UblkDisk;
+
+static const ublkpp::raid1::SuperBlock async_raid1_superblock = {
+    .header = {.magic = {0x53, 0x25, 0xff, 0x0a, 0x34, 0x99, 0x3e, 0xc5, 0x67, 0x3a, 0xc8, 0x17, 0x49, 0xae, 0x1b,
+                         0x64},
+               .version = htobe16(1),
+               .uuid = {0xad, 0xa4, 0x07, 0x37, 0x30, 0xe3, 0x49, 0xfe, 0x99, 0x42, 0x5a, 0x28, 0x7d, 0x71, 0xeb,
+                        0x3f}},
+    .fields = {.clean_unmount = 1,
+               .read_route = static_cast< uint8_t >(ublkpp::raid1::read_route::EITHER),
+               .device_b = 0,
+               .bitmap = {._reserved = {0x00}, .chunk_size = htobe32(32 * Ki), .age = 0}},
+    .superbitmap_reserved = {0x00}};
+
+// Default async_iov action: registers the CqeState in the pool without submitting a real SQE.
+// Tests call inject_cqe() to deliver synthetic results.
+inline auto make_async_iov_action() {
+    return [](ublksrv_queue const*, ublk_io_data const* data, ublkpp::sub_cmd_t sub_cmd, iovec*, uint32_t,
+              uint64_t) -> io_result {
+        ublkpp::build_cqe_state_data(data, static_cast< uint64_t >(sub_cmd));
+        return 1;
+    };
+}
+
+struct AsyncRaid1Fixture : public ::testing::Test {
+    static constexpr uint64_t k_disk_cap = 1 * Gi;
+    static constexpr std::string_view k_uuid = "ada40737-30e3-49fe-9942-5a287d71eb3f";
+
+    std::shared_ptr< ublkpp::AsyncTestDisk > disk_a, disk_b;
+    std::shared_ptr< ublkpp::Raid1Disk > raid;
+    std::unique_ptr< ublkpp::MockUblksrv > mock;
+
+    void SetUp() override {
+        using ::testing::NiceMock;
+
+        TestParams const pa{.capacity = k_disk_cap, .id = "DiskA", .is_slot_b = false};
+        TestParams const pb{.capacity = k_disk_cap, .id = "DiskB", .is_slot_b = true};
+        disk_a = std::make_shared< NiceMock< ublkpp::AsyncTestDisk > >(pa);
+        disk_b = std::make_shared< NiceMock< ublkpp::AsyncTestDisk > >(pb);
+
+        ON_CALL(*disk_a, open_for_uring(_, _)).WillByDefault(Return(std::list< int >{}));
+        ON_CALL(*disk_b, open_for_uring(_, _)).WillByDefault(Return(std::list< int >{}));
+
+        ON_CALL(*disk_a, sync_iov(_, _, _, _))
+            .WillByDefault([](uint8_t op, iovec* iovecs, uint32_t, off_t) -> io_result {
+                if (op == UBLK_IO_OP_READ && iovecs && iovecs->iov_base)
+                    memcpy(iovecs->iov_base, &async_raid1_superblock, ublkpp::raid1::k_page_size);
+                return static_cast< int >(iovecs->iov_len);
+            });
+        ON_CALL(*disk_b, sync_iov(_, _, _, _))
+            .WillByDefault([](uint8_t op, iovec* iovecs, uint32_t, off_t) -> io_result {
+                if (op == UBLK_IO_OP_READ && iovecs && iovecs->iov_base) {
+                    memcpy(iovecs->iov_base, &async_raid1_superblock, ublkpp::raid1::k_page_size);
+                    static_cast< ublkpp::raid1::SuperBlock* >(iovecs->iov_base)->fields.device_b = 1;
+                }
+                return static_cast< int >(iovecs->iov_len);
+            });
+
+        ON_CALL(*disk_a, async_iov(_, _, _, _, _, _)).WillByDefault(make_async_iov_action());
+        ON_CALL(*disk_b, async_iov(_, _, _, _, _, _)).WillByDefault(make_async_iov_action());
+
+        ON_CALL(*disk_a, handle_flush(_, _, _)).WillByDefault(Return(io_result{0}));
+        ON_CALL(*disk_b, handle_flush(_, _, _)).WillByDefault(Return(io_result{0}));
+
+        ON_CALL(*disk_a, handle_discard(_, _, _, _, _)).WillByDefault(Return(io_result{1}));
+        ON_CALL(*disk_b, handle_discard(_, _, _, _, _)).WillByDefault(Return(io_result{1}));
+
+        raid = std::make_shared< ublkpp::Raid1Disk >(boost::uuids::string_generator()(std::string(k_uuid)), disk_a,
+                                                     disk_b);
+        // Disable background resync to keep tests deterministic.
+        raid->toggle_resync(false);
+        mock = std::make_unique< ublkpp::MockUblksrv >(raid);
+    }
+};

--- a/src/raid/raid1/tests/async/discard.cpp
+++ b/src/raid/raid1/tests/async/discard.cpp
@@ -1,0 +1,39 @@
+#include "async_raid1_common.hpp"
+
+// Healthy discard: fans out to both replicas via handle_discard.
+// Each child's default handle_iov_async calls handle_discard (returns 1) → awaits CqeAwaitable.
+// inject active first (RAID1 suspends on backup), then inject backup → completion.
+TEST_F(AsyncRaid1Fixture, DiscardBothDevices) {
+    EXPECT_CALL(*disk_a, handle_discard(_, _, _, _, _)).Times(1);
+    EXPECT_CALL(*disk_b, handle_discard(_, _, _, _, _)).Times(1);
+
+    // 32KiB discard — chunk-aligned so totally_aligned=true (chunk_size=32Ki)
+    auto res = mock->submit_io(0, UBLK_IO_OP_DISCARD, 0, 32 * Ki / 512, nullptr);
+    ASSERT_TRUE(res);
+    EXPECT_EQ(res.value(), 2u); // active + backup CqeStates
+
+    // Active done, suspend on backup
+    EXPECT_TRUE(mock->inject_cqe(0, 0).empty());
+    // Backup done → completion
+    auto completions = mock->inject_cqe(0, 0);
+    ASSERT_EQ(completions.size(), 1u);
+    EXPECT_EQ(completions[0].tag, 0);
+    EXPECT_EQ(completions[0].result, 0);
+}
+
+// Discard where handle_discard returns 0 (synchronous inline completion) → task finishes
+// without suspending on CqeAwaitable. RAID1 still awaits both tasks.
+TEST_F(AsyncRaid1Fixture, DiscardSyncCompletion) {
+    ON_CALL(*disk_a, handle_discard(_, _, _, _, _)).WillByDefault(Return(io_result{0}));
+    ON_CALL(*disk_b, handle_discard(_, _, _, _, _)).WillByDefault(Return(io_result{0}));
+
+    auto res = mock->submit_io(0, UBLK_IO_OP_DISCARD, 0, 32 * Ki / 512, nullptr);
+    ASSERT_TRUE(res);
+    // Both tasks complete synchronously; no CqeStates registered
+    EXPECT_EQ(res.value(), 0u);
+
+    // No waiter — task already done; inject_cqe returns stored result immediately
+    auto completions = mock->inject_cqe(0, 0);
+    ASSERT_EQ(completions.size(), 1u);
+    EXPECT_EQ(completions[0].result, 0);
+}

--- a/src/raid/raid1/tests/async/failover.cpp
+++ b/src/raid/raid1/tests/async/failover.cpp
@@ -1,0 +1,88 @@
+#include "async_raid1_common.hpp"
+
+// Read failover: primary device fails → failover to backup.
+// Initial submit registers 1 CqeState (primary only). After injecting -EIO,
+// RAID1 starts the failover task (registers a second CqeState) and suspends.
+// Second inject delivers success to backup → completion returned.
+TEST_F(AsyncRaid1Fixture, ReadFailoverToBackup) {
+    std::thread([this] {
+        // Expect both disks to be called: primary attempt + failover attempt.
+        EXPECT_CALL(*disk_a, async_iov(_, _, _, _, _, _)).Times(1);
+        EXPECT_CALL(*disk_b, async_iov(_, _, _, _, _, _)).Times(1);
+
+        auto res = mock->submit_io(0, UBLK_IO_OP_READ, 0, 4 * Ki / 512, nullptr);
+        ASSERT_TRUE(res);
+        EXPECT_EQ(res.value(), 1u); // only primary task started
+
+        // Primary fails → RAID1 starts failover task (not done yet)
+        EXPECT_TRUE(mock->inject_cqe(0, -EIO).empty());
+        // Backup succeeds → RAID1 completes
+        auto completions = mock->inject_cqe(0, 4 * Ki);
+        ASSERT_EQ(completions.size(), 1u);
+        EXPECT_EQ(completions[0].tag, 0);
+        EXPECT_EQ(completions[0].result, 4 * Ki);
+    }).join();
+}
+
+// Read failover: both devices fail → -EIO returned.
+TEST_F(AsyncRaid1Fixture, ReadBothDevicesFail) {
+    std::thread([this] {
+        auto res = mock->submit_io(0, UBLK_IO_OP_READ, 0, 4 * Ki / 512, nullptr);
+        ASSERT_TRUE(res);
+        EXPECT_EQ(res.value(), 1u);
+
+        // Primary fails → failover task started
+        EXPECT_TRUE(mock->inject_cqe(0, -EIO).empty());
+        // Backup also fails → -EIO
+        auto completions = mock->inject_cqe(0, -EIO);
+        ASSERT_EQ(completions.size(), 1u);
+        EXPECT_EQ(completions[0].result, -EIO);
+    }).join();
+}
+
+// Write: active device fails; backup was started eagerly and succeeds.
+// co_return backup_res (backup bytes returned).
+TEST_F(AsyncRaid1Fixture, WriteActiveFailsBecomeDegraded) {
+    EXPECT_CALL(*disk_a, async_iov(_, _, _, _, _, _)).Times(1);
+    EXPECT_CALL(*disk_b, async_iov(_, _, _, _, _, _)).Times(1);
+
+    auto res = mock->submit_io(0, UBLK_IO_OP_WRITE, 0, 4 * Ki / 512, nullptr);
+    ASSERT_TRUE(res);
+    EXPECT_EQ(res.value(), 2u);
+
+    // Active -EIO → RAID1 awaits already-started backup
+    EXPECT_TRUE(mock->inject_cqe(0, -EIO).empty());
+    // Backup succeeds → co_return backup_res = 4Ki
+    auto completions = mock->inject_cqe(0, 4 * Ki);
+    ASSERT_EQ(completions.size(), 1u);
+    EXPECT_EQ(completions[0].result, 4 * Ki);
+}
+
+// Write: active succeeds but backup device fails → become degraded, co_return active_res.
+TEST_F(AsyncRaid1Fixture, WriteReplicaFailsBecomeDegraded) {
+    EXPECT_CALL(*disk_a, async_iov(_, _, _, _, _, _)).Times(1);
+    EXPECT_CALL(*disk_b, async_iov(_, _, _, _, _, _)).Times(1);
+
+    auto res = mock->submit_io(0, UBLK_IO_OP_WRITE, 0, 4 * Ki / 512, nullptr);
+    ASSERT_TRUE(res);
+    EXPECT_EQ(res.value(), 2u);
+
+    // Active succeeds → RAID1 awaits backup
+    EXPECT_TRUE(mock->inject_cqe(0, 4 * Ki).empty());
+    // Backup -EIO → become_degraded, co_return active_res = 4Ki
+    auto completions = mock->inject_cqe(0, -EIO);
+    ASSERT_EQ(completions.size(), 1u);
+    EXPECT_EQ(completions[0].result, 4 * Ki);
+}
+
+// Write: both devices fail → -EIO.
+TEST_F(AsyncRaid1Fixture, WriteBothDevicesFail) {
+    auto res = mock->submit_io(0, UBLK_IO_OP_WRITE, 0, 4 * Ki / 512, nullptr);
+    ASSERT_TRUE(res);
+    EXPECT_EQ(res.value(), 2u);
+
+    EXPECT_TRUE(mock->inject_cqe(0, -EIO).empty());
+    auto completions = mock->inject_cqe(0, -EIO);
+    ASSERT_EQ(completions.size(), 1u);
+    EXPECT_EQ(completions[0].result, -EIO);
+}

--- a/src/raid/raid1/tests/async/flush.cpp
+++ b/src/raid/raid1/tests/async/flush.cpp
@@ -1,0 +1,18 @@
+#include "async_raid1_common.hpp"
+
+// RAID1's handle_flush returns 0 synchronously — no children are called, no SQEs submitted.
+// handle_io_async co_returns 0 immediately — pool size is 0.
+// inject_cqe with any result on a finished task returns the stored value.
+TEST_F(AsyncRaid1Fixture, FlushCompletesSync) {
+    EXPECT_CALL(*disk_a, async_iov(_, _, _, _, _, _)).Times(0);
+    EXPECT_CALL(*disk_b, async_iov(_, _, _, _, _, _)).Times(0);
+
+    auto res = mock->submit_io(0, UBLK_IO_OP_FLUSH, 0, 0, nullptr);
+    ASSERT_TRUE(res);
+    EXPECT_EQ(res.value(), 0u); // no CqeStates registered
+
+    auto completions = mock->inject_cqe(0, 0);
+    ASSERT_EQ(completions.size(), 1u);
+    EXPECT_EQ(completions[0].tag, 0);
+    EXPECT_EQ(completions[0].result, 0);
+}

--- a/src/raid/raid1/tests/async/raid1_async_test.cpp
+++ b/src/raid/raid1/tests/async/raid1_async_test.cpp
@@ -1,0 +1,28 @@
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <sisl/logging/logging.h>
+#include <sisl/options/options.h>
+
+#define ENABLED_OPTIONS logging, raid1
+
+SISL_LOGGING_INIT(ublk_raid)
+SISL_OPTIONS_ENABLE(ENABLED_OPTIONS)
+
+extern "C" {
+struct ublksrv_queue;
+extern int ublksrv_queue_send_event(ublksrv_queue const*) {
+    LOGTRACE("Queue event!");
+    return 0;
+}
+}
+
+int main(int argc, char* argv[]) {
+    int parsed_argc = argc;
+    ::testing::InitGoogleTest(&parsed_argc, argv);
+    SISL_OPTIONS_LOAD(parsed_argc, argv, ENABLED_OPTIONS);
+    sisl::logging::SetLogger(std::string(argv[0]));
+    spdlog::set_pattern("[%D %T.%e] [%n] [%^%l%$] [%t] %v");
+    parsed_argc = 1;
+    return RUN_ALL_TESTS();
+}

--- a/src/raid/raid1/tests/async/read_write.cpp
+++ b/src/raid/raid1/tests/async/read_write.cpp
@@ -1,0 +1,59 @@
+#include "async_raid1_common.hpp"
+
+// Healthy read: routes to one device, 1 CqeState registered.
+// thread_local last_read starts at DEVB on a fresh thread, so first read → DEVA (disk_a).
+TEST_F(AsyncRaid1Fixture, ReadSingleDevice) {
+    std::thread([this] {
+        auto res = mock->submit_io(0, UBLK_IO_OP_READ, 0, 4 * Ki / 512, nullptr);
+        ASSERT_TRUE(res);
+        EXPECT_EQ(res.value(), 1u);
+
+        auto completions = mock->inject_cqe(0, 4 * Ki);
+        ASSERT_EQ(completions.size(), 1u);
+        EXPECT_EQ(completions[0].tag, 0);
+        EXPECT_EQ(completions[0].result, 4 * Ki);
+    }).join();
+}
+
+// Healthy write: replicates to both devices.
+// inject active CQE first (task suspends on backup), then inject backup CQE (task done).
+TEST_F(AsyncRaid1Fixture, WriteBothDevices) {
+    EXPECT_CALL(*disk_a, async_iov(_, _, _, _, _, _)).Times(1);
+    EXPECT_CALL(*disk_b, async_iov(_, _, _, _, _, _)).Times(1);
+
+    auto res = mock->submit_io(0, UBLK_IO_OP_WRITE, 0, 4 * Ki / 512, nullptr);
+    ASSERT_TRUE(res);
+    EXPECT_EQ(res.value(), 2u); // active + backup CqeStates registered
+
+    // First inject → active done, RAID1 suspends on backup → no completion yet
+    EXPECT_TRUE(mock->inject_cqe(0, 4 * Ki).empty());
+    // Second inject → backup done, RAID1 completes → returns active bytes
+    auto completions = mock->inject_cqe(0, 4 * Ki);
+    ASSERT_EQ(completions.size(), 1u);
+    EXPECT_EQ(completions[0].tag, 0);
+    EXPECT_EQ(completions[0].result, 4 * Ki);
+}
+
+// Two concurrent write slots: each independent tag resolves separately.
+TEST_F(AsyncRaid1Fixture, TwoTagsWriteIndependent) {
+    auto res0 = mock->submit_io(0, UBLK_IO_OP_WRITE, 0, 4 * Ki / 512, nullptr);
+    auto res1 = mock->submit_io(1, UBLK_IO_OP_WRITE, 64, 4 * Ki / 512, nullptr);
+    ASSERT_TRUE(res0);
+    ASSERT_TRUE(res1);
+    EXPECT_EQ(res0.value(), 2u);
+    EXPECT_EQ(res1.value(), 2u);
+
+    // Resolve tag 1 first (inject active then backup)
+    EXPECT_TRUE(mock->inject_cqe(1, 4 * Ki).empty());
+    auto c1 = mock->inject_cqe(1, 4 * Ki);
+    ASSERT_EQ(c1.size(), 1u);
+    EXPECT_EQ(c1[0].tag, 1);
+    EXPECT_EQ(c1[0].result, 4 * Ki);
+
+    // Resolve tag 0
+    EXPECT_TRUE(mock->inject_cqe(0, 4 * Ki).empty());
+    auto c0 = mock->inject_cqe(0, 4 * Ki);
+    ASSERT_EQ(c0.size(), 1u);
+    EXPECT_EQ(c0[0].tag, 0);
+    EXPECT_EQ(c0[0].result, 4 * Ki);
+}


### PR DESCRIPTION
## Phase 5 of #210 — RAID1 async API migration

### Problem

Phase 4 left RAID0's `uses_async_api()` returning `false` whenever any child was RAID1 — meaning RAID10 (RAID0 of RAID1 pairs) stayed on the old `queue_tgt_io + CqeAwaiter` loop. The blocker: RAID0's `handle_io_async` called `async_iov` on children (one CqeState per call), but RAID1's `async_iov` submits two SQEs (primary + mirror). RAID0 has no mechanism to track or await CqeStates it didn't register, so the two disks couldn't compose cleanly.

### What this PR does

**`StartedTaskAwaitable<T>`** — awaitable for an already-started `disk_task<T>`. `await_ready()` fast-paths tasks that completed synchronously before the caller reached the `co_await`. `await_suspend` installs the caller as `_continuation` so `final_awaiter` resumes the parent on completion. Needed because RAID0 and RAID1 eagerly start all child tasks (to submit SQEs in parallel) before suspending on their results.

**`UblkDisk::handle_iov_async`** — new virtual coroutine taking `iovec*` / `addr` with custom scatter-list (unlike `handle_io_async` which takes `ublk_io_data`). Default implementation (shared by FSDisk — no override required): READ/WRITE calls `async_iov` then `co_await CqeAwaitable`; DISCARD/WRITE_ZEROES calls `handle_discard` then awaits. The custom sgv decouples data splitting from dispatch, letting RAID0 call `handle_iov_async` on children with pre-computed stripe bounds.

**RAID0 `handle_io_async`** — inner fan-out loop replaced: calls `handle_iov_async` on each child stripe, eagerly starts all tasks via `_coro.resume()`, then awaits each via `StartedTaskAwaitable`. All SQEs are submitted before the first `co_await`, preserving kernel parallelism. Early-exits the await loop on the first negative result.

**RAID1** overrides `uses_async_api()=true` and adds `handle_io_async` + `handle_iov_async`:

- **FLUSH**: delegates to existing `handle_flush`, returns synchronously (no child SQEs).
- **READ** (`__failover_read_async`): load-balancer picks primary device; starts one child `handle_iov_async` task; awaits result. On failure: marks unavail, retries on the other device. No recursive scheduling — single failover, returns `-EIO` on both failing.
- **WRITE**: `BackupMode` enum (SKIP / REPLICATE / OPTIMISTIC) encodes backup disposition in the coroutine frame, replacing the sub_cmd flag round-trip (`REPLICATE` / `INTERNAL` / `RETRIED`). Active and optional backup tasks start eagerly; each is awaited via `StartedTaskAwaitable`. `enqueue_write` / `dequeue_write` called inline after each await — no synthetic eventfd injection. Failures are handled inline: `dirty_region`, `__become_degraded`, `clean_region` called directly from the coroutine body.
- **DISCARD**: fans out to both replicas via `handle_discard` + `CqeAwaitable` per child; backup mode follows the same SKIP / REPLICATE logic as WRITE.

With both RAID0 and RAID1 returning `uses_async_api()=true`, RAID10 (RAID0 of RAID1 pairs) automatically migrates to the new coroutine path — no direct changes required.

The `_pending_results` / eventfd / `collect_async` injection path is fully bypassed for RAID1. `process_result` and the `CqeAwaiter` while-loop are retained for Phase 6 cleanup.

### What is unchanged

- RAID10 — no direct changes; inherits the new path via RAID0 and RAID1 both advertising `uses_async_api()=true`
- `async_iov`, `handle_flush`, `handle_discard` — kept as synchronous SQE-submission helpers
- `sync_iov`, `on_io_complete`, `collect_async`, `queue_internal_resp`, `process_result`, `CqeAwaiter` — retained for Phase 6 cleanup once all disk types are migrated
- `Raid1ResyncTask`, `__become_degraded`, `__capture_route_state`, `__route_to_device`, dirty bitmap operations — reused unchanged
- `sub_cmd_t` route bits — still used to key `async_io::ensure` so concurrent active/backup SQEs get distinct CqeStates; flag bits (`REPLICATE`, `INTERNAL`, `RETRIED`) are dead for RAID1's new path, replaced by local booleans

### Test plan
- [x] `test_raid1_async` — 11 new tests via `inject_cqe`: flush (sync), discard fan-out + sync completion, read (single device, failover, both-fail), write (both devices, degraded-skip, degraded-internal/OPTIMISTIC, active fails, replica fails, both fail)
- [x] All existing `test_raid0`, `test_raid0_async`, and `test_raid1` tests pass (Debug + ASAN/UBSan)