### PR TITLE
feat(iscsi): re-enable iSCSIDisk on the coroutine I/O model (#238)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -66,8 +66,9 @@ it like a standard-library type." Internal classes keep traditional `PascalCase`
 
 - **Public API types** (in `include/ublkpp/`): `lower_snake_case` for both classes and free
   functions; e.g. base class `ublk_disk`, alias `disk_handle`, factories `make_fs_disk`,
-  `make_raid0_disk`, `make_raid1_disk`, target `ublkpp_tgt`. Drivers and RAID arrays are
-  not exposed as classes; they are opaque `disk_handle`s constructed via factories.
+  `make_iscsi_disk`, `make_raid0_disk`, `make_raid1_disk`, target `ublkpp_tgt`. Drivers and
+  RAID arrays are **not** exposed as classes; they are opaque `disk_handle`s constructed via
+  factories.
 - **Internal classes** (in `src/`): `PascalCase`; e.g. `SuperBlock`, `Bitmap`, `Raid1Disk`
   (the impl behind `make_raid1_disk`), `MirrorDevice`, `Raid1ResyncTask`.
 - **Functions / methods:** `snake_case` everywhere (`async_iov`, `prepare`, `swap_device`).
@@ -83,7 +84,7 @@ it like a standard-library type." Internal classes keep traditional `PascalCase`
 
 **Logging:**
 - Use SISL macros: `RLOGW`, `DLOGE`, `TLOGD`, `TLOGE`, `LOGINFO`
-- Modules: `ublksrv`, `ublk_tgt`, `ublk_raid`, `ublk_drivers`
+- Modules: `ublksrv`, `ublk_tgt`, `ublk_raid`, `ublk_drivers`, `libiscsi`
 
 ## Development Workflow
 
@@ -136,14 +137,15 @@ it like a standard-library type." Internal classes keep traditional `PascalCase`
 **Core:** `sisl` v14+ (logging, options, metrics, HTTP server), `ublksrv`, `isa-l`
 **Test:** `gtest`, `fio`
 **Build:** Conan 2.0, CMake 3.x, C++23 (GCC 13+ or Clang 17+), clang-format
+**Optional:** `libiscsi` (iSCSI backend; `-o ublkpp/*:iscsi=True`)
 
 ## Project Structure
 
 ```
 src/
-├── driver/   # File-backed backend implementation
+├── driver/   # File-backed and libiscsi-backed disk implementations (behind make_*_disk)
 ├── lib/      # ublk_disk base, disk_task, cqe_state, utilities
-├── metrics/  # IO and RAID metrics
+├── metrics/  # IO, file-backed disk, RAID metrics
 ├── raid/     # RAID0, RAID1 (bitmap, superblock)
 └── target/   # ublkpp_tgt
 

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ logs/*
 *-verify.state
 
 scripts
+Testing

--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -27,6 +27,12 @@ pipeline {
             }
         }
 
+        stage('Prepare') {
+            steps {
+                sh "bash prepare_v2.sh"
+            }
+        }
+
         stage("Pre-flight") {
             steps {
                 script {
@@ -44,9 +50,6 @@ pipeline {
                     slackSend color: '#9B59B6', channel: "${SLACK_THREAD}", message: "⛽ *${PROJECT}* `${BRANCH_NAME}` build #${BUILD_NUMBER} \nAll systems Go...going somewhere anyways...\nLet's light this 🕯️... 3... 2... 1...!"
                 }
                 sh "conan create -s:h build_type=Debug ${CONAN_FLAGS} ."
-                script {
-                    slackSend color: '#E67E22', channel: "${SLACK_THREAD}", message: "🧑‍🚀 *${PROJECT}* `${BRANCH_NAME}`\n*Debug: green.* One more build between us and home.\nI've been in here long enough to start naming the compiler warnings. Don't ask.\nRelWithDebInfo... *please don't fail me now.*"
-                }
                 sh "conan create -s:h build_type=RelWithDebInfo -o sisl/*:malloc_impl=tcmalloc ${CONAN_FLAGS} ."
             }
         }
@@ -77,7 +80,7 @@ pipeline {
             }
         }
         success {
-            slackSend color: '#85B717', channel: "${SLACK_THREAD}", replyBroadcast: true, message: "✅ *${PROJECT}* `${VER}` (`${BRANCH_NAME}`) build #${BUILD_NUMBER} — it actually worked\nDebug + RelWithDebInfo both green in _${currentBuild.durationString}_\n<${BUILD_URL}|Full report>\n🍾 Mission successful!"
+            slackSend color: '#85B717', channel: "${SLACK_THREAD}", replyBroadcast: true, message: "🧑‍🚀 *${PROJECT}* `${VER}` (`${BRANCH_NAME}`) build #${BUILD_NUMBER} — it actually worked\nEveryone survived after _${currentBuild.durationString}_\n<${BUILD_URL}|Full report>\n🍾 Mission successful!"
         }
     }
 }

--- a/3rd_party/libiscsi/conandata.yml
+++ b/3rd_party/libiscsi/conandata.yml
@@ -1,0 +1,7 @@
+sources:
+  "1.20.2":
+    url: "https://github.com/sahlberg/libiscsi/archive/refs/tags/1.20.2.tar.gz"
+    sha256: "2b2a773ea0d3a708c1cafe61bbee780325fb1aafec6477f17d3f403e8732c9bf"
+  "1.20.3":
+    url: "https://github.com/sahlberg/libiscsi/archive/refs/tags/1.20.3.tar.gz"
+    sha256: "212f6e1fd8e7ddb4b02208aafc6de600f6f330f40359babeefdd83b0c79d47a1"

--- a/3rd_party/libiscsi/conanfile.py
+++ b/3rd_party/libiscsi/conanfile.py
@@ -1,0 +1,97 @@
+from conan import ConanFile
+from conan.tools.gnu import Autotools, AutotoolsToolchain, AutotoolsDeps
+from conan.tools.files import apply_conandata_patches, export_conandata_patches, get, replace_in_file
+from os.path import join
+
+required_conan_version = ">=1.60.0"
+
+class LibIScsiConan(ConanFile):
+    name = "libiscsi"
+    description = "Data Plane Development Kit"
+    url = "https://github.com/sahlberg/libiscsi"
+    homepage = "https://github.com/sahlberg/libiscsi"
+    license = "BSD-3"
+    exports = ["LICENSE"]
+    settings = "os", "compiler", "build_type", "arch"
+    options = {
+        "shared": ['True', 'False'],
+        "fPIC": ['True', 'False'],
+        "md5_provider": ['False', 'libgcrypt', 'gnutls'],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+        "md5_provider": 'False',
+    }
+
+    def requirements(self):
+        if self.options.md5_provider == 'gnutls':
+            self.requires("gnutls/3.8.7")
+        elif self.options.md5_provider == 'libgcrypt':
+            self.requires("libgcrypt/1.10.3")
+
+    def configure(self):
+        del self.settings.compiler.libcxx
+
+    def export_sources(self):
+        export_conandata_patches(self)
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        tc = AutotoolsToolchain(self)
+        e = tc.environment()
+        e.append("CFLAGS", "-Wno-unused-but-set-variable")
+
+        # clang-18 promotes two warnings that libiscsi 1.20.3's -Werror catches but gcc lets pass:
+        #   scsi-lowlevel.c:1244 cast through uint8_t* raises alignment 1->2 (-Wcast-align)
+        #   socket.c:170         iscsi_decrement_iface_rr() K&R-style void decl (-Wstrict-prototypes)
+        # Both are upstream code-quality nits, not real bugs; demote to warnings for clang only.
+        if self.settings.compiler == "clang":
+            e.append("CFLAGS", "-Wno-error=cast-align")
+            e.append("CFLAGS", "-Wno-error=strict-prototypes")
+
+        # iSER (iSCSI over RDMA) is auto-detected purely from header presence in libiscsi's
+        # configure.ac — the AC_CACHE_CHECK does not link-test, so when /usr/include/infiniband
+        # exists the iser.o is built but ibv_*/rdma_* symbols are unresolved at link time.
+        # Override the autoconf cache so the check returns "no" and iser.c stays out.
+        e.define("libiscsi_cv_HAVE_LINUX_ISER", "no")
+
+        # MD5 backend: libiscsi's --with-{gnutls,libgcrypt} flags select which library
+        # provides MD5 for CHAP login. False uses libiscsi's built-in (NEED_MD5=yes).
+        if self.options.md5_provider == 'False':
+            tc.configure_args.append("--without-gnutls")
+            tc.configure_args.append("--without-libgcrypt")
+        elif self.options.md5_provider == 'gnutls':
+            tc.configure_args.append("--with-gnutls")
+            tc.configure_args.append("--without-libgcrypt")
+        elif self.options.md5_provider == 'libgcrypt':
+            tc.configure_args.append("--without-gnutls")
+            tc.configure_args.append("--with-libgcrypt")
+
+        if self.settings.build_type == "Debug":
+            tc.configure_args.append("--enable-debug")
+        tc.generate(e)
+
+        td = AutotoolsDeps(self)
+        td.generate()
+
+    def build(self):
+        apply_conandata_patches(self)
+        autotools = Autotools(self)
+        autotools.autoreconf()
+        autotools.configure()
+        autotools.make()
+
+    def package(self):
+        autotools = Autotools(self)
+        autotools.install(args=["DESTDIR={}".format(self.package_folder)])
+
+    def deploy(self):
+        pass
+
+    def package_info(self):
+        self.cpp_info.libs = [
+                              "iscsi",
+                              ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.31.0 feature: native iSCSI support with libiscsi
+
 ## 0.30.0 refactor: async coroutine I/O, public API 1.0.0 uplift, and RAID1 hardening
  - Async I/O (Phases 1-11):
    - cqe_state pool per queue; raw cqe_state* encoded directly in SQE user_data
@@ -19,27 +21,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - **Breaking**: removed `handle_rw`, `queue_tgt_io`, `handle_discard`, `sub_cmd_t`, and the `open_for_uring`/`handle_io_async`/`handle_iov_async` virtual surface -- replaced by `prepare` and `async_iov`
  - **Breaking**: updaetd sisl to v14.x which drops Folly and iomgr (in testing) dependencies.
 
-## 0.22.2
-- raid1: Fix `stop()` IDLE→STOPPING race - when the resync thread finishes naturally and
+## 0.22.x
+- raid1: Fix `stop()` IDLE->STOPPING race - when the resync thread finishes naturally and
   `stop()` is called before `join()`, the `IDLE+joinable` handler now returns `SUCCESS` instead
-  of `RETRY_WITH_SLEEP`, preventing an accidental `CAS(IDLE→STOPPING)` that left no thread to
+  of `RETRY_WITH_SLEEP`, preventing an accidental `CAS(IDLE->STOPPING)` that left no thread to
   clear the state; subsequent `launch()` call in `swap_device()` would spin forever.
-
-## 0.22.1
-- raid1: Fix dequeue/resume race - `_resync_state` and `_outstanding_writes` are now packed into a single `sisl::atomic_status_counter` so the counter decrement and PAUSE→ACTIVE transition are one indivisible CAS; `__resume()` is removed.
+- raid1: Fix dequeue/resume race - `_resync_state` and `_outstanding_writes` are now packed into a single `sisl::atomic_status_counter` so the counter decrement and PAUSE->ACTIVE transition are one indivisible CAS; `__resume()` is removed.
 - raid1: Fix enqueue/pause race - `enqueue_write()` now always calls `__pause()` on every enqueue, not only the first; previously a concurrent second enqueuer could skip `__pause()` while the first was still establishing it, allowing resync to overwrite an in-flight write with stale data
 - raid1: Replace GCC `__builtin_popcount`/`__builtin_clz`/`__builtin_ctz` with C++23 `std::popcount`/`std::countl_zero`/`std::countr_zero`
 - build: `libatomic` is now declared as a Conan system lib on Linux - propagated automatically to consumers, no downstream changes required
-
-## 0.22.0
 - raid1: Fix multi-queue idle probe race conditions - probes now start only when all queues are idle, mutex serializes concurrent launch/stop calls, `open_for_uring` counts queue threads for accurate `nr_hw_queues`
 - **Breaking**: `UblkDisk::open_for_uring` signature changed from `(int)` to `(ublksrv_queue const*, int)` - out-of-tree subclasses must update their override
-
-## 0.21.6
-- raid0: Fix stale alive_cmds in __distribute() corrupting the next I/O on the same thread after a failed multi-stride operation
-
-## 0.21.5
-- raid1: Only log in reference to Resync if it was actually running.
 
 ## 0.21.x
 - raid0: Fix stale alive_cmds in __distribute() corrupting the next I/O on the same thread after a failed multi-stride operation
@@ -106,7 +98,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - raid1: Reservation size is now dynamically calculated during init, prevents resize
 
 ## 0.15.x
-- Fix homeblock_disk linkage
 - Enable C++23 extensions
 - Replace usage of folly::Expected with std::expected
 
@@ -136,7 +127,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 0.11.x
 - raid1: Fix Bitmap bugs when representing > 4Gi
-- ublkpp_disk: Support for HomeBlkDisk type
 - raid1: Another resync_task termination fix
 - raid1: Fix resync_task termination
 - raid1: Resync task handles no-dirty pages
@@ -181,14 +171,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## 0.6.x
 - raid1: Do not re-write unchanged pages
 - raid1: Round-Robin reading
-- homeblk_disk: Disable by default
 - raid1: Calculate reserved area based on limits
 - ublkpp_tgt: Clear async_event before calling process_result
 - raid1: Bitmap words should be encoded as NETWORK byte order
 - raid1: Records dirty chunks to the BITMAP pages
 
 ## 0.5.x
-- homeblk_disk : introduced
 - raid1: more intelligent retry handling
 - ublkpp_tgt : fix narrowing conversion
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,12 @@ include_directories(BEFORE ${CMAKE_CURRENT_SOURCE_DIR}/include)
 find_package(sisl REQUIRED)
 find_package(ublksrv REQUIRED)
 find_package(isa-l REQUIRED)
+find_package(libiscsi QUIET)
 find_package(fio QUIET)
+
+if (libiscsi_FOUND)
+    add_compile_options(-DHAVE_ISCSI)
+endif()
 
 add_subdirectory (src)
 if ((DEFINED ENABLE_TESTS) AND (${ENABLE_TESTS}))

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 - **RAID1 Resilient Bitmap**: Memory-efficient dirty tracking (4 KiB page tracks 1 GiB data)
 - **Hot Device Replacement**: Swap devices in degraded RAID1 arrays without downtime
 - **Lock-Free I/O Path**: Read/write operations use lock-free algorithms (x86-64/ARM64)
-- **Factory-Based API**: File-backed disks and RAID compositions through supported factory functions
+- **Multiple Backends**: File-backed (`make_fs_disk`) and in-process iSCSI initiator (`make_iscsi_disk`, libiscsi-based)
 - **Coroutine I/O**: Single-event-loop, CQE-driven coroutine pipeline
 - **Comprehensive Testing**: High test coverage with unit and functional (fio-driven) tests
 - **Modern C++**: Built with C++23, leveraging `std::expected` for error handling
@@ -59,6 +59,9 @@ conan build -s:h build_type=Debug -o ublkpp/*:coverage=True --build missing .
 # With sanitizers (address or thread)
 conan build -s:h build_type=Debug -o ublkpp/*:sanitize=address --build missing .
 conan build -s:h build_type=Debug -o ublkpp/*:sanitize=thread --build missing .
+
+# Optional iSCSI backend (in-process libiscsi initiator; no kernel iSCSI module needed)
+conan build -o ublkpp/*:iscsi=True --build missing .
 ```
 
 ## 🏗️ Architecture
@@ -68,12 +71,12 @@ conan build -s:h build_type=Debug -o ublkpp/*:sanitize=thread --build missing .
 ```
 ublkpp/
 ├── include/ublkpp/       # Public headers
-│   ├── drivers.hpp       # File-backed disk factory
+│   ├── drivers.hpp       # make_fs_disk, make_iscsi_disk factories
 │   ├── raid.hpp          # RAID factories and helpers
 │   ├── target.hpp        # ublk target interface
 │   └── lib/              # Base disk subclassing API
 ├── src/
-│   ├── driver/           # File-backed backend implementation
+│   ├── driver/           # Backend implementations
 │   ├── lib/              # Core ublk_disk base classes
 │   ├── metrics/          # I/O and RAID metrics
 │   ├── raid/             # RAID logic (bitmap, superblock)
@@ -86,6 +89,7 @@ ublkpp/
 - **`ublk_disk`**: Base class for all block devices
 - **`disk_handle`**: Shared ownership handle for disks and RAID composites
 - **`make_fs_disk()`**: File/block-backed disk construction
+- **`make_iscsi_disk()`**: Factory for an in-process libiscsi-backed disk (optional, `-o ublkpp/*:iscsi=True`)
 - **`make_raid0_disk()` / `make_raid1_disk()`**: RAID composition factories
 - **`raid0::*` / `raid1::*`**: Free-function helpers for topology and mirror management
 - **`ublkpp_tgt`**: Exposes devices to kernel via ublk
@@ -164,6 +168,11 @@ sudo ublkpp_disk --raid10 file1.dat,file2.dat,file3.dat,file4.dat
 
 # Recover existing device
 sudo ublkpp_disk --device_id 0 --raid1 /dev/sde,/dev/sdf
+
+# iSCSI legs (libiscsi initiator, no kernel iSCSI module required)
+sudo ublkpp_disk --raid1 \
+    iscsi://user%password@10.0.0.1/iqn.2026-05.example:lun0/1,\
+    iscsi://user%password@10.0.0.2/iqn.2026-05.example:lun0/1
 ```
 
 ### Verify Device
@@ -191,18 +200,21 @@ $ sudo mount /dev/ublkb0 /mnt
 
 ### Naming Conventions
 
+The library uses a **two-tier convention** to telegraph the boundary between the stable
+public surface and internal implementation detail.
+
 | Element | Convention | Example |
 |---------|------------|---------|
 | **Public API types** (`include/ublkpp/`) | `lower_snake_case` | `ublk_disk`, `disk_handle`, `ublkpp_tgt` |
-| **Public API factories** (free functions) | `make_<thing>` | `make_fs_disk()`, `make_raid1_disk()` |
+| **Public API factories** (free functions) | `make_<thing>` | `make_fs_disk()`, `make_iscsi_disk()`, `make_raid1_disk()` |
 | **Internal classes** (`src/`) | `PascalCase` | `SuperBlock`, `Bitmap`, `Raid1Disk` (impl), `MirrorDevice` |
 | Functions / methods | `snake_case` | `async_iov()`, `prepare()`, `swap_device()` |
 | Members | `_snake_case` | `_device`, `_dirty_bitmap` |
 | Constants | `k_snake_case` | `k_page_size` |
 | Macros / Enums | `SCREAMING_SNAKE_CASE` | `UBLK_IO_OP_WRITE` |
 
-Driver and RAID array implementations are not part of the public surface; consumers construct
-opaque `disk_handle`s via `make_*_disk()` factories and compose them.
+Driver and RAID array implementations are **not** part of the public surface; consumers
+construct opaque `disk_handle`s via `make_*_disk()` factories and compose them.
 
 ### Workflow
 
@@ -297,6 +309,7 @@ TEST(Raid1, YourTestName) {
 
 - **[stdexec](https://github.com/NVIDIA/stdexec)**: C++ sender/receiver framework (fetched automatically via CMake FetchContent)
 - **fio**: Functional I/O testing (optional; tests skip gracefully if absent)
+- **[libiscsi](https://github.com/sahlberg/libiscsi)**: in-process iSCSI initiator. Enables the `make_iscsi_disk()` driver, which speaks SCSI/iSCSI directly from the queue thread via io_uring `POLL_ADD`, removing the need for a host kernel iSCSI module or `/etc/iscsi` state. Enable with `-o ublkpp/*:iscsi=True`.
 
 ### Build Tools
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -10,7 +10,7 @@ required_conan_version = ">=2.0"
 
 class UBlkPPConan(ConanFile):
     name = "ublkpp"
-    version = "0.30.0"
+    version = "0.31.0"
 
     homepage = "https://github.com/szmyd/ublkpp"
     description = "A UBlk library for CPP application"
@@ -25,12 +25,14 @@ class UBlkPPConan(ConanFile):
                 "fPIC": ['True', 'False'],
                 "coverage": ['True', 'False'],
                 "sanitize": ['address', 'thread', 'False'],
+                "iscsi": ['True', 'False'],
                 }
     default_options = {
                 'shared': False,
                 'fPIC': True,
                 'coverage': False,
                 'sanitize': False,
+                'iscsi': True,
             }
 
     exports_sources = (
@@ -72,6 +74,8 @@ class UBlkPPConan(ConanFile):
 
         self.requires("isa-l/2.30.0")
         self.requires("ublksrv/nbi.1.5.0.1", transitive_headers=True)
+        if self.options.get_safe("iscsi"):
+            self.requires("libiscsi/1.20.3")
 
     def layout(self):
         self.folders.source = "."
@@ -127,7 +131,11 @@ class UBlkPPConan(ConanFile):
         cmake.configure()
         cmake.build()
         if not self.conf.get("tools.build:skip_test", default=False):
-            self.run(f"ctest --test-dir '{self.build_folder}' --output-on-failure")
+            # Unit tests: quiet on success.
+            self.run(f"ctest --test-dir '{self.build_folder}' -LE Functional --output-on-failure")
+            # Functional tests (fio-driven): always surface stdout so the per-job stats block is
+            # visible. The engine .so defaults to log level 'warn' so fio's stats aren't swamped.
+            self.run(f"ctest --test-dir '{self.build_folder}' -L Functional --verbose")
 
     def package(self):
         copy(self, "LICENSE", self.source_folder, join(self.package_folder, "licenses"), keep_path=False)
@@ -139,6 +147,9 @@ class UBlkPPConan(ConanFile):
         self.cpp_info.requires = ["sisl::cache", "isa-l::isa-l", "ublksrv::ublksrv"]
         if self.settings.os == "Linux":
             self.cpp_info.system_libs = ["atomic"]
+        if (self.options.get_safe("iscsi")):
+            self.cpp_info.requires.extend(["libiscsi::libiscsi"])
+            self.cpp_info.defines.append("HAVE_ISCSI")
         if self.options.get_safe("sanitize") and self.options.sanitize != "False":
             if self.options.sanitize == "thread":
                 self.cpp_info.sharedlinkflags.append("-fsanitize=thread")

--- a/docs/functional_testing.md
+++ b/docs/functional_testing.md
@@ -14,12 +14,12 @@ fio job file
 libublkpp_fio_engine.so          (custom fio external engine)
      │  disk_type / disk_files / raid_chunk_size options
      ▼
-disk_handle ───────────────► make_fs_disk / make_raid0_disk / make_raid1_disk
-     │
-     ▼
-MockUblksrv
-(io_uring SQE/CQE loop)
-     │
+ublk_disk  ─────────────────────► make_fs_disk / make_iscsi_disk / make_raid0_disk / make_raid1_disk
+     │                               │           │
+     ▼                               │           │
+MockUblksrv                          │           │
+(io_uring SQE/CQE loop)              │           │
+     │                               ▼           ▼
      └──────────────────────► backing image files (*.img)
                                   (regular files on disk)
 ```
@@ -41,7 +41,9 @@ src/tests/fio_engine/
     ├── raid1_rw.fio        # RAID1 write-verify
     ├── raid10_rw.fio       # RAID10 write-verify
     ├── raid0_cross_stripe.fio   # RAID0 cross-stripe boundary (bs=96k)
-    └── raid10_cross_stripe.fio  # RAID10 cross-stripe boundary (bs=96k)
+    ├── raid10_cross_stripe.fio  # RAID10 cross-stripe boundary (bs=96k)
+    ├── iscsi_rw.fio             # Single-LUN iSCSI write-verify
+    └── iscsi_raid10_rw.fio      # RAID10 over four iSCSI LUNs (cross-stripe)
 ```
 
 Backing images land in `<build_dir>/src/tests/fio_engine/test_data/`.
@@ -88,12 +90,14 @@ ctest --test-dir build/Debug -L Functional -j4 --output-on-failure
 
 | CTest name | Job file | Topology | bs | Size | What it exercises |
 |---|---|---|---|---|---|
-| `FunctionalFSDisk` | `fsdisk_rw.fio` | File-backed disk (1 file) | 4k–64k | 64 MiB | Baseline I/O, single-device path |
+| `FunctionalFSDisk` | `fsdisk_rw.fio` | File-backed (1 file) | 4k–64k | 64 MiB | Baseline I/O, single-device path |
 | `FunctionalRAID0` | `raid0_rw.fio` | RAID0 (2 files) | 4k–64k | 64 MiB | Stripe distribution, chunk alignment |
 | `FunctionalRAID1` | `raid1_rw.fio` | RAID1 (2 files) | 4k–64k | 64 MiB | Mirror replication, bitmap tracking |
 | `FunctionalRAID10` | `raid10_rw.fio` | RAID10 (4 files) | 4k–64k | 64 MiB | Full RAID10 stack (stripe + mirror) |
 | `FunctionalRAID0CrossStripe` | `raid0_cross_stripe.fio` | RAID0 (2 files) | 96k fixed | 96 MiB | Cross-stripe splitting, iovec accumulation |
 | `FunctionalRAID10CrossStripe` | `raid10_cross_stripe.fio` | RAID10 (4 files) | 96k fixed | 96 MiB | Cross-stripe through RAID0 + RAID1 layers |
+| `FunctionalISCSI` | `iscsi_rw.fio` | iSCSI (1 LUN) | 4k–64k | 32 MiB | Single-LUN iSCSI write-verify via libiscsi |
+| `FunctionalISCSIRAID10` | `iscsi_raid10_rw.fio` | RAID10 over 4 iSCSI LUNs | 96k fixed | 96 MiB | RAID10 cross-stripe through libiscsi async path |
 
 ### Cross-stripe tests explained
 
@@ -119,11 +123,13 @@ each mirror pair.
 1. Parses the custom fio options (`disk_type`, `disk_files`, `raid_chunk_size`).
 2. Pre-allocates backing files via `posix_fallocate` (falls back to `ftruncate` on tmpfs).
 3. Constructs the requested disk type:
-   - **`fsdisk`** — `make_fs_disk(path)`
-   - **`raid0`** — `make_raid0_disk(uuid, chunk_size, [make_fs_disk(...)...])`
-   - **`raid1`** — `make_raid1_disk(uuid, make_fs_disk(a), make_fs_disk(b))`
-   - **`raid10`** — `make_raid0_disk(uuid, chunk_size, [raid1_pair_a, raid1_pair_b])` (two RAID1 pairs
-     striped together)
+   - **`fsdisk`**: `make_fs_disk(path)`
+   - **`iscsi`**: `make_iscsi_disk(url)` (libiscsi initiator; URL form
+     `iscsi://[user%password@]host[:port]/iqn/lun`)
+   - **`raid0`**: `make_raid0_disk(uuid, chunk_size, [legs...])`
+   - **`raid1`**: `make_raid1_disk(uuid, leg_a, leg_b)`
+   - **`raid10`**: `make_raid0_disk(uuid, chunk_size, [raid1_pair_a, raid1_pair_b])` (two RAID1
+     pairs striped together; legs may be file-backed or iSCSI)
 4. Wraps the disk in `MockUblksrv` (io_uring SQE/CQE loop, no kernel module).
 5. Allocates a tag array (size = `iodepth`) for in-flight I/O tracking.
 
@@ -134,8 +140,9 @@ namespace), so the superblock check passes across fio job sections that reopen t
 
 | Option | Type | Default | Description |
 |---|---|---|---|
-| `disk_type` | string | `fsdisk` | Disk topology: `fsdisk`, `raid0`, `raid1`, `raid10` |
-| `disk_files` | string | *(required)* | Colon-separated backing file paths |
+| `disk_type` | string | `fsdisk` | Disk topology: `fsdisk`, `iscsi`, `raid0`, `raid1`, `raid10` |
+| `disk_files` | string | *(one of)* | Colon-separated backing file paths (file-backed legs) |
+| `disk_url` | string | *(one of)* | Pipe-separated iSCSI URLs (iSCSI legs) |
 | `raid_chunk_size` | int | `32768` | RAID chunk size in bytes |
 
 ### Environment variables (set by CMake)
@@ -143,7 +150,7 @@ namespace), so the superblock check passes across fio job sections that reopen t
 | Variable | Used by |
 |---|---|
 | `ENGINE_SO` | Passed as `ioengine=external:${ENGINE_SO}` in job files |
-| `TEST_FILE` | Single file-backed disk path |
+| `TEST_FILE` | File-backed disk single backing path |
 | `TEST_FILE_A` … `TEST_FILE_D` | RAID backing paths (A/B for RAID0/1, A–D for RAID10) |
 | `ASAN_OPTIONS=verify_asan_link_order=0` | ASan builds only — suppresses link-order warning |
 | `LD_PRELOAD=<engine.so>` | Release/tcmalloc builds — works around static TLS block exhaustion |
@@ -270,9 +277,50 @@ above.
 | `FunctionalRAID10` | 180 s |
 | `FunctionalRAID0CrossStripe` | 180 s |
 | `FunctionalRAID10CrossStripe` | 180 s |
+| `FunctionalISCSI` | 120 s |
+| `FunctionalISCSIRAID10` | 180 s |
 
 RAID1 and RAID10 are slower because every write is replicated to both mirror members and the
 dirty bitmap is updated.
+
+---
+
+## iSCSI Functional Tests
+
+The `FunctionalISCSI*` tests require a running iSCSI target on `127.0.0.1:13260` exporting at
+least four LUNs under `iqn.2026-05.test.ublkpp:lun0`. CTest brings the target up and tears it
+down automatically via the `iscsi_target` fixture, which wraps
+[`src/driver/tests/iscsi_tgtd_setup.sh`](../src/driver/tests/iscsi_tgtd_setup.sh) (`tgtd start`
+/ `tgtd stop`).
+
+### Soft-skip behavior
+
+The setup script exits 0 (allowing the fixture to "succeed") and the C++ tests probe the port
+at runtime, calling `GTEST_SKIP()` if the target is unreachable. So a missing `tgtd`/`tgtadm`,
+a port already squatted by something other than `tgtd`, or an inaccessible `/var/run/tgtd`
+all surface as **Skipped** (green) rather than failing the suite. CI runs with `tgtd`
+preinstalled; local dev boxes without it just skip.
+
+### Local setup
+
+`tgtd` writes its per-port lock under `/var/run/tgtd/`. The directory must be writable by
+the test runner. Three options:
+
+1. Run as root.
+2. One-shot (lost on reboot, since `/var/run` is tmpfs):
+   ```bash
+   sudo mkdir -p /var/run/tgtd && sudo chown $USER /var/run/tgtd
+   ```
+3. Persistent (survives reboot):
+   ```bash
+   echo 'd /var/run/tgtd 0755 $USER $USER -' | sudo tee /etc/tmpfiles.d/tgtd.conf
+   sudo systemd-tmpfiles --create /etc/tmpfiles.d/tgtd.conf
+   ```
+
+Override the port (`ISCSI_TEST_PORT`, default 13260), control port
+(`ISCSI_TEST_CTRL_PORT`, default 13261), state directory (`ISCSI_TEST_STATE`, default
+`/tmp/ublkpp_iscsi_test`), or LUN count (`ISCSI_TEST_LUN_COUNT`, default 4) via env vars
+if those defaults clash on your machine.
 
 ---
 

--- a/example/ublkpp_disk.cpp
+++ b/example/ublkpp_disk.cpp
@@ -61,7 +61,17 @@ static std::shared_ptr< ublkpp::ublk_disk > get_driver(std::string const& resour
     if (auto path = std::filesystem::path(resource); std::filesystem::exists(path)) {
         return ublkpp::make_fs_disk(path, metrics_id);
     }
-    return ublkpp::make_missing_disk();
+#ifdef HAVE_ISCSI
+    // From libiscsi.h iSCSI URLs are in the form:
+    //   iscsi://[<username>[%<password>]@]<host>[:<port>]/<target-iqn>/<lun>
+    try {
+        return ublkpp::make_iscsi_disk(resource);
+    } catch (std::exception const&) {
+#endif
+        return ublkpp::make_missing_disk();
+#ifdef HAVE_ISCSI
+    }
+#endif
 }
 
 Result create_loop(boost::uuids::uuid const& id, std::string const& path) {
@@ -97,7 +107,7 @@ Result create_raid1(boost::uuids::uuid const& id, std::vector< std::string > con
     auto raid_uuid = boost::uuids::to_string(id);
 
     try {
-        // Create file-backed devices with RAID1 UUID for correlation
+        // Create FSDisk devices with RAID1 UUID for correlation
         auto dev_a = get_driver(*layout.begin(), raid_uuid);
         auto dev_b = get_driver(*(layout.begin() + 1), raid_uuid);
 

--- a/include/ublkpp/drivers.hpp
+++ b/include/ublkpp/drivers.hpp
@@ -14,4 +14,13 @@ using disk_handle = std::shared_ptr< ublk_disk >;
 // Throws std::runtime_error on open / fstat / ioctl probe failure.
 disk_handle make_fs_disk(std::filesystem::path const& path, std::string const& parent_id = "");
 
+#ifdef HAVE_ISCSI
+// Construct an iSCSI-backed disk from a libiscsi-style URL:
+//   iscsi://[<user>[%<pwd>]@]<host>[:<port>]/<target-iqn>/<lun>
+// `parent_id` is woven into the metrics labels; pass empty if metrics correlation is not needed.
+// Throws std::runtime_error on URL parse / login / readcapacity failure.
+// Only declared when ublkpp is built with iscsi=True (HAVE_ISCSI propagated via Conan defines).
+disk_handle make_iscsi_disk(std::string const& url, std::string const& parent_id = "");
+#endif
+
 } // namespace ublkpp

--- a/include/ublkpp/lib/cqe_state.hpp
+++ b/include/ublkpp/lib/cqe_state.hpp
@@ -35,9 +35,9 @@ namespace ublkpp {
 //   - Per-IO (build_cqe_state_data path): allocated in async_io::_pool, owned
 //     by the IO slot, _owner non-null so the loop can call ublksrv_complete_io
 //     with -EIO if the coroutine throws.
-//   - Stand-alone service loops: coroutine-frame-local, _owner = nullptr, and
-//     callers handle their own errors. Encode the user_data manually with
-//     `reinterpret_cast<uint64_t>(state) | k_target_bit`.
+//   - Stand-alone (e.g. iSCSIDisk POLL_ADD service loop): coroutine-frame-local,
+//     _owner = nullptr, callers handle their own errors. Encode the user_data
+//     manually with `reinterpret_cast<uint64_t>(state) | k_target_bit`.
 //
 // Reference implementation: src/driver/fs_disk.cpp.
 // =============================================================================
@@ -76,7 +76,7 @@ struct async_io {
 //
 // _owner is nullable: per-IO cqe_states (build_cqe_state_data path) point at the slot's
 // async_io so an exception on resume can be reported via ublksrv_complete_io. Stand-alone
-// cqe_states set _owner = nullptr; callers handle their own errors.
+// cqe_states (long-lived service loops) set _owner = nullptr; callers handle their own errors.
 struct cqe_state {
     async_io* _owner{nullptr};
     int _result{0};

--- a/include/ublkpp/target.hpp
+++ b/include/ublkpp/target.hpp
@@ -9,7 +9,13 @@
 
 // Convenience module list for SISL_LOGGING_INIT. Append the consumer's own
 // modules after this list.
+// `libiscsi` is folded in automatically when HAVE_ISCSI is set (propagated via the
+// Conan package's cpp_info.defines).
+#ifdef HAVE_ISCSI
+#define UBLKPP_LOG_MODS ublk_tgt, ublk_raid, ublk_drivers, libiscsi
+#else
 #define UBLKPP_LOG_MODS ublk_tgt, ublk_raid, ublk_drivers
+#endif
 
 namespace ublkpp {
 

--- a/prepare_v2.sh
+++ b/prepare_v2.sh
@@ -3,6 +3,7 @@ set -eu
 echo -n "Exporting custom recipes..."
 echo -n "ublksrv..."
 conan export 3rd_party/ublksrv --version nbi.1.5.0.1 >/dev/null
+conan export 3rd_party/libiscsi --version 1.20.3 >/dev/null
 echo -n "fio..."
 conan export 3rd_party/fio --version nbi.3.28 >/dev/null
 echo "done."

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,6 +14,7 @@ list(APPEND LIBRARY_OBJECTS
   $<TARGET_OBJECTS:raid0>
   $<TARGET_OBJECTS:raid1>
   $<TARGET_OBJECTS:fs_disk>
+  $<TARGET_OBJECTS:iscsi_disk>
   $<TARGET_OBJECTS:ublkpp_tgt>
   $<TARGET_OBJECTS:ublk_disk>
   $<TARGET_OBJECTS:ublk_metrics>
@@ -24,6 +25,11 @@ list(APPEND LIBRARY_LINKS
     ublksrv::ublksrv
     STDEXEC::stdexec
   )
+if(${libiscsi_FOUND})
+list(APPEND LIBRARY_LINKS
+    libiscsi::libiscsi
+)
+endif()
 
 add_library(ublkpp)
 target_sources(ublkpp PRIVATE

--- a/src/driver/CMakeLists.txt
+++ b/src/driver/CMakeLists.txt
@@ -9,6 +9,19 @@ target_link_libraries(fs_disk
     ublksrv::ublksrv
 )
 
+if(${libiscsi_FOUND})
+    add_library(iscsi_disk OBJECT)
+    target_sources(iscsi_disk PRIVATE
+        iscsi_disk.cpp
+    )
+    target_link_libraries(iscsi_disk
+        sisl::cache
+        ublksrv::ublksrv
+        STDEXEC::stdexec
+        libiscsi::libiscsi
+    )
+endif()
+
 
 include_directories(BEFORE ${CMAKE_CURRENT_SOURCE_DIR})
 

--- a/src/driver/iscsi_disk.cpp
+++ b/src/driver/iscsi_disk.cpp
@@ -1,0 +1,654 @@
+#include "ublkpp/drivers.hpp"
+
+#include <coroutine>
+#include <memory>
+#include <mutex>
+#include <vector>
+
+#include <ublkpp/lib/ublk_disk.hpp>
+
+#include <sisl/logging/logging.h>
+#include <sisl/options/options.h>
+#include <ublksrv.h>
+
+extern "C" {
+#include <iscsi/iscsi.h>
+#include <iscsi/scsi-lowlevel.h>
+#include <poll.h>
+#include <sys/eventfd.h>
+#include <unistd.h>
+}
+
+#include <ublkpp/lib/cqe_state.hpp>
+#include <ublkpp/lib/disk_task.hpp>
+
+#include "lib/common.hpp"
+#include "lib/logging.hpp"
+
+SISL_LOGGING_DEF(libiscsi)
+
+namespace ublkpp {
+
+/// TODO Should be discoverable from Inquiry Pages
+constexpr auto k_physical_block_size = 4 * Ki;
+
+struct iscsi_session {
+    ~iscsi_session() {
+        if (url) iscsi_destroy_url(url);
+        if (ctx) {
+            // Skip logout on a dead ctx: target is unreachable so the LOGOUT PDU would block
+            // the destructor on libiscsi's internal poll loop until scsi_timeout (or forever).
+            if (!dead) iscsi_logout_sync(ctx);
+            iscsi_destroy_context(ctx);
+        }
+    }
+
+    iscsi_context* ctx{nullptr};
+    iscsi_url* url{nullptr};
+    // Set to true after a sync iSCSI op fails with the underlying ctx in deferred-reconnect
+    // state (max_retries=0 + first failure cancels all PDUs and freezes the ctx). The next
+    // sync_iov call observes this and tears down + rebuilds the ctx via iscsi_full_connect_sync
+    // before retrying.
+    bool dead{false};
+};
+
+// Per-queue async service: owns one libiscsi context, an eventfd used to wake the service-loop
+// coroutine when async_iov queues new work, the cqe_state the loop awaits on, and the suspended
+// coroutine handle itself.
+//
+// Lifetime: created lazily in iSCSIDisk::prepare(q) on the queue thread, destroyed by the
+// iSCSIDisk destructor (which runs after queue threads have joined). Destroying the suspended
+// coroutine_handle frees the frame; iscsi_logout_sync drives its own internal poll loop and
+// does not depend on the service loop coroutine.
+// Session-loss state machine.
+//   alive       -> normal operation; service loop polls libiscsi socket fd.
+//   dead        -> iscsi_service returned -1 (max_retries=0 + first reconnect failure cancelled
+//                  all in-flight PDUs and set reconnect_deferred). ctx is permanently unusable;
+//                  service loop suspends on evfd waiting for a recovery trigger.
+//   rebuilding  -> recovery requested. Service loop will (next iteration) destroy the dead ctx,
+//                  create a fresh one, and call iscsi_full_connect_async. Login completion fires
+//                  rebuild_login_cb which transitions to alive (success) or back to dead (fail).
+//
+// All transitions happen on the queue thread. Cross-thread (sync_iov on resync/probe thread)
+// triggers recovery only by writing to evfd; the queue's service loop interprets that wake as
+// "advance dead -> rebuilding". No atomic needed.
+enum class qs_state_t { alive, dead, rebuilding };
+
+struct queue_service {
+    iscsi_context* ctx{nullptr};
+    int evfd{-1};
+    cqe_state poll_state{};
+    std::coroutine_handle<> service_handle{};
+    // Set by the service loop before each suspend; read by async_iov to decide whether the
+    // eventfd write is needed. When the loop is suspended on the libiscsi socket fd, a freshly
+    // submitted PDU's response will wake it via POLLIN naturally -- no evfd kick required.
+    // Plain bool: async_iov and the service loop body both run on the queue thread, never
+    // concurrently (coroutines on a single thread), so no atomicity needed.
+    bool waiting_on_evfd{false};
+
+    qs_state_t state{qs_state_t::alive};
+    // True between the service loop calling iscsi_full_connect_async and rebuild_login_cb firing.
+    // Prevents the loop from re-kicking another rebuild while one is in flight.
+    bool rebuild_kicked_off{false};
+
+    // Captured at prepare() time; needed during rebuild because the dead ctx (which sourced these)
+    // is destroyed before the new ctx is built. Owned strings, lifetime = queue_service lifetime.
+    std::string portal;
+    std::string target;
+    int lun{0};
+
+    queue_service() = default;
+    queue_service(queue_service const&) = delete;
+    queue_service& operator=(queue_service const&) = delete;
+
+    ~queue_service() {
+        // Destroy the suspended service-loop frame first; safe because per-IO are already drained
+        // (umount-gated del_dev) and the kernel silently cancels the in-flight POLL_ADD when the
+        // io_uring is torn down by ublksrv_queue_deinit before this destructor runs.
+        if (service_handle) service_handle.destroy();
+        if (ctx) {
+            // Skip logout if ctx is dead/rebuilding: socket is gone or still connecting, the
+            // LOGOUT PDU would block on libiscsi's internal poll until scsi_timeout (or never).
+            if (state == qs_state_t::alive) iscsi_logout_sync(ctx);
+            iscsi_destroy_context(ctx);
+        }
+        if (evfd >= 0) close(evfd);
+    }
+};
+
+// libiscsi level scheme (per its public iscsi.h):
+//   0 disabled, 1 errors only, 2 connection info, 3 user vars, 4+ function calls
+// Level 1 surfaces SCSI sense returns including benign UNIT_ATTENTION/BUS_RESET
+// (asserted by every target on session establishment); treat as WARN, not ERROR.
+// Real fatal errors are reported separately via iscsi_get_error() at our call sites.
+static void iscsi_log(int level, const char* message) {
+    if (1 >= level) {
+        LOGWARNMOD(libiscsi, "{}", message);
+    } else if (2 == level) {
+        LOGINFOMOD(libiscsi, "{}", message);
+    } else if (3 == level) {
+        LOGDEBUGMOD(libiscsi, "{}", message);
+    } else {
+        LOGTRACEMOD(libiscsi, "{}", message);
+    }
+}
+
+static std::unique_ptr< iscsi_session > create_iscsi_session(std::string const& url) {
+    auto session = std::make_unique< iscsi_session >();
+    DEBUG_ASSERT(session, "Failed to allocate iSCSI session!");
+
+    if (session->ctx = iscsi_create_context("iqn.2002-10.com.ublkpp:client"); !session->ctx) {
+        DLOGE("failed to init context")
+        return nullptr;
+    }
+    iscsi_set_log_level(session->ctx, (spdlog::level::level_enum::critical - module_level_ublk_drivers) * 2);
+    iscsi_set_log_fn(session->ctx, iscsi_log);
+
+    if (iscsi_set_alias(session->ctx, "ublkpp")) return nullptr;
+
+    session->url = iscsi_parse_full_url(session->ctx, url.data());
+    if (!session->url) {
+        DLOGE("{}", iscsi_get_error(session->ctx))
+        return nullptr;
+    }
+
+    return session;
+}
+
+// max_retries=0 makes libiscsi treat the first reconnect failure as terminal: it cancels every
+// in-flight PDU (callbacks fire with SCSI_STATUS_CANCELLED) and marks the ctx reconnect_deferred,
+// so iscsi_service returns -1 from then on. Recovery is then our job (destroy + recreate ctx);
+// see queue_service / __service_loop. Without this, libiscsi auto-replays PDUs on reconnect,
+// which is unsafe when the caller (RAID1) is also retrying.
+static constexpr int k_iscsi_reconnect_max_retries = 0;
+
+static bool iscsi_login(iscsi_session& session) {
+    iscsi_set_session_type(session.ctx, ISCSI_SESSION_NORMAL);
+    iscsi_set_header_digest(session.ctx, ISCSI_HEADER_DIGEST_NONE);
+    iscsi_set_targetname(session.ctx, session.url->target);
+    iscsi_set_reconnect_max_retries(session.ctx, k_iscsi_reconnect_max_retries);
+
+    if (0 != iscsi_full_connect_sync(session.ctx, session.url->portal, session.url->lun)) {
+        DLOGE("{}", iscsi_get_error(session.ctx))
+        return false;
+    }
+    return (0 != iscsi_is_logged_in(session.ctx));
+}
+
+// Configure a freshly-created per-queue iscsi_context. Used by both prepare() (sync login path)
+// and the async rebuild path inside the service loop. Throws on alias-set failure since the
+// caller treats per-queue setup as fatal.
+static void setup_qs_ctx(iscsi_context* ctx, char const* target) {
+    iscsi_set_log_level(ctx, (spdlog::level::level_enum::critical - module_level_ublk_drivers) * 2);
+    iscsi_set_log_fn(ctx, iscsi_log);
+    if (iscsi_set_alias(ctx, "ublkpp")) throw std::runtime_error("Failed to set per-queue iSCSI alias");
+    iscsi_set_session_type(ctx, ISCSI_SESSION_NORMAL);
+    iscsi_set_header_digest(ctx, ISCSI_HEADER_DIGEST_NONE);
+    iscsi_set_targetname(ctx, target);
+    iscsi_set_reconnect_max_retries(ctx, k_iscsi_reconnect_max_retries);
+}
+
+// iscsi_full_connect_async completion callback used by the rebuild path. Runs synchronously
+// inside iscsi_service() on the queue thread (same thread as the service loop), so direct
+// state mutation is safe -- no atomics needed.
+static void __rebuild_login_cb(iscsi_context* ctx, int status, void* /*data*/, void* private_data) {
+    auto qs = reinterpret_cast< queue_service* >(private_data);
+    qs->rebuild_kicked_off = false;
+    if (SCSI_STATUS_GOOD == status) {
+        qs->state = qs_state_t::alive;
+        DLOGD("iSCSI session rebuild complete")
+    } else {
+        qs->state = qs_state_t::dead;
+        DLOGW("iSCSI session rebuild failed: {}", iscsi_get_error(ctx))
+    }
+}
+
+// Tear down a dead sync ctx and rebuild it via iscsi_full_connect_sync. Caller must hold
+// _sync_mutex. Returns true on success; on failure, session.ctx is left null and session.dead
+// stays true so the next sync_iov retries.
+static bool rebuild_sync_session(iscsi_session& session) {
+    DLOGD("Rebuilding sync iSCSI session for target {}", session.url->target)
+    if (session.ctx) {
+        // Skip logout: ctx is in deferred-reconnect state, LOGOUT PDU would hang.
+        iscsi_destroy_context(session.ctx);
+        session.ctx = nullptr;
+    }
+    session.ctx = iscsi_create_context("iqn.2002-10.com.ublkpp:client");
+    if (!session.ctx) {
+        DLOGE("Sync session rebuild: failed to allocate context")
+        return false;
+    }
+    iscsi_set_log_level(session.ctx, (spdlog::level::level_enum::critical - module_level_ublk_drivers) * 2);
+    iscsi_set_log_fn(session.ctx, iscsi_log);
+    if (iscsi_set_alias(session.ctx, "ublkpp")) {
+        DLOGE("Sync session rebuild: failed to set alias")
+        iscsi_destroy_context(session.ctx);
+        session.ctx = nullptr;
+        return false;
+    }
+    if (!iscsi_login(session)) {
+        // iscsi_login already logged the error
+        iscsi_destroy_context(session.ctx);
+        session.ctx = nullptr;
+        return false;
+    }
+    session.dead = false;
+    return true;
+}
+
+static std::pair< uint64_t, uint32_t > probe_topology(iscsi_session& session) {
+    auto task = iscsi_readcapacity16_sync(session.ctx, session.url->lun);
+    if (!task || task->status != SCSI_STATUS_GOOD) {
+        DLOGE("Failed to send readcapacity16 command");
+        if (task) { scsi_free_scsi_task(task); }
+        return std::make_pair(0UL, 0U);
+    }
+
+    uint64_t capacity{0UL};
+    uint32_t block_size{0U};
+    if (auto rc16 = static_cast< scsi_readcapacity16* >(scsi_datain_unmarshall(task)); rc16) {
+        capacity = rc16->block_length * (rc16->returned_lba + 1);
+        block_size = rc16->block_length;
+        DLOGD("Logged into LUN with [sz:{}|bs:{}]", capacity, block_size)
+    } else
+        DLOGE("Failed to unmarshall ReadCapacity16 data")
+    scsi_free_scsi_task(task);
+    return std::make_pair(capacity, block_size);
+}
+
+// File-local concrete ublk_disk; constructed only via the make_iscsi_disk factory below. The
+// public header exposes only the factory; raid/composite consumers cast back to ublk_disk.
+class iSCSIDisk : public ublk_disk {
+    // Setup-time iSCSI session: used for sync_iov (called by Raid1 resync_task on its own thread,
+    // by the avail-probe path, by superblock/bitmap I/O at construction, and by the destructor's
+    // logout). Stays alive across the disk lifetime; libiscsi contexts are not thread-safe so this
+    // session is independent of the per-queue async sessions.
+    std::unique_ptr< iscsi_session > _sync_session;
+    // Serialises concurrent sync_iov callers (resync vs. probe vs. raid1 read-fallback). libiscsi
+    // contexts are not thread-safe, and the rebuild-on-failure path mutates _sync_session->ctx.
+    std::mutex _sync_mutex;
+    int _lun{0};
+
+    // Per-queue async services. Slot vector sized to MAX_NR_HW_QUEUES at construction; populated
+    // in prepare() (queue thread, exactly once per q_id) and read lock-free from async_iov on the
+    // same thread. Slot ownership is unique to its queue thread, so no synchronisation is needed
+    // beyond the construction-time sizing. Each queue_service owns its own iscsi_context, eventfd,
+    // and service-loop coroutine handle; see the dispatch protocol described above.
+    std::vector< std::unique_ptr< queue_service > > _services;
+
+public:
+    explicit iSCSIDisk(std::string const& url, std::string const& parent_id = "");
+    ~iSCSIDisk() override;
+
+    std::string id() const noexcept override;
+    prepare_result prepare(ublksrv_queue const*, int const) override;
+
+    disk_task< int > async_iov(ublksrv_queue const* q, ublk_io_data const* data, iovec* iovecs, uint32_t nr_vecs,
+                               uint64_t addr) override;
+    io_result sync_iov(uint8_t op, iovec* iovecs, uint32_t nr_vecs, off_t offset) noexcept override;
+
+    static void __iscsi_rw_cb(iscsi_context*, int, void*, void*);
+};
+
+iSCSIDisk::iSCSIDisk(std::string const& url, std::string const& /* TODO: metrics */) : _services(MAX_NR_HW_QUEUES) {
+    _direct_io = true;
+
+    if (_sync_session = create_iscsi_session(url); !_sync_session)
+        throw std::runtime_error(fmt::format("Failed to attach iSCSI target: {}", url));
+    if (!iscsi_login(*_sync_session)) throw std::runtime_error("Could not login to target");
+    _lun = _sync_session->url->lun;
+
+    auto const [capacity, lba_size] = probe_topology(*_sync_session);
+    if (0 == capacity) throw std::runtime_error("Could not probe LUN to discover capacity");
+    auto const block_shift = ilog2(lba_size);
+
+    auto& our_params = *params();
+    our_params.basic.logical_bs_shift = static_cast< uint8_t >(block_shift);
+    our_params.basic.physical_bs_shift = static_cast< uint8_t >(block_shift);
+    our_params.basic.dev_sectors = capacity >> SECTOR_SHIFT;
+
+    // TODO Implement discard
+    our_params.types |= ~UBLK_PARAM_TYPE_DISCARD;
+
+    DLOGD("iSCSI device [{}:{}:{}]!", _sync_session->url->target, lba_size, k_physical_block_size)
+}
+
+iSCSIDisk::~iSCSIDisk() = default;
+
+std::string iSCSIDisk::id() const noexcept { return _sync_session->url->target; }
+
+// Service-loop coroutine: pumps libiscsi events through io_uring POLL_ADD on the queue thread.
+//
+// Steady-state behaviour:
+//   - Compute iscsi_which_events(); if non-zero, POLL_ADD on the libiscsi socket fd.
+//   - If zero, POLL_ADD on the queue_service's eventfd to be woken by async_iov.
+//   - Suspend on cqe_state until run_queue_loop dispatches the CQE.
+//   - On wake: drain eventfd if applicable, then call iscsi_service(revents) to advance libiscsi.
+//
+// Recovery behaviour (qs->state machine, see qs_state_t):
+//   - iscsi_service returning -1 (max_retries=0 + reconnect failure) sets state=dead.
+//   - In dead state we wait on evfd only -- iscsi_get_fd would return a stale/closed fd and
+//     polling on it would tight-loop with POLLNVAL; iscsi_which_events would return 0 anyway.
+//   - Any evfd kick while dead advances to rebuilding (the kick is the recovery trigger from
+//     async_iov on this queue, or sync_iov broadcasting from RAID1's probe/resync thread).
+//   - In rebuilding state, on the first iteration we destroy the dead ctx, build a fresh one,
+//     and call iscsi_full_connect_async(__rebuild_login_cb). Subsequent iterations poll the new
+//     socket fd normally; iscsi drives the connect/login PDU exchange via iscsi_service. When
+//     login completes, __rebuild_login_cb sets state=alive (or back to dead on failure).
+//
+// This coroutine never returns; it is owned by queue_service::service_handle and destroyed
+// (frame freed) by the queue_service destructor at iSCSIDisk teardown. It uses cqe_state
+// with _owner = nullptr (the stand-alone form documented in cqe_state.hpp); errors thrown
+// out of resume are swallowed by the catch in run_queue_loop because _owner is null.
+static disk_task< int > __service_loop(ublksrv_queue const* q, queue_service* qs) {
+    while (true) {
+        // Rebuild kickoff: dead ctx is gone, allocate fresh, set max_retries=0 so the new ctx
+        // has the same fail-fast semantics, kick async login. login_cb flips state on completion.
+        if (qs->state == qs_state_t::rebuilding && !qs->rebuild_kicked_off) {
+            if (qs->ctx) {
+                // No iscsi_logout_sync: ctx is in deferred-reconnect state, the LOGOUT PDU would
+                // hang on libiscsi's internal poll. iscsi_destroy_context is sufficient because
+                // max_retries=0 already cancelled all in-flight PDUs (callbacks fired with
+                // SCSI_STATUS_CANCELLED, our cb_data freed) when the ctx transitioned to dead.
+                iscsi_destroy_context(qs->ctx);
+                qs->ctx = nullptr;
+            }
+            qs->ctx = iscsi_create_context("iqn.2002-10.com.ublkpp:client");
+            if (!qs->ctx) {
+                DLOGE("iSCSI rebuild: failed to allocate new context")
+                qs->state = qs_state_t::dead;
+            } else {
+                try {
+                    setup_qs_ctx(qs->ctx, qs->target.c_str());
+                } catch (std::exception const& e) {
+                    DLOGE("iSCSI rebuild: setup failed: {}", e.what())
+                    iscsi_destroy_context(qs->ctx);
+                    qs->ctx = nullptr;
+                    qs->state = qs_state_t::dead;
+                }
+                if (qs->ctx) {
+                    // Set kicked_off=true BEFORE the call: __rebuild_login_cb may fire
+                    // synchronously inside iscsi_full_connect_async on local errors and would
+                    // reset the flag; we must not then overwrite that with true.
+                    qs->rebuild_kicked_off = true;
+                    if (0 != iscsi_full_connect_async(qs->ctx, qs->portal.c_str(), qs->lun, __rebuild_login_cb, qs)) {
+                        DLOGE("iSCSI rebuild: full_connect_async failed: {}", iscsi_get_error(qs->ctx))
+                        qs->rebuild_kicked_off = false;
+                        qs->state = qs_state_t::dead;
+                    }
+                }
+            }
+        }
+
+        // In dead state we cannot poll on iscsi_get_fd -- the underlying socket is closed and
+        // POLL_ADD on it would deliver POLLNVAL immediately, tight-looping. Wait on evfd only;
+        // any kick (from async_iov on this queue, or sync_iov from RAID1's probe thread) is the
+        // signal to retry. In alive/rebuilding state, iscsi_which_events tells us what the lib
+        // wants to wait on.
+        int wait_fd, wait_events;
+        bool const can_poll_socket = (qs->state != qs_state_t::dead) && qs->ctx;
+        int const events = can_poll_socket ? iscsi_which_events(qs->ctx) : 0;
+        if (0 == events) {
+            wait_fd = qs->evfd;
+            wait_events = POLLIN;
+            qs->waiting_on_evfd = true;
+        } else {
+            // iscsi_get_fd is recomputed each iteration: it changes after rebuild (new socket).
+            wait_fd = iscsi_get_fd(qs->ctx);
+            wait_events = events;
+            qs->waiting_on_evfd = false;
+        }
+
+        qs->poll_state._result = 0;
+        qs->poll_state._result_ready = false;
+        qs->poll_state._waiter = {};
+
+        auto sqe = next_sqe(q);
+        io_uring_prep_poll_add(sqe, wait_fd, wait_events);
+        sqe->user_data = reinterpret_cast< uint64_t >(&qs->poll_state) | k_target_bit;
+
+        int const revents = co_await qs->poll_state;
+
+        if (qs->waiting_on_evfd) {
+            uint64_t v;
+            if (auto r = read(qs->evfd, &v, sizeof(v)); sizeof(v) != static_cast< size_t >(r)) {
+                DLOGT("eventfd read returned {}", r);
+            }
+            // Trigger recovery if we were sitting in dead. The kick may have come from async_iov
+            // (this queue) or from sync_iov (cross-thread, after a successful sync probe). Both
+            // mean "try again"; the next iteration's rebuild kickoff handles the rest.
+            if (qs->state == qs_state_t::dead) qs->state = qs_state_t::rebuilding;
+            continue;
+        }
+
+        if (revents > 0 && qs->ctx) {
+            if (iscsi_service(qs->ctx, revents) < 0) {
+                // libiscsi side-effect (iscsi_defer_reconnect) has already cancelled all in-flight
+                // PDUs as SCSI_STATUS_CANCELLED -> our cb fires -EIO -> waiters resumed. The ctx
+                // is now permanently in reconnect_deferred state; only destroy+recreate revives it.
+                DLOGW("iSCSI service failed: {}", iscsi_get_error(qs->ctx))
+                qs->state = qs_state_t::dead;
+            }
+        }
+    }
+}
+
+// Initialize per-queue iSCSI context + eventfd + service-loop coroutine.
+// Each queue gets its own libiscsi context (multi-queue forward-compat); login is sync.
+ublk_disk::prepare_result iSCSIDisk::prepare(ublksrv_queue const* q, int const) {
+    auto qs = std::make_unique< queue_service >();
+
+    // Stash portal/target/lun for the rebuild path. The rebuild destroys the old ctx (which
+    // owns the libiscsi-internal copies) before creating the new one, so we need our own copies.
+    qs->portal = _sync_session->url->portal;
+    qs->target = _sync_session->url->target;
+    qs->lun = _sync_session->url->lun;
+
+    qs->ctx = iscsi_create_context("iqn.2002-10.com.ublkpp:client");
+    if (!qs->ctx) throw std::runtime_error("Failed to init per-queue iSCSI context");
+    setup_qs_ctx(qs->ctx, qs->target.c_str());
+    if (0 != iscsi_full_connect_sync(qs->ctx, qs->portal.c_str(), qs->lun))
+        throw std::runtime_error(fmt::format("Per-queue iSCSI login failed: {}", iscsi_get_error(qs->ctx)));
+
+    qs->evfd = eventfd(0, EFD_NONBLOCK);
+    if (0 > qs->evfd) throw std::runtime_error(fmt::format("Could not initialize eventfd: {}", strerror(errno)));
+
+    // Build service-loop coroutine and start it. Resuming runs synchronously to first co_await
+    // (POLL_ADD setup), staging an SQE in q->ring_ptr; the queue's submit_and_wait_timeout picks
+    // it up on the next iteration.
+    auto task = __service_loop(q, qs.get());
+    qs->service_handle = std::exchange(task._coro, {}); // steal the handle; task dtor is now no-op
+    qs->service_handle.resume();
+
+    // Slot is owned by this queue thread; vector was sized at construction and slot indices are
+    // unique to their queue thread, so no lock is needed.
+    if (q->q_id < 0 || static_cast< size_t >(q->q_id) >= _services.size())
+        throw std::runtime_error(fmt::format("q_id {} out of range (max {})", q->q_id, _services.size()));
+    _services[q->q_id] = std::move(qs);
+    return {.max_sqes_per_io = 0}; // Everything submitted through libiscsi
+}
+
+io_result iSCSIDisk::sync_iov(uint8_t op, iovec* iovecs, uint32_t nr_vecs, off_t addr) noexcept {
+    auto const len = iovec_len(iovecs, iovecs + nr_vecs);
+    auto const lba = addr >> params()->basic.logical_bs_shift;
+
+    DLOGT("{} : [INTERNAL] ublk io [lba:{:#0x}|len:{:#0x}]", op == UBLK_IO_OP_READ ? "READ" : "WRITE", lba, len)
+
+    // Serialise concurrent callers (RAID1 probe vs. resync vs. read-fallback). libiscsi contexts
+    // are not thread-safe; the rebuild path mutates _sync_session->ctx; both must be locked.
+    std::lock_guard< std::mutex > lk(_sync_mutex);
+
+    // Rebuild a previously-dead sync session before issuing IO. Failure here is reported as
+    // not-connected so callers (RAID1) can distinguish it from a SCSI-level error.
+    if (_sync_session->dead) {
+        if (!rebuild_sync_session(*_sync_session))
+            return std::unexpected(std::make_error_condition(std::errc::not_connected));
+    }
+
+    auto task = (UBLK_IO_OP_READ == op)
+        ? iscsi_read16_iov_sync(_sync_session->ctx, _lun, lba, len, block_size(), 0, 0, 0, 0, 0,
+                                reinterpret_cast< scsi_iovec* >(iovecs), nr_vecs)
+        : iscsi_write16_iov_sync(_sync_session->ctx, _lun, lba, NULL, len, block_size(), 0, 0, 0, 0, 0,
+                                 reinterpret_cast< scsi_iovec* >(iovecs), nr_vecs);
+    if (!task) return std::unexpected(std::make_error_condition(std::errc::not_enough_memory));
+    io_result res = len;
+    if (SCSI_STATUS_GOOD != task->status) {
+        DLOGW("iSCSI cmd returned error: [status:{}] iscsi_err: ", task->status, iscsi_get_error(_sync_session->ctx));
+        if (SCSI_SENSE_ILLEGAL_REQUEST == task->sense.key) {
+            if (SCSI_SENSE_ASCQ_LOGICAL_UNIT_NOT_SUPPORTED == task->sense.ascq) {
+                res = std::unexpected(std::make_error_condition(std::errc::resource_unavailable_try_again));
+            }
+        }
+        res = std::unexpected(std::make_error_condition(std::errc::io_error));
+    }
+    scsi_free_scsi_task(task);
+
+    // If the ctx fell out of logged-in state during the call, max_retries=0 has placed it in
+    // permanent reconnect_deferred. Mark dead so the next sync_iov rebuilds the ctx end-to-end.
+    if (!iscsi_is_logged_in(_sync_session->ctx)) _sync_session->dead = true;
+
+    // "Sync corrects async": on a successful sync IO the target is reachable, so kick every
+    // per-queue async service whose ctx is not currently logged in. The kick wakes their service
+    // loops; each loop interprets the wake as "advance dead -> rebuilding" and starts an async
+    // login. evfd writes are kernel-atomic and harmless if the loop is on the socket fd.
+    if (res) {
+        for (auto& qs_ptr : _services) {
+            auto* qs = qs_ptr.get();
+            if (!qs || qs->evfd < 0) continue;
+            if (qs->ctx && iscsi_is_logged_in(qs->ctx)) continue;
+            uint64_t one = 1;
+            if (auto r = write(qs->evfd, &one, sizeof(one)); sizeof(one) != static_cast< size_t >(r)) {
+                DLOGT("sync_iov evfd kick returned {}", r)
+            }
+        }
+    }
+
+    return res;
+}
+
+// Per-IO callback bound to libiscsi via iscsi_*_async. Runs from inside iscsi_service() which
+// itself runs from the service-loop coroutine on the queue thread. We write the result to the
+// per-IO cqe_state and resume the awaiting coroutine via symmetric transfer (handled by
+// run_queue_loop's CQE dispatch path, except here we resume directly because we already have
+// the state pointer).
+struct iscsi_cb_data {
+    cqe_state* state;
+    int len;
+    scsi_iovec io_vec[16]{{0, 0}};
+};
+
+void iSCSIDisk::__iscsi_rw_cb(iscsi_context* ctx, int status, void* data, void* private_data) {
+    auto cb = reinterpret_cast< iscsi_cb_data* >(private_data);
+    int result = cb->len;
+    if (SCSI_STATUS_GOOD != status) [[unlikely]] {
+        result = -EIO;
+        auto task = reinterpret_cast< scsi_task* >(data);
+        DLOGW("iSCSI cmd returned error: [status:{}|key:{:#0x}|ascq:{:#0x}] iscsi_err: {}", status,
+              (uint8_t)task->sense.key, task->sense.ascq, iscsi_get_error(ctx));
+        if (SCSI_SENSE_ILLEGAL_REQUEST == task->sense.key) {
+            if (SCSI_SENSE_ASCQ_LOGICAL_UNIT_NOT_SUPPORTED == task->sense.ascq) { result = -EAGAIN; }
+        }
+    } else
+        DLOGT("Got iSCSI completion: status: {}", status);
+
+    cb->state->_result = result;
+    cb->state->_result_ready = true;
+    if (auto h = std::exchange(cb->state->_waiter, {})) h.resume();
+
+    scsi_free_scsi_task(reinterpret_cast< scsi_task* >(data));
+    delete cb;
+}
+
+disk_task< int > iSCSIDisk::async_iov(ublksrv_queue const* q, ublk_io_data const* data, iovec* iovecs, uint32_t nr_vecs,
+                                      uint64_t addr) {
+    // Lock-free: slot was populated by prepare() on this same queue thread.
+    auto* qs = _services[q->q_id].get();
+    if (!qs) co_return -EIO; // prepare() must have populated this
+
+    // Fail-fast on a downed session. RAID1 above us marks the leg dirty on -ENOTCONN; recovery is
+    // driven by sync_iov (probe/resync) rebuilding the qs ctx and broadcasting to all queue evfds.
+    // Kick our evfd here so the service loop, if currently parked in dead state, advances to
+    // rebuilding without waiting for the next sync_iov broadcast.
+    if (!iscsi_is_logged_in(qs->ctx)) {
+        if (qs->waiting_on_evfd) {
+            uint64_t one = 1;
+            if (auto r = write(qs->evfd, &one, sizeof(one)); sizeof(one) != static_cast< size_t >(r)) {
+                DLOGT("eventfd kick on dead session returned {}", r);
+            }
+        }
+        co_return -ENOTCONN;
+    }
+
+    auto const op = ublksrv_get_op(data->iod);
+    if (op == UBLK_IO_OP_FLUSH) co_return 0;
+    if (op == UBLK_IO_OP_DISCARD || op == UBLK_IO_OP_WRITE_ZEROES) co_return -ENOTSUP; // TODO discard
+
+    int const len = iovec_len(iovecs, iovecs + nr_vecs);
+    auto const lba = addr >> params()->basic.logical_bs_shift;
+
+    DLOGT("{} : [tag:{:#0x}] ublk io [lba:{:#0x}|len:{:#0x}]", op == UBLK_IO_OP_READ ? "READ" : "WRITE", data->tag, lba,
+          len)
+
+    // Allocate per-IO cqe_state in the slot's async_io::_pool. _owner points at the slot so the
+    // exception path in run_queue_loop can complete the IO with -EIO if the per-IO coroutine
+    // throws.
+    auto [state, _] = build_cqe_state_data(data);
+
+    // libiscsi captures the iovec base pointers internally; iov_base lives in the kernel-allocated
+    // ublk IO buffer and is stable for the IO's lifetime. We copy the iovec descriptors only
+    // because libiscsi's API takes scsi_iovec by reference; the actual data buffers are not
+    // copied. TODO: drop this copy if libiscsi guarantees iov-array stability.
+    auto cb = new iscsi_cb_data{};
+    cb->state = state;
+    cb->len = len;
+    for (auto i = 0U; nr_vecs > i; ++i) {
+        cb->io_vec[i].iov_base = iovecs[i].iov_base;
+        cb->io_vec[i].iov_len = iovecs[i].iov_len;
+    }
+
+    auto task = (UBLK_IO_OP_READ == op) ? iscsi_read16_iov_task(qs->ctx, _lun, lba, len, block_size(), 0, 0, 0, 0, 0,
+                                                                __iscsi_rw_cb, cb, cb->io_vec, nr_vecs)
+                                        : iscsi_write16_iov_task(qs->ctx, _lun, lba, NULL, len, block_size(), 0, 0, 0,
+                                                                 0, 0, __iscsi_rw_cb, cb, cb->io_vec, nr_vecs);
+    if (!task) {
+        DLOGE("Failed {} to iSCSI LUN. {}", op == UBLK_IO_OP_READ ? "READ" : "WRITE", iscsi_get_error(qs->ctx));
+        delete cb;
+        co_return -ENOMEM;
+    }
+
+    // Push the queued PDU through the socket synchronously where possible. The common path is
+    // a single non-blocking write that fully drains; the service loop then awaits POLLIN for
+    // the response. TODO: handle the buffer-full case (libiscsi keeps POLLOUT pending and the
+    // service loop, currently waiting on POLLIN only, would not re-arm) via cancel-and-rearm.
+    if (int events = iscsi_which_events(qs->ctx); events & POLLOUT) {
+        if (iscsi_service(qs->ctx, POLLOUT) < 0) {
+            DLOGE("iSCSI inline service failed: {}", iscsi_get_error(qs->ctx));
+            // The callback may not have fired; cb->state may still be unresumed. Best effort:
+            // mark the state ready with an error so the await below returns instead of hanging.
+            state->_result = -EIO;
+            state->_result_ready = true;
+            // cb is still owned by libiscsi (will be freed via __iscsi_rw_cb on its eventual call,
+            // or leaked on context destroy). Don't double-free here.
+            co_return -EIO;
+        }
+    }
+
+    // Wake the service loop only if it is suspended on the eventfd. If it is suspended on the
+    // libiscsi socket fd, the response we just submitted will arrive there and wake it via
+    // POLLIN -- no kick needed. The flag is set by the loop before each suspend; same-thread
+    // coroutines mean we always read the value matching the loop's current wait_fd.
+    if (qs->waiting_on_evfd) {
+        uint64_t one = 1;
+        if (auto r = write(qs->evfd, &one, sizeof(one)); sizeof(one) != static_cast< size_t >(r)) {
+            DLOGT("eventfd write returned {}", r);
+        }
+    }
+
+    co_return co_await *state;
+}
+
+std::shared_ptr< ublk_disk > make_iscsi_disk(std::string const& url, std::string const& parent_id) {
+    return std::make_shared< iSCSIDisk >(url, parent_id);
+}
+
+} // namespace ublkpp

--- a/src/driver/tests/CMakeLists.txt
+++ b/src/driver/tests/CMakeLists.txt
@@ -17,3 +17,39 @@ target_link_libraries (test_fsdisk
   ublksrv::ublksrv
 )
 add_test(NAME FSDiskTest COMMAND test_fsdisk -cv warning)
+
+if(${libiscsi_FOUND})
+    add_executable(test_iscsi_disk)
+    target_sources(test_iscsi_disk PRIVATE
+       test_iscsi_disk.cpp
+      $<TARGET_OBJECTS:iscsi_disk>
+      $<TARGET_OBJECTS:ublk_disk>
+      $<TARGET_OBJECTS:ublk_metrics>
+      $<TARGET_OBJECTS:logging>
+    )
+    target_link_libraries(test_iscsi_disk
+      GTest::gmock
+      sisl::cache
+      ublksrv::ublksrv
+      STDEXEC::stdexec
+      libiscsi::libiscsi
+    )
+
+    # tgtd lifecycle as CTest fixtures: start once before iSCSIDiskTest, tear down after.
+    # Setup script soft-skips (exit 0) when tgtd is missing; the test then runtime-probes
+    # 127.0.0.1:13260 and GTEST_SKIPs all cases if nothing is listening.
+    set(_iscsi_setup_script "${CMAKE_CURRENT_SOURCE_DIR}/iscsi_tgtd_setup.sh")
+    add_test(NAME ISCSISetup    COMMAND "${_iscsi_setup_script}" start)
+    add_test(NAME ISCSITeardown COMMAND "${_iscsi_setup_script}" stop)
+    set_tests_properties(ISCSISetup    PROPERTIES
+        FIXTURES_SETUP iscsi_target
+        SKIP_REGULAR_EXPRESSION "ISCSI_SOFT_SKIP")
+    set_tests_properties(ISCSITeardown PROPERTIES FIXTURES_CLEANUP iscsi_target)
+
+    add_test(NAME iSCSIDiskTest COMMAND test_iscsi_disk -cv warning)
+    # When the C++ runtime probe finds no listener, every test case GTEST_SKIPs and
+    # gtest reports "PASSED ] 0 tests" — match that to surface as Skipped in CTest.
+    set_tests_properties(iSCSIDiskTest PROPERTIES
+        FIXTURES_REQUIRED iscsi_target
+        SKIP_REGULAR_EXPRESSION "PASSED  \\] 0 tests")
+endif()

--- a/src/driver/tests/iscsi_tgtd_setup.sh
+++ b/src/driver/tests/iscsi_tgtd_setup.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+# Manage a transient tgtd instance for iSCSIDisk tests.
+#
+# Usage: iscsi_tgtd_setup.sh start|stop
+#
+# Starts tgtd in the foreground (backgrounded by us) bound to 127.0.0.1:13260
+# for the iSCSI portal and 13261 for the management channel (--control-port,
+# avoids tgtd's hardcoded /var/run/tgtd unix socket). Single sparse-file-backed
+# LUN exported as iqn.2026-05.test.ublkpp:lun0.
+#
+# Soft-skip exit codes (exit 0): tgtd missing, port squatted by non-tgtd
+# process, lock-file inaccessible without sudo. Combined with the C++ test's
+# runtime port probe + GTEST_SKIP, a soft-skip surfaces as Skipped (green).
+
+set -eu
+
+PORT="${ISCSI_TEST_PORT:-13260}"
+CTRL_PORT="${ISCSI_TEST_CTRL_PORT:-13261}"
+STATE_DIR="${ISCSI_TEST_STATE:-/tmp/ublkpp_iscsi_test}"
+PID_FILE="$STATE_DIR/tgtd.pid"
+BACKING_SIZE="${ISCSI_TEST_LUN_SIZE:-256M}"
+# Number of LUNs to provision. RAID10 composition tests need 4; the single-LUN
+# FunctionalISCSI test just uses LUN 1.
+LUN_COUNT="${ISCSI_TEST_LUN_COUNT:-4}"
+TARGET_IQN="iqn.2026-05.test.ublkpp:lun0"
+
+start() {
+    if ! command -v tgtd >/dev/null || ! command -v tgtadm >/dev/null; then
+        echo "ISCSI_SOFT_SKIP: tgtd/tgtadm not in PATH"
+        exit 0
+    fi
+
+    # tgtd writes its per-port lock file at /var/run/tgtd/socket.<CTRL_PORT>.lock
+    # (path is hardcoded; --control-port only changes the suffix). The directory
+    # must exist and be writable. /var/run is tmpfs, so a chown disappears on
+    # reboot — for a persistent dev-box setup, prefer a tmpfiles.d entry. Three
+    # ways to satisfy this:
+    #   1. Already root (CI container path).
+    #   2. The directory exists and is writable by us (dev-box path).
+    #   3. Passwordless sudo is available (CI runner path) — we mkdir on demand.
+    # If none apply, soft-skip with an actionable hint.
+    SUDO=""
+    IPC_DIR="/var/run/tgtd"
+    if [[ $EUID -eq 0 ]]; then
+        mkdir -p "$IPC_DIR"
+    elif [[ -d "$IPC_DIR" && -w "$IPC_DIR" ]]; then
+        : # user can write into the dir; run tgtd as user
+    elif command -v sudo >/dev/null && sudo -n true 2>/dev/null; then
+        SUDO="sudo"
+        $SUDO mkdir -p "$IPC_DIR"
+    else
+        cat >&2 <<EOF
+ISCSI_SOFT_SKIP: tgtd needs $IPC_DIR to be writable (or root / passwordless sudo).
+Per-boot one-shot:
+    sudo mkdir -p $IPC_DIR && sudo chown \$USER $IPC_DIR
+Persistent (survives reboot — /var/run is tmpfs):
+    echo 'd $IPC_DIR 0755 \$USER \$USER -' | sudo tee /etc/tmpfiles.d/tgtd.conf
+    sudo systemd-tmpfiles --create /etc/tmpfiles.d/tgtd.conf
+Soft-skipping iSCSIDisk tests for this run.
+EOF
+        exit 0
+    fi
+
+    if [[ -f "$PID_FILE" ]] && $SUDO kill -0 "$(cat "$PID_FILE")" 2>/dev/null; then
+        echo "tgtd already running (pid $(cat "$PID_FILE"))"
+        return 0
+    fi
+
+    # Pre-flight: an earlier failed run may have left a tgtd squatting on our
+    # port. tgtd is owned by root when launched via sudo, so ss without sudo
+    # may hide the pid; route ss through $SUDO to make sure we can identify it.
+    if command -v ss >/dev/null; then
+        squatter=$($SUDO ss -Hltnp "sport = :$PORT" 2>/dev/null | grep -oE 'pid=[0-9]+' | head -1 | cut -d= -f2)
+        if [[ -n "$squatter" ]]; then
+            squatter_name=$(cat "/proc/$squatter/comm" 2>/dev/null || echo unknown)
+            if [[ "$squatter_name" == "tgtd" ]]; then
+                echo "Killing stale tgtd (pid $squatter) bound to port $PORT"
+                $SUDO kill "$squatter" 2>/dev/null || true
+                for _ in $(seq 1 50); do
+                    $SUDO kill -0 "$squatter" 2>/dev/null || break
+                    sleep 0.1
+                done
+                $SUDO kill -9 "$squatter" 2>/dev/null || true
+            else
+                echo "ISCSI_SOFT_SKIP: Port $PORT is in use by '$squatter_name' (pid $squatter)"
+                exit 0
+            fi
+        fi
+    fi
+
+    mkdir -p "$STATE_DIR"
+    for i in $(seq 1 "$LUN_COUNT"); do
+        truncate -s "$BACKING_SIZE" "$STATE_DIR/lun${i}.img"
+    done
+
+    $SUDO tgtd \
+        --foreground \
+        --iscsi portal=127.0.0.1:"$PORT" \
+        --control-port "$CTRL_PORT" \
+        >"$STATE_DIR/tgtd.log" 2>&1 &
+    echo $! >"$PID_FILE"
+
+    # Wait until tgtadm can reach the control port. Probing tgtadm directly is
+    # more reliable than watching for a unix-socket path.
+    for _ in $(seq 1 300); do
+        if $SUDO tgtadm --control-port "$CTRL_PORT" --lld iscsi --op show --mode target >/dev/null 2>&1; then
+            break
+        fi
+        sleep 0.1
+    done
+    if ! $SUDO tgtadm --control-port "$CTRL_PORT" --lld iscsi --op show --mode target >/dev/null 2>&1; then
+        echo "ISCSI_SOFT_SKIP: tgtd failed to come up; log follows:"
+        cat "$STATE_DIR/tgtd.log" || true
+        $SUDO kill "$(cat "$PID_FILE")" 2>/dev/null || true
+        # Wait for tgtd to actually die — otherwise it keeps the port and
+        # the test gets a confusing "Connection reset by peer" instead of
+        # a clean GTEST_SKIP via failed connect().
+        for _ in $(seq 1 50); do
+            $SUDO kill -0 "$(cat "$PID_FILE")" 2>/dev/null || break
+            sleep 0.1
+        done
+        $SUDO kill -9 "$(cat "$PID_FILE")" 2>/dev/null || true
+        exit 0  # soft-skip; the C++ probe will GTEST_SKIP all tests
+    fi
+
+    $SUDO tgtadm --control-port "$CTRL_PORT" --lld iscsi --op new --mode target --tid 1 -T "$TARGET_IQN"
+    for i in $(seq 1 "$LUN_COUNT"); do
+        $SUDO tgtadm --control-port "$CTRL_PORT" --lld iscsi --op new --mode logicalunit --tid 1 \
+            --lun "$i" -b "$STATE_DIR/lun${i}.img"
+    done
+    $SUDO tgtadm --control-port "$CTRL_PORT" --lld iscsi --op bind --mode target --tid 1 -I ALL
+}
+
+stop() {
+    SUDO=""
+    if [[ $EUID -ne 0 ]] && command -v sudo >/dev/null && sudo -n true 2>/dev/null; then
+        SUDO="sudo"
+    fi
+
+    # Find tgtd by its listening socket, not PID_FILE: when start() ran tgtd via
+    # sudo, $! was sudo's PID (sudo forks for PAM/audit proxying on most distros)
+    # and SIGTERM to sudo doesn't always reach the child. Killing the actual
+    # listener is reliable.
+    pid=""
+    if command -v ss >/dev/null; then
+        pid=$($SUDO ss -Hltnp "sport = :$PORT" 2>/dev/null | grep -oE 'pid=[0-9]+' | head -1 | cut -d= -f2)
+    fi
+    if [[ -n "$pid" ]]; then
+        $SUDO kill "$pid" 2>/dev/null || true
+        for _ in $(seq 1 50); do
+            $SUDO kill -0 "$pid" 2>/dev/null || break
+            sleep 0.1
+        done
+        $SUDO kill -9 "$pid" 2>/dev/null || true
+    fi
+
+    # Best-effort kill of the recorded PID too, in case tgtd already exited
+    # but a sudo wrapper is still around.
+    if [[ -f "$PID_FILE" ]]; then
+        $SUDO kill "$(cat "$PID_FILE")" 2>/dev/null || true
+    fi
+
+    rm -f "$PID_FILE" "$STATE_DIR"/lun*.img
+    # Intentionally leave $STATE_DIR/tgtd.log in place for post-mortem; the
+    # next start() truncates the log via the daemon redirect, so this won't
+    # accumulate across runs.
+}
+
+case "${1:-}" in
+    start) start ;;
+    stop)  stop ;;
+    *) echo "Usage: $0 start|stop" >&2; exit 1 ;;
+esac

--- a/src/driver/tests/test_iscsi_disk.cpp
+++ b/src/driver/tests/test_iscsi_disk.cpp
@@ -1,0 +1,171 @@
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <arpa/inet.h>
+#include <errno.h>
+#include <netinet/in.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <cstdlib>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <sisl/logging/logging.h>
+#include <sisl/options/options.h>
+#include <ublksrv.h>
+
+#include "ublkpp/drivers.hpp"
+#include "lib/common.hpp"
+#include "ublkpp/lib/ublk_disk.hpp"
+
+SISL_LOGGING_INIT(ublk_drivers, libiscsi)
+
+SISL_OPTIONS_ENABLE(logging)
+
+namespace {
+
+// Matches iscsi_tgtd_setup.sh defaults; can be overridden via env for parallel CI.
+static std::string iscsi_url() {
+    auto* port = std::getenv("ISCSI_TEST_PORT");
+    auto* host = std::getenv("ISCSI_TEST_HOST");
+    return std::string("iscsi://") + (host ? host : "127.0.0.1") + ":" + (port ? port : "13260") +
+        "/iqn.2026-05.test.ublkpp:lun0/1";
+}
+
+// Probe the listener once per process. tgtd may not be installed (CI without
+// the package, or contributor without tgt locally); when it isn't we skip
+// rather than fail. The fixture script's "soft skip" exit-0 path means CTest
+// would still run us; the runtime probe is what actually keeps things green.
+static bool tgtd_reachable() {
+    auto* port = std::getenv("ISCSI_TEST_PORT");
+    auto* host = std::getenv("ISCSI_TEST_HOST");
+    int p = port ? std::atoi(port) : 13260;
+    int sock = ::socket(AF_INET, SOCK_STREAM, 0);
+    if (sock < 0) return false;
+    sockaddr_in addr{};
+    addr.sin_family = AF_INET;
+    addr.sin_port = htons(static_cast< uint16_t >(p));
+    inet_pton(AF_INET, host ? host : "127.0.0.1", &addr.sin_addr);
+    int rc = ::connect(sock, reinterpret_cast< sockaddr* >(&addr), sizeof(addr));
+    ::close(sock);
+    return 0 == rc;
+}
+
+// Aligned buffer helper (libiscsi tolerates unaligned, but we mirror FSDisk's
+// O_DIRECT-style alignment so the same patterns transfer if/when we exercise
+// async_iov through the real ublk path later).
+class AlignedBuffer {
+    void* _ptr{nullptr};
+    size_t _size{0};
+
+public:
+    explicit AlignedBuffer(size_t size, size_t alignment = 512) : _size(size) {
+        if (posix_memalign(&_ptr, alignment, size) != 0) _ptr = nullptr;
+        if (_ptr) std::memset(_ptr, 0, size);
+    }
+    ~AlignedBuffer() {
+        if (_ptr) std::free(_ptr);
+    }
+    AlignedBuffer(AlignedBuffer const&) = delete;
+    AlignedBuffer& operator=(AlignedBuffer const&) = delete;
+    void* get() { return _ptr; }
+    uint8_t* data() { return static_cast< uint8_t* >(_ptr); }
+    size_t size() const { return _size; }
+};
+
+class iSCSIDiskTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        if (!tgtd_reachable()) GTEST_SKIP() << "tgtd not reachable on the test port; skipping iSCSIDisk tests";
+    }
+};
+
+TEST_F(iSCSIDiskTest, ConstructorAndProbe) {
+    std::shared_ptr< ublkpp::ublk_disk > disk;
+    ASSERT_NO_THROW({ disk = ublkpp::make_iscsi_disk(iscsi_url()); });
+    EXPECT_GT(disk->capacity(), 0u);
+    EXPECT_GT(disk->block_size(), 0u);
+    // id() returns the target IQN (no LUN / portal suffix per current impl).
+    EXPECT_NE(disk->id().find("iqn.2026-05.test.ublkpp:lun0"), std::string::npos);
+}
+
+TEST_F(iSCSIDiskTest, SyncReadWriteRoundtrip) {
+    auto disk = ublkpp::make_iscsi_disk(iscsi_url());
+    auto const block_size = disk->block_size();
+
+    AlignedBuffer write_buf(block_size);
+    for (size_t i = 0; i < block_size; ++i)
+        write_buf.data()[i] = static_cast< uint8_t >(i & 0xFF);
+
+    iovec iov{.iov_base = write_buf.get(), .iov_len = block_size};
+    auto wres = disk->sync_iov(UBLK_IO_OP_WRITE, &iov, 1, 0);
+    ASSERT_TRUE(wres.has_value()) << "write failed";
+    EXPECT_EQ(wres.value(), block_size);
+
+    AlignedBuffer read_buf(block_size);
+    iov.iov_base = read_buf.get();
+    auto rres = disk->sync_iov(UBLK_IO_OP_READ, &iov, 1, 0);
+    ASSERT_TRUE(rres.has_value()) << "read failed";
+    EXPECT_EQ(rres.value(), block_size);
+    EXPECT_EQ(0, std::memcmp(write_buf.get(), read_buf.get(), block_size));
+}
+
+TEST_F(iSCSIDiskTest, SyncVectoredReadWrite) {
+    auto disk = ublkpp::make_iscsi_disk(iscsi_url());
+    auto const block_size = disk->block_size();
+
+    AlignedBuffer w1(block_size), w2(block_size);
+    std::memset(w1.get(), 0x11, block_size);
+    std::memset(w2.get(), 0x22, block_size);
+
+    iovec wivs[2] = {
+        {.iov_base = w1.get(), .iov_len = block_size},
+        {.iov_base = w2.get(), .iov_len = block_size},
+    };
+    auto wres = disk->sync_iov(UBLK_IO_OP_WRITE, wivs, 2, 0);
+    ASSERT_TRUE(wres.has_value());
+    EXPECT_EQ(wres.value(), 2 * block_size);
+
+    AlignedBuffer r1(block_size), r2(block_size);
+    iovec rivs[2] = {
+        {.iov_base = r1.get(), .iov_len = block_size},
+        {.iov_base = r2.get(), .iov_len = block_size},
+    };
+    auto rres = disk->sync_iov(UBLK_IO_OP_READ, rivs, 2, 0);
+    ASSERT_TRUE(rres.has_value());
+    EXPECT_EQ(rres.value(), 2 * block_size);
+    EXPECT_EQ(0, std::memcmp(w1.get(), r1.get(), block_size));
+    EXPECT_EQ(0, std::memcmp(w2.get(), r2.get(), block_size));
+}
+
+TEST_F(iSCSIDiskTest, SyncReadAtOffset) {
+    auto disk = ublkpp::make_iscsi_disk(iscsi_url());
+    auto const block_size = disk->block_size();
+    off_t const off = static_cast< off_t >(block_size) * 8;
+
+    AlignedBuffer wbuf(block_size);
+    std::memset(wbuf.get(), 0xCD, block_size);
+    iovec iov{.iov_base = wbuf.get(), .iov_len = block_size};
+    auto wres = disk->sync_iov(UBLK_IO_OP_WRITE, &iov, 1, off);
+    ASSERT_TRUE(wres.has_value());
+
+    AlignedBuffer rbuf(block_size);
+    iov.iov_base = rbuf.get();
+    auto rres = disk->sync_iov(UBLK_IO_OP_READ, &iov, 1, off);
+    ASSERT_TRUE(rres.has_value());
+    EXPECT_EQ(0, std::memcmp(wbuf.get(), rbuf.get(), block_size));
+}
+
+} // namespace
+
+int main(int argc, char* argv[]) {
+    int parsed_argc = argc;
+    ::testing::InitGoogleTest(&parsed_argc, argv);
+    SISL_OPTIONS_LOAD(parsed_argc, argv, logging);
+    sisl::logging::SetLogger(std::string(argv[0]));
+    spdlog::set_pattern("[%D %T.%e] [%n] [%^%l%$] [%t] %v");
+    return RUN_ALL_TESTS();
+}

--- a/src/target/ublkpp_tgt.cpp
+++ b/src/target/ublkpp_tgt.cpp
@@ -378,14 +378,21 @@ static int init_queue(const struct ublksrv_queue* q, void**) {
     TLOGD("Init Queue")
     auto device = reinterpret_cast< ublk_disk* >(q->dev->tgt.tgt_data);
     // All current disk types return no FDs from per-queue init; non-empty means the FDs would go
-    // unregistered with io_uring and fixed-file I/O would crash — treat it as a fatal init failure.
-    auto const prep = device->prepare(q, 0);
-    if (!prep.fds.empty()) return -1;
-    // async_io is placement-new'd into ublksrv-calloc'd bytes; _pool is pre-reserved to the SQE
-    // ceiling so push_back during I/O never reallocates and cqe_state* pointers stay stable.
-    for (int i = 0; i < q->q_depth; ++i) {
-        auto* io = new (ublksrv_io_private_data(q, i)) async_io{};
-        io->_pool.reserve(prep.max_sqes_per_io);
+    // unregistered with io_uring and fixed-file I/O would crash -- treat it as a fatal init failure.
+    // prepare() can throw (iSCSIDisk: per-queue login failure across the C boundary).
+    try {
+        // unregistered with io_uring and fixed-file I/O would crash — treat it as a fatal init failure.
+        auto const prep = device->prepare(q, 0);
+        if (!prep.fds.empty()) return -1;
+        // async_io is placement-new'd into ublksrv-calloc'd bytes; _pool is pre-reserved to the SQE
+        // ceiling so push_back during I/O never reallocates and cqe_state* pointers stay stable.
+        for (int i = 0; i < q->q_depth; ++i) {
+            auto* io = new (ublksrv_io_private_data(q, i)) async_io{};
+            io->_pool.reserve(prep.max_sqes_per_io);
+        }
+    } catch (std::exception const& e) {
+        TLOGE("Queue {} prepare() threw: {}", q->q_id, e.what())
+        return -1;
     }
     return 0;
 }

--- a/src/tests/fio_engine/CMakeLists.txt
+++ b/src/tests/fio_engine/CMakeLists.txt
@@ -113,6 +113,10 @@ set(FIO_BASE_ARGS
     --allow_file_create=0
 )
 
+# fio's exit code is 0 even when a child process crashes ("got signal=N" line in
+# stdout); match that to mark the ctest entry as Failed instead of silently Passed.
+set(FIO_FAIL_REGEX "got signal=")
+
 # --- FSDisk ---
 add_test(NAME FunctionalFSDisk
     COMMAND ${FIO_EXECUTABLE} ${FIO_BASE_ARGS}
@@ -138,6 +142,7 @@ set_tests_properties(FunctionalFSDisk PROPERTIES
     FIXTURES_REQUIRED FunctionalImages
     TIMEOUT 120
     LABELS "Functional"
+    FAIL_REGULAR_EXPRESSION "${FIO_FAIL_REGEX}"
 )
 
 # --- RAID0 ---
@@ -151,6 +156,7 @@ set_tests_properties(FunctionalRAID0 PROPERTIES
     FIXTURES_REQUIRED FunctionalImages
     TIMEOUT 120
     LABELS "Functional"
+    FAIL_REGULAR_EXPRESSION "${FIO_FAIL_REGEX}"
 )
 
 # --- RAID1 ---
@@ -164,6 +170,7 @@ set_tests_properties(FunctionalRAID1 PROPERTIES
     FIXTURES_REQUIRED FunctionalImages
     TIMEOUT 180
     LABELS "Functional"
+    FAIL_REGULAR_EXPRESSION "${FIO_FAIL_REGEX}"
 )
 
 # --- RAID10 ---
@@ -177,6 +184,7 @@ set_tests_properties(FunctionalRAID10 PROPERTIES
     FIXTURES_REQUIRED FunctionalImages
     TIMEOUT 180
     LABELS "Functional"
+    FAIL_REGULAR_EXPRESSION "${FIO_FAIL_REGEX}"
 )
 
 # --- RAID0 cross-stripe (bs=96k forces iovec accumulation in __distribute) ---
@@ -190,6 +198,7 @@ set_tests_properties(FunctionalRAID0CrossStripe PROPERTIES
     FIXTURES_REQUIRED FunctionalImages
     TIMEOUT 180
     LABELS "Functional"
+    FAIL_REGULAR_EXPRESSION "${FIO_FAIL_REGEX}"
 )
 
 # --- RAID10 cross-stripe (same pattern through RAID0+RAID1 stack) ---
@@ -203,7 +212,43 @@ set_tests_properties(FunctionalRAID10CrossStripe PROPERTIES
     FIXTURES_REQUIRED FunctionalImages
     TIMEOUT 180
     LABELS "Functional"
+    FAIL_REGULAR_EXPRESSION "${FIO_FAIL_REGEX}"
 )
+
+# --- iSCSI (chains onto the iscsi_target fixture from src/driver/tests) ---
+if (libiscsi_FOUND)
+    set(ISCSI_BASE "iscsi://127.0.0.1:13260/iqn.2026-05.test.ublkpp:lun0")
+    set(ISCSI_URL "${ISCSI_BASE}/1")
+    add_test(NAME FunctionalISCSI
+        COMMAND ${FIO_EXECUTABLE} ${FIO_BASE_ARGS}
+            ${CMAKE_CURRENT_SOURCE_DIR}/jobs/iscsi_rw.fio
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    )
+    # When tgtd is unavailable, ISCSISetup soft-skips and CTest auto-skips this
+    # test via FIXTURES_REQUIRED — no SKIP_REGULAR_EXPRESSION needed.
+    set_tests_properties(FunctionalISCSI PROPERTIES
+        ENVIRONMENT "ENGINE_SO=${ENGINE_SO};ISCSI_URL=${ISCSI_URL};${FUNCTIONAL_ENV}"
+        FIXTURES_REQUIRED iscsi_target
+        TIMEOUT 120
+        LABELS "Functional"
+        FAIL_REGULAR_EXPRESSION "${FIO_FAIL_REGEX}"
+    )
+
+    # RAID10 over four iSCSI LUNs: exercises RAID0 striping + RAID1 mirroring +
+    # iSCSIDisk service-loop cascade with realistic concurrency.
+    add_test(NAME FunctionalISCSIRAID10
+        COMMAND ${FIO_EXECUTABLE} ${FIO_BASE_ARGS}
+            ${CMAKE_CURRENT_SOURCE_DIR}/jobs/iscsi_raid10_rw.fio
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    )
+    set_tests_properties(FunctionalISCSIRAID10 PROPERTIES
+        ENVIRONMENT "ENGINE_SO=${ENGINE_SO};ISCSI_URL_1=${ISCSI_BASE}/1;ISCSI_URL_2=${ISCSI_BASE}/2;ISCSI_URL_3=${ISCSI_BASE}/3;ISCSI_URL_4=${ISCSI_BASE}/4;${FUNCTIONAL_ENV}"
+        FIXTURES_REQUIRED iscsi_target
+        TIMEOUT 180
+        LABELS "Functional"
+        FAIL_REGULAR_EXPRESSION "${FIO_FAIL_REGEX}"
+    )
+endif()
 
 # ---------------------------------------------------------------------------
 # Convenience target: cmake --build <dir> --target functional

--- a/src/tests/fio_engine/jobs/iscsi_raid10_rw.fio
+++ b/src/tests/fio_engine/jobs/iscsi_raid10_rw.fio
@@ -1,0 +1,29 @@
+# RAID10 over four iSCSI LUNs with cross-stripe block size to exercise the
+# RAID0 accumulator (a single write that wraps the stripe and hits the same
+# RAID1 pair twice).
+#
+# RAID10 = RAID0 over two RAID1 pairs. With chunk_size=32k, stride_width=64k.
+# bs=96k = 3 x chunk_size. Each IO maps as:
+#   [0..32k)   -> RAID1 pair A  (iovec #1)
+#   [32k..64k) -> RAID1 pair B  (iovec #1, flushed)
+#   [64k..96k) -> RAID1 pair A  (iovec #2, flushed as 2-iovec scatter-gather
+#                                through RAID1 -> two iSCSI WRITE16 SCSI ops)
+#
+# This exercises the RAID0 __distribute accumulation path AND fans the
+# resulting multi-iovec writes through libiscsi's async path with the
+# coroutine-model service-loop cascade.
+[global]
+ioengine=external:${ENGINE_SO}
+disk_type=raid10
+disk_url=${ISCSI_URL_1}|${ISCSI_URL_2}|${ISCSI_URL_3}|${ISCSI_URL_4}
+raid_chunk_size=32768
+bs=96k
+iodepth=32
+verify=md5
+verify_fatal=1
+time_based=0
+direct=0
+
+[write-verify]
+rw=write
+size=96m

--- a/src/tests/fio_engine/jobs/iscsi_rw.fio
+++ b/src/tests/fio_engine/jobs/iscsi_rw.fio
@@ -1,0 +1,14 @@
+[global]
+ioengine=external:${ENGINE_SO}
+disk_type=iscsi
+disk_url=${ISCSI_URL}
+bsrange=4k-64k
+iodepth=32
+verify=md5
+verify_fatal=1
+time_based=0
+direct=0
+
+[write-verify]
+rw=write
+size=32m

--- a/src/tests/fio_engine/ublkpp_fio_engine.cpp
+++ b/src/tests/fio_engine/ublkpp_fio_engine.cpp
@@ -5,11 +5,17 @@
 ///
 /// Usage (fio job file):
 ///   ioengine=external:${ENGINE_SO}
-///   disk_type=fsdisk          # or raid0 / raid1
-///   disk_files=/tmp/a.img     # colon-separated for RAID
+///   disk_type=fsdisk          # or raid0 / raid1 / raid10 / iscsi
+///   disk_files=/tmp/a.img     # colon-separated for RAID with file legs
+///   disk_url=iscsi://...      # single URL for iscsi; pipe-separated ('|')
+///                             # for RAID with iSCSI legs. URLs contain ':'
+///                             # natively and fio treats ';' as an inline
+///                             # comment marker, so '|' is the list sep.
+///                             # Overrides disk_files when both set.
 ///   raid_chunk_size=32768     # optional, default 32 KiB
 
 #include <cassert>
+#include <cstdlib>
 #include <cstring>
 #include <deque>
 #include <filesystem>
@@ -73,14 +79,19 @@ SISL_OPTIONS_ENABLE(logging, raid1)
 static void ensure_sisl_init() {
     static std::once_flag flag;
     std::call_once(flag, []() {
+        // Default to warn so functional-test stdout shows fio's job/stats output without being
+        // drowned in DLOGT/DLOGD traffic from the engine. Override via UBLKPP_FIO_LOG_LEVEL when
+        // debugging (any sisl level: critical/error/warn/info/debug/trace).
+        char const* env_level = std::getenv("UBLKPP_FIO_LOG_LEVEL");
+        std::string level = env_level ? env_level : "warn";
         int argc = 3;
         char prog[] = "ublkpp_fio";
         char v_flag[] = "-v";
-        char v_level[] = "debug";
-        char* argv[] = {prog, v_flag, v_level};
+        std::vector< char > level_buf(level.begin(), level.end());
+        level_buf.push_back('\0');
+        char* argv[] = {prog, v_flag, level_buf.data()};
         SISL_OPTIONS_LOAD(argc, argv, logging, raid1);
         sisl::logging::SetLogger("ublkpp_fio");
-        // Set trace on all loggers — including SISL per-module loggers already created
         spdlog::set_pattern("[%D %T.%e] [%n] [%^%l%$] [%t] %v");
     });
 }
@@ -90,8 +101,9 @@ static void ensure_sisl_init() {
 // ---------------------------------------------------------------------------
 struct ublkpp_options {
     void* pad;                    // required: first field must be void* (thread_data placeholder)
-    char* disk_type;              // "fsdisk" | "raid0" | "raid1"
+    char* disk_type;              // "fsdisk" | "raid0" | "raid1" | "raid10" | "iscsi"
     char* disk_files;             // colon-separated backing file paths
+    char* disk_url;               // iSCSI URL (used when disk_type=iscsi)
     unsigned int raid_chunk_size; // bytes, default 32 KiB
 };
 
@@ -111,6 +123,15 @@ static fio_option engine_options[] = {
         .type = FIO_OPT_STR_STORE,
         .off1 = offsetof(struct ublkpp_options, disk_files),
         .help = "Colon-separated backing file paths",
+        .category = FIO_OPT_C_ENGINE,
+        .group = FIO_OPT_G_INVALID,
+    },
+    {
+        .name = "disk_url",
+        .lname = "Disk URL",
+        .type = FIO_OPT_STR_STORE,
+        .off1 = offsetof(struct ublkpp_options, disk_url),
+        .help = "iSCSI URL (used when disk_type=iscsi)",
         .category = FIO_OPT_C_ENGINE,
         .group = FIO_OPT_G_INVALID,
     },
@@ -161,12 +182,12 @@ static boost::uuids::uuid uuid_for_paths(std::vector< std::string > const& paths
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-static std::vector< std::string > split_colon(char const* s) {
+static std::vector< std::string > split_on(char const* s, char delim) {
     std::vector< std::string > result;
     if (!s || !*s) return result;
     std::istringstream ss(s);
     std::string token;
-    while (std::getline(ss, token, ':'))
+    while (std::getline(ss, token, delim))
         if (!token.empty()) result.push_back(token);
     return result;
 }
@@ -233,61 +254,88 @@ static int ublkpp_init(struct thread_data* td) {
     auto* opts = reinterpret_cast< ublkpp_options* >(td->eo);
     char const* disk_type = (opts && opts->disk_type) ? opts->disk_type : "fsdisk";
     char const* disk_files = (opts && opts->disk_files) ? opts->disk_files : "";
+    char const* disk_url = (opts && opts->disk_url) ? opts->disk_url : "";
     uint32_t chunk_size = (opts && opts->raid_chunk_size) ? opts->raid_chunk_size : 32768u;
+    std::string const type(disk_type);
 
-    auto paths = split_colon(disk_files);
-    if (paths.empty()) {
-        log_err("ublkpp_fio: disk_files option is required\n");
-        return -1;
-    }
+    // RAID composition can use either FSDisk legs (disk_files) or iSCSIDisk legs
+    // (disk_url, pipe-separated). disk_url takes precedence when both are set.
+    auto paths = split_on(disk_files, ':');
+    // URLs use '|' as list sep: ':' is part of every iSCSI URL (host:port, IQN
+    // suffix) and ';' is fio's inline-comment marker which silently strips the
+    // value. For type=iscsi (single URL), pass through unsplit.
+    auto urls =
+        (type == "iscsi" && disk_url && *disk_url) ? std::vector< std::string >{disk_url} : split_on(disk_url, '|');
+    bool const use_iscsi_legs = (type == "raid0" || type == "raid1" || type == "raid10") && !urls.empty();
 
-    // Size: use td->o.size + td->o.start_offset, rounded to sector, plus
-    // 64 MiB overhead for RAID metadata / superblocks
-    uint64_t const disk_size = ((td->o.size + td->o.start_offset + 511ULL) & ~511ULL) + (64ULL << 20);
-
-    for (auto const& p : paths) {
-        if (!ensure_file_size(p, disk_size)) {
-            log_err("ublkpp_fio: cannot allocate backing file %s\n", p.c_str());
+    if (type != "iscsi" && !use_iscsi_legs) {
+        if (paths.empty()) {
+            log_err("ublkpp_fio: disk_files option is required\n");
             return -1;
+        }
+        uint64_t const disk_size = ((td->o.size + td->o.start_offset + 511ULL) & ~511ULL) + (64ULL << 20);
+        for (auto const& p : paths) {
+            if (!ensure_file_size(p, disk_size)) {
+                log_err("ublkpp_fio: cannot allocate backing file %s\n", p.c_str());
+                return -1;
+            }
         }
     }
 
     // Build the disk
     std::shared_ptr< ublkpp::ublk_disk > disk;
+    auto const& leg_ids = use_iscsi_legs ? urls : paths;
+    auto make_leg = [&](size_t i) -> std::shared_ptr< ublkpp::ublk_disk > {
+        if (use_iscsi_legs) {
+#ifdef HAVE_ISCSI
+            return ublkpp::make_iscsi_disk(urls[i]);
+#else
+            throw std::runtime_error("iSCSI legs requested but engine built without HAVE_ISCSI");
+#endif
+        }
+        return ublkpp::make_fs_disk(paths[i]);
+    };
     try {
-        std::string const type(disk_type);
-        if (type == "fsdisk") {
+        if (type == "iscsi") {
+#ifdef HAVE_ISCSI
+            if (!disk_url || !*disk_url) {
+                log_err("ublkpp_fio: disk_type=iscsi requires disk_url\n");
+                return -1;
+            }
+            disk = ublkpp::make_iscsi_disk(disk_url);
+#else
+            log_err("ublkpp_fio: iscsi disk_type requested but engine built without HAVE_ISCSI\n");
+            return -1;
+#endif
+        } else if (type == "fsdisk") {
             disk = ublkpp::make_fs_disk(paths[0]);
         } else if (type == "raid0") {
-            if (paths.size() < 2) {
-                log_err("ublkpp_fio: raid0 requires at least 2 disk_files\n");
+            if (leg_ids.size() < 2) {
+                log_err("ublkpp_fio: raid0 requires at least 2 legs (disk_files or disk_url)\n");
                 return -1;
             }
             std::vector< std::shared_ptr< ublkpp::ublk_disk > > members;
-            for (auto const& p : paths)
-                members.push_back(ublkpp::make_fs_disk(p));
-            disk = ublkpp::make_raid0_disk(uuid_for_paths(paths), chunk_size, std::move(members));
+            for (size_t i = 0; i < leg_ids.size(); ++i)
+                members.push_back(make_leg(i));
+            disk = ublkpp::make_raid0_disk(uuid_for_paths(leg_ids), chunk_size, std::move(members));
         } else if (type == "raid1") {
-            if (paths.size() < 2) {
-                log_err("ublkpp_fio: raid1 requires 2 disk_files\n");
+            if (leg_ids.size() < 2) {
+                log_err("ublkpp_fio: raid1 requires 2 legs (disk_files or disk_url)\n");
                 return -1;
             }
-            disk = ublkpp::make_raid1_disk(uuid_for_paths(paths), ublkpp::make_fs_disk(paths[0]),
-                                           ublkpp::make_fs_disk(paths[1]));
+            disk = ublkpp::make_raid1_disk(uuid_for_paths(leg_ids), make_leg(0), make_leg(1));
         } else if (type == "raid10") {
-            if (paths.size() != 4) {
-                log_err("ublkpp_fio: raid10 requires exactly 4 disk_files\n");
+            if (leg_ids.size() != 4) {
+                log_err("ublkpp_fio: raid10 requires exactly 4 legs (disk_files or disk_url)\n");
                 return -1;
             }
             // RAID10: two mirrored pairs striped together
-            std::vector< std::string > const pair_a_paths{paths[0], paths[1]};
-            std::vector< std::string > const pair_b_paths{paths[2], paths[3]};
-            auto pair_a = ublkpp::make_raid1_disk(uuid_for_paths(pair_a_paths), ublkpp::make_fs_disk(paths[0]),
-                                                  ublkpp::make_fs_disk(paths[1]));
-            auto pair_b = ublkpp::make_raid1_disk(uuid_for_paths(pair_b_paths), ublkpp::make_fs_disk(paths[2]),
-                                                  ublkpp::make_fs_disk(paths[3]));
+            std::vector< std::string > const pair_a_ids{leg_ids[0], leg_ids[1]};
+            std::vector< std::string > const pair_b_ids{leg_ids[2], leg_ids[3]};
+            auto pair_a = ublkpp::make_raid1_disk(uuid_for_paths(pair_a_ids), make_leg(0), make_leg(1));
+            auto pair_b = ublkpp::make_raid1_disk(uuid_for_paths(pair_b_ids), make_leg(2), make_leg(3));
             std::vector< std::shared_ptr< ublkpp::ublk_disk > > members{std::move(pair_a), std::move(pair_b)};
-            disk = ublkpp::make_raid0_disk(uuid_for_paths(paths), chunk_size, std::move(members));
+            disk = ublkpp::make_raid0_disk(uuid_for_paths(leg_ids), chunk_size, std::move(members));
         } else {
             log_err("ublkpp_fio: unknown disk_type '%s'\n", disk_type);
             return -1;

--- a/src/tests/mock_ublksrv/mock_ublksrv.cpp
+++ b/src/tests/mock_ublksrv/mock_ublksrv.cpp
@@ -119,8 +119,26 @@ void MockUblksrv::process_cqe(io_uring_cqe* cqe, std::vector< Completion >& out)
     state->_result_ready = true;
 
     if (auto h = std::exchange(state->_waiter, {})) h.resume();
-    auto& opt = _async_tasks[tag];
-    if (opt && opt->done()) out.push_back({tag, opt->result()});
+
+    // TODO: consider mirroring ublkpp_tgt's __handle_io_async pattern -- wrap each
+    // slot in an outer task that co_awaits async_iov and reports {tag, result} on
+    // its own. That removes the divergence below and exercises the disk_task<int>
+    // awaiter side (currently only _coro.done() is checked, so awaiter regressions
+    // slip past).
+    //
+    // After resumption, any number of slot tasks may have become done. Per-IO
+    // states resume their own slot directly (state->_owner -> tagged async_io),
+    // but stand-alone service-loop states (iSCSIDisk POLL_ADD, _owner=nullptr)
+    // drive cascades through libiscsi callbacks that can resume one or more
+    // slot coroutines. Scan all slots and harvest completed tasks; reset after
+    // reporting so subsequent CQEs do not re-emit the same completion.
+    for (int t = 0; t < static_cast< int >(_async_tasks.size()); ++t) {
+        auto& opt = _async_tasks[t];
+        if (opt && opt->done()) {
+            out.push_back({t, opt->result()});
+            opt.reset();
+        }
+    }
 }
 
 std::vector< MockUblksrv::Completion > MockUblksrv::inject_cqe(int tag, int result) {

--- a/src/tests/mock_ublksrv/mock_ublksrv.hpp
+++ b/src/tests/mock_ublksrv/mock_ublksrv.hpp
@@ -63,7 +63,7 @@ private:
     struct TagState {
         ublksrv_io_desc iod{};
         ublk_io_data data{};
-        // Per-tag storage — io_uring reads iovecs at submit time (which is deferred to
+        // Per-tag storage: io_uring reads iovecs at submit time (which is deferred to
         // poll()), so a single shared/thread_local iovec would be overwritten by later
         // submit_io() calls before the kernel sees the earlier SQE.
         iovec iov{};


### PR DESCRIPTION
Adapt the libiscsi-based iSCSIDisk driver to the post-#210 single-event-loop coroutine architecture and re-enable it in the build, behind `-o ublkpp/*:iscsi=True`. The legacy eventfd + polling-thread integration is gone; libiscsi sockets are registered into the queue's io_uring via POLL_ADD/multishot, the queue thread drives `iscsi_service()` directly, and per-IO completions resume their coroutines through the shared cqe_state + symmetric-transfer pattern that FSDisk uses today.

Bundled with this branch (separate from the API uplift squash on spike/api_uplift):

- Hook libiscsi's fd via POLL_ADD; service-CQE state is a stand-alone cqe_state (`_owner = nullptr`) handled inline on the queue thread.
- Add functional fio jobs: `iscsi_rw.fio` (single LUN) and `iscsi_raid10_rw.fio` (RAID10 over four iSCSI LUNs, cross-stripe).
- Add `iscsi_tgtd_setup.sh` ctest fixture that brings up a transient `tgtd` on 127.0.0.1:13260, with soft-skip semantics (missing tgtd, port squatter, inaccessible /var/run/tgtd) so the suite stays green on dev boxes without iSCSI tooling.
- Bring the mocks/tests in line with the post-API-uplift surface (make_*_disk factories, disk_handle, ublk_disk lower-case base, prepare() returning std::vector).

Docs:
- README.md: add iSCSI to the backend list, update Core Abstractions and example commands to show factories, document the two-tier naming convention (public lower_snake_case types/factories vs internal PascalCase classes).
- docs/functional_testing.md: register FunctionalISCSI and FunctionalISCSIRAID10, document the tgtd fixture and soft-skip behavior, add iscsi to disk_type, update factory references.
- .claude/CLAUDE.md: spell out the same two-tier naming rule, refresh Project Structure to drop stale class names.

Closes #238