### PR TITLE
Experiment/md migration

### DIFF
--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -21,7 +21,13 @@ pipeline {
             when { not { branch "stable/v*" } }
             steps {
                 script {
-                    CONAN_CHANNEL = sh(script: "echo ${BRANCH_NAME} | sed -E 's,(\\w+-?\\d*)/.*,\\1,' | sed -E 's,-,_,' | tr -d '\n'", returnStdout: true)
+                    // Channel = the branch name with the leading category (e.g. "feature/")
+                    // stripped, since '/' is not valid in a Conan channel. Dashes are
+                    // also collapsed to underscores for the same reason.
+                    //   feature/248_md_raid_migration -> 248_md_raid_migration
+                    //   dev/v0.23.x                   -> v0.23.x
+                    //   PR-1234                       -> PR_1234
+                    CONAN_CHANNEL = sh(script: "echo ${BRANCH_NAME} | sed -E 's,.*/,,' | sed -E 's,-,_,g' | tr -d '\n'", returnStdout: true)
                     CONAN_FLAGS = "${CONAN_FLAGS} --user oss --channel ${CONAN_CHANNEL}"
                 }
             }

--- a/conanfile.py
+++ b/conanfile.py
@@ -10,7 +10,7 @@ required_conan_version = ">=2.0"
 
 class UBlkPPConan(ConanFile):
     name = "ublkpp"
-    version = "0.30.0"
+    version = "0.31.0"
 
     homepage = "https://github.com/szmyd/ublkpp"
     description = "A UBlk library for CPP application"

--- a/example/ublkpp_disk.cpp
+++ b/example/ublkpp_disk.cpp
@@ -25,6 +25,16 @@ SISL_OPTION_GROUP(ublkpp_disk,
                    "<path>[,<path>,...]"),
                   (raid10, "", "raid10", "Devices for RAID10 device", ::cxxopts::value< std::vector< std::string > >(),
                    "<path>[,<path>,...]"),
+                  (md_raid1, "", "md_raid1",
+                   "Import a clean 2-disk md-raid array (md level 1, or a 2-leg near=2 md-raid 10; "
+                   "1.2 SB) as RAID1. After first attach the md superblock is overwritten; the "
+                   "array is no longer recognizable to mdadm.",
+                   ::cxxopts::value< std::vector< std::string > >(), "<leg_a>,<leg_b>"),
+                  (md_raid10, "", "md_raid10",
+                   "Import a clean md-raid 10 array (near=2 layout, 1.2 SB) as RAID10. "
+                   "Provide all 2N legs in any order; pairs are reconstructed from md dev_role. "
+                   "After first attach the md superblock is overwritten on each leg.",
+                   ::cxxopts::value< std::vector< std::string > >(), "<leg>[,<leg>,...]"),
                   (stripe_size, "", "stripe_size", "RAID-0 Stripe Size",
                    ::cxxopts::value< uint32_t >()->default_value("131072"), ""),
                   (device_id, "", "device_id", "Recover existing device",
@@ -107,6 +117,48 @@ Result create_raid1(boost::uuids::uuid const& id, std::vector< std::string > con
     return _run_target(id, std::move(dev));
 }
 
+// For md-import paths the leaf must already exist (it's an existing md leg); fall back
+// to fs_disk directly so a typo'd path fails loud rather than producing a missing-leg
+// placeholder that MdDisk would reject.
+static std::shared_ptr< ublkpp::ublk_disk > get_md_leaf(std::string const& path, std::string const& metrics_id) {
+    if (!std::filesystem::exists(path)) throw std::runtime_error(fmt::format("md leaf does not exist: {}", path));
+    return ublkpp::make_fs_disk(path, metrics_id);
+}
+
+Result create_md_raid1(boost::uuids::uuid const& id, std::vector< std::string > const& layout) {
+    if (layout.size() != 2) {
+        LOGERROR("--md_raid1 requires exactly 2 leg paths, got {}", layout.size())
+        return std::unexpected(std::make_error_condition(std::errc::invalid_argument));
+    }
+    auto dev = std::shared_ptr< ublkpp::ublk_disk >();
+    auto raid_uuid_str = boost::uuids::to_string(id);
+    try {
+        auto leg_a = get_md_leaf(layout[0], raid_uuid_str);
+        auto leg_b = get_md_leaf(layout[1], raid_uuid_str);
+        dev = ublkpp::md::make_md_raid1_disk(id, {std::move(leg_a), std::move(leg_b)}, raid_uuid_str);
+    } catch (std::runtime_error const& e) { LOGERROR("md-raid1 import failed: {}", e.what()) }
+    if (!dev) return std::unexpected(std::make_error_condition(std::errc::operation_not_permitted));
+    return _run_target(id, std::move(dev));
+}
+
+Result create_md_raid10(boost::uuids::uuid const& id, std::vector< std::string > const& layout) {
+    if (layout.size() < 4 || (layout.size() & 1U) != 0) {
+        LOGERROR("--md_raid10 requires an even number of legs >= 4, got {}", layout.size())
+        return std::unexpected(std::make_error_condition(std::errc::invalid_argument));
+    }
+    auto dev = std::shared_ptr< ublkpp::ublk_disk >();
+    auto raid_uuid_str = boost::uuids::to_string(id);
+    try {
+        auto legs = std::vector< std::shared_ptr< ublkpp::ublk_disk > >();
+        legs.reserve(layout.size());
+        for (auto const& path : layout)
+            legs.push_back(get_md_leaf(path, raid_uuid_str));
+        dev = ublkpp::md::make_md_raid10_disk(id, std::move(legs), raid_uuid_str);
+    } catch (std::runtime_error const& e) { LOGERROR("md-raid10 import failed: {}", e.what()) }
+    if (!dev) return std::unexpected(std::make_error_condition(std::errc::operation_not_permitted));
+    return _run_target(id, std::move(dev));
+}
+
 Result create_raid10(boost::uuids::uuid const& id, std::vector< std::string > const& layout) {
     if (1 > layout.size()) {
         LOGERROR("Zero mirrors in Array [uuid:{}]!", to_string(id))
@@ -162,6 +214,10 @@ int main(int argc, char* argv[]) {
         res = create_raid1(vol_id, SISL_OPTIONS["raid1"].as< std::vector< std::string > >());
     } else if (0 < SISL_OPTIONS["raid10"].count()) {
         res = create_raid10(vol_id, SISL_OPTIONS["raid10"].as< std::vector< std::string > >());
+    } else if (0 < SISL_OPTIONS["md_raid1"].count()) {
+        res = create_md_raid1(vol_id, SISL_OPTIONS["md_raid1"].as< std::vector< std::string > >());
+    } else if (0 < SISL_OPTIONS["md_raid10"].count()) {
+        res = create_md_raid10(vol_id, SISL_OPTIONS["md_raid10"].as< std::vector< std::string > >());
     } else
         std::cout << SISL_PARSER.help({}) << std::endl;
 

--- a/include/ublkpp/raid.hpp
+++ b/include/ublkpp/raid.hpp
@@ -36,6 +36,46 @@ disk_handle get_device(ublk_disk const& disk, uint32_t stripe_offset) noexcept;
 
 } // namespace raid0
 
+namespace md {
+
+// One-way, in-place migration of an md-raid 10 array (near=2 layout, superblock 1.2) onto
+// ublkpp's RAID-10 stack (RAID0 over N RAID1 mirrors). User data is preserved byte-for-byte
+// at md's data_offset on each leg; ublkpp metadata is written into the dead zone md left in
+// front of the data area.
+//
+// Each leaf is wrapped in a thin per-leg shim that persists across reboots (its own 4 KiB SB
+// at leaf byte 0). Subsequent attaches walk the shim transparently.
+//
+// Validation (throws std::runtime_error on any failure):
+//   - Each leg must carry a valid md 1.2 SB at byte 4 KiB (or a previously-stamped MdDisk SB
+//     at byte 0 if the array was already migrated).
+//   - Array must be clean: resync_offset == MaxSector, no reshape/recovery active.
+//   - Layout must be near=2 (far/offset rejected).
+//   - Cross-leg: set_uuid, md_chunk_size, data_offset, raid_disks, layout, events all match.
+//   - dev_roles complementary: pair K covers roles 2K and 2K+1 for K in [0, raid_disks/2).
+//
+// The first call on a fresh import overwrites the md superblock at byte 4 KiB so the kernel
+// will not auto-assemble it on next boot; after that call returns successfully, the array
+// is no longer recognizable to mdadm.
+
+// Wrap a single leaf in an MdDisk shim. Useful for testing or manual composition; production
+// code should prefer the higher-level make_md_raid1_disk / make_md_raid10_disk factories.
+disk_handle make_md_disk(disk_handle leaf);
+
+// Construct a 2-way RAID1 mirror from a near=2 md-raid 10 leg pair. Both legs must carry the
+// same md set_uuid and have complementary dev_roles (2K and 2K+1).
+disk_handle make_md_raid1_disk(boost::uuids::uuid const& uuid, std::pair< disk_handle, disk_handle > legs,
+                               std::string const& parent_id = "");
+
+// Construct an N-pair RAID-10 (RAID0 of RAID1 mirrors) from a near=2 md-raid 10 array. Accepts
+// 2N raw leaves (any order). Pairs are reconstructed by dev_role / 2; mirrors are then composed
+// in ascending pair-K order so md's chunk-to-pair mapping is preserved byte-identical. The
+// RAID0 stripe size is taken from md's chunk_size.
+disk_handle make_md_raid10_disk(boost::uuids::uuid const& uuid, std::vector< disk_handle >&& legs,
+                                std::string const& parent_id = "");
+
+} // namespace md
+
 namespace raid1 {
 
 ENUM(replica_state, uint8_t, CLEAN = 0, SYNCING = 1, ERROR = 2, UNAVAIL = 3);

--- a/include/ublkpp/raid.hpp
+++ b/include/ublkpp/raid.hpp
@@ -38,39 +38,49 @@ disk_handle get_device(ublk_disk const& disk, uint32_t stripe_offset) noexcept;
 
 namespace md {
 
-// One-way, in-place migration of an md-raid 10 array (near=2 layout, superblock 1.2) onto
-// ublkpp's RAID-10 stack (RAID0 over N RAID1 mirrors). User data is preserved byte-for-byte
-// at md's data_offset on each leg; ublkpp metadata is written into the dead zone md left in
-// front of the data area.
+// One-way, in-place migration of an md-raid array (level 1 or level 10 near=2, superblock 1.2)
+// onto ublkpp's RAID stack. User data is preserved byte-for-byte at md's data_offset on each
+// leg; ublkpp metadata is written into the dead zone md left in front of the data area.
 //
 // Each leaf is wrapped in a thin per-leg shim that persists across reboots (its own 4 KiB SB
 // at leaf byte 0). Subsequent attaches walk the shim transparently.
 //
+// Identity model: the caller supplies a `uuid` that is the volume identity. By production
+// construction this equals the md array's `set_uuid` (mdadm --uuid passed at create time).
+// Every layer verifies against this uuid on attach and refuses to consume legs that don't
+// match - mirroring how plain ublkpp raid0 / raid1 use their SB uuid as a guard:
+//   - MdDisk verifies the caller's uuid against the leg's md SB set_uuid (first import) or
+//     the MdDisk-stamped SB's stored uuid (reattach).
+//   - For make_md_raid1_disk: the resulting RAID1 SB also stamps / verifies this same uuid.
+//   - For make_md_raid10_disk: the resulting RAID0 SB stamps / verifies this same uuid; per-
+//     pair RAID1 SBs use name_generator(uuid)("partition_K") just as a fresh raid10 create
+//     would, so each pair has its own stable identity derived from the volume uuid.
+//
 // Validation (throws std::runtime_error on any failure):
 //   - Each leg must carry a valid md 1.2 SB at byte 4 KiB (or a previously-stamped MdDisk SB
 //     at byte 0 if the array was already migrated).
+//   - md level must be 1 (2-way mirror) or 10 (near=2 only). Other levels and layouts rejected.
 //   - Array must be clean: resync_offset == MaxSector, no reshape/recovery active.
-//   - Layout must be near=2 (far/offset rejected).
-//   - Cross-leg: set_uuid, md_chunk_size, data_offset, raid_disks, layout, events all match.
-//   - dev_roles complementary: pair K covers roles 2K and 2K+1 for K in [0, raid_disks/2).
+//   - Cross-leg: set_uuid, md_level, md_chunk_size, data_offset, raid_disks, layout, events all
+//     match.
+//   - dev_roles complementary: pair K covers roles 2K and 2K+1 (md raid 1 is the K=0 case).
+//   - Caller's uuid must match each leg's recorded set_uuid (the guard described above).
 //
 // The first call on a fresh import overwrites the md superblock at byte 4 KiB so the kernel
 // will not auto-assemble it on next boot; after that call returns successfully, the array
 // is no longer recognizable to mdadm.
 
-// Wrap a single leaf in an MdDisk shim. Useful for testing or manual composition; production
-// code should prefer the higher-level make_md_raid1_disk / make_md_raid10_disk factories.
-disk_handle make_md_disk(disk_handle leaf);
-
-// Construct a 2-way RAID1 mirror from a near=2 md-raid 10 leg pair. Both legs must carry the
-// same md set_uuid and have complementary dev_roles (2K and 2K+1).
+// Construct a 2-way RAID1 mirror from an md-raid leg pair. Source array can be md level 1
+// (a pure 2-way mirror) or md level 10 (a 2-leg near=2 array, equivalent layout). Both legs
+// must carry the same md set_uuid and have complementary dev_roles (0 and 1). `uuid` is the
+// volume identity guard (see comment above).
 disk_handle make_md_raid1_disk(boost::uuids::uuid const& uuid, std::pair< disk_handle, disk_handle > legs,
                                std::string const& parent_id = "");
 
 // Construct an N-pair RAID-10 (RAID0 of RAID1 mirrors) from a near=2 md-raid 10 array. Accepts
 // 2N raw leaves (any order). Pairs are reconstructed by dev_role / 2; mirrors are then composed
 // in ascending pair-K order so md's chunk-to-pair mapping is preserved byte-identical. The
-// RAID0 stripe size is taken from md's chunk_size.
+// RAID0 stripe size is taken from md's chunk_size. `uuid` is the volume identity guard.
 disk_handle make_md_raid10_disk(boost::uuids::uuid const& uuid, std::vector< disk_handle >&& legs,
                                 std::string const& parent_id = "");
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,6 +13,7 @@ add_subdirectory (target)
 list(APPEND LIBRARY_OBJECTS
   $<TARGET_OBJECTS:raid0>
   $<TARGET_OBJECTS:raid1>
+  $<TARGET_OBJECTS:md_disk>
   $<TARGET_OBJECTS:fs_disk>
   $<TARGET_OBJECTS:ublkpp_tgt>
   $<TARGET_OBJECTS:ublk_disk>

--- a/src/raid/CMakeLists.txt
+++ b/src/raid/CMakeLists.txt
@@ -2,3 +2,4 @@ cmake_minimum_required (VERSION 3.11)
 
 add_subdirectory(raid0)
 add_subdirectory(raid1)
+add_subdirectory(md)

--- a/src/raid/md/CMakeLists.txt
+++ b/src/raid/md/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required (VERSION 3.11)
+
+add_library(md_disk OBJECT)
+target_sources(md_disk PRIVATE
+    md_disk.cpp
+    md_superblock.cpp
+)
+target_link_libraries(md_disk
+    sisl::cache
+    ublksrv::ublksrv
+)
+
+if ((DEFINED ENABLE_TESTS) AND (${ENABLE_TESTS}))
+add_subdirectory (tests)
+endif()

--- a/src/raid/md/md_disk.cpp
+++ b/src/raid/md/md_disk.cpp
@@ -1,0 +1,466 @@
+#include "md_disk.hpp"
+
+extern "C" {
+#include <endian.h>
+}
+
+#include <algorithm>
+#include <cstdlib>
+#include <cstring>
+#include <map>
+#include <memory>
+#include <stdexcept>
+#include <vector>
+
+#include <boost/uuid/name_generator.hpp>
+#include <boost/uuid/uuid_io.hpp>
+#include <fmt/format.h>
+#include <ublk_cmd.h>
+#include <ublksrv.h>
+
+#include "ublkpp/raid.hpp"
+
+#include "lib/common.hpp"
+#include "lib/logging.hpp"
+#include "raid/raid1/raid1_superblock.hpp" // for sizeof(raid1::SuperBlock) and k_min_chunk_size
+
+namespace ublkpp::md {
+
+namespace {
+
+// md superblock 1.2 lives at byte 4 KiB on each leg. Field offsets per kernel
+// include/uapi/linux/raid/md_p.h. Subset relevant to our parser.
+constexpr uint64_t k_md_sb_offset = 4 * Ki;
+constexpr uint32_t k_md_magic = 0xa92b4efc;
+constexpr uint32_t k_md_major_version = 1;
+constexpr uint32_t k_md_feature_reshape_active = 0x4;
+constexpr uint32_t k_md_feature_recovery_offset = 0x10;
+constexpr uint32_t k_md_level_raid10 = 10;
+constexpr uint64_t k_md_sector_clean = ~uint64_t{0}; // MaxSector
+
+constexpr size_t k_md_off_magic = 0x00;
+constexpr size_t k_md_off_major_version = 0x04;
+constexpr size_t k_md_off_feature_map = 0x08;
+constexpr size_t k_md_off_set_uuid = 0x10;
+constexpr size_t k_md_off_level = 0x48;
+constexpr size_t k_md_off_layout = 0x4C;
+constexpr size_t k_md_off_chunksize = 0x58;
+constexpr size_t k_md_off_raid_disks = 0x5C;
+constexpr size_t k_md_off_data_offset = 0x80;
+constexpr size_t k_md_off_dev_number = 0xA0;
+constexpr size_t k_md_off_events = 0xC8;
+constexpr size_t k_md_off_resync_offset = 0xD0;
+constexpr size_t k_md_off_dev_roles = 0x100;
+
+// RAID1 aligns _reserved_size to the logical block size of its members (so user-data offsets
+// stay block-aligned for O_DIRECT). MdDisk reports the leaf's block_size upward, so the
+// alignment we need to reproduce here is the leaf's block_size.
+
+// LE field readers - md SB is stored little-endian on disk.
+inline uint16_t le16_at(uint8_t const* p, size_t off) noexcept {
+    uint16_t v;
+    std::memcpy(&v, p + off, sizeof(v));
+    return le16toh(v);
+}
+inline uint32_t le32_at(uint8_t const* p, size_t off) noexcept {
+    uint32_t v;
+    std::memcpy(&v, p + off, sizeof(v));
+    return le32toh(v);
+}
+inline uint64_t le64_at(uint8_t const* p, size_t off) noexcept {
+    uint64_t v;
+    std::memcpy(&v, p + off, sizeof(v));
+    return le64toh(v);
+}
+
+struct AlignedBuf {
+    void* ptr{nullptr};
+    explicit AlignedBuf(uint32_t align, size_t sz) {
+        if (auto err = ::posix_memalign(&ptr, align, sz); err || !ptr)
+            throw std::runtime_error(fmt::format("MdDisk: posix_memalign({}, {}) failed: {}", align, sz, err));
+        std::memset(ptr, 0, sz);
+    }
+    ~AlignedBuf() {
+        if (ptr) std::free(ptr);
+    }
+    AlignedBuf(AlignedBuf const&) = delete;
+    AlignedBuf& operator=(AlignedBuf const&) = delete;
+};
+
+// Read `len` bytes at leaf byte offset `off` directly from the leaf, bypassing any
+// translation that MdDisk would apply through its own sync_iov.
+io_result leaf_pread(ublk_disk& leaf, uint64_t off, void* buf, size_t len) noexcept {
+    auto iov = iovec{.iov_base = buf, .iov_len = len};
+    return leaf.sync_iov(UBLK_IO_OP_READ, &iov, 1, static_cast< off_t >(off));
+}
+
+io_result leaf_pwrite(ublk_disk& leaf, uint64_t off, void const* buf, size_t len) noexcept {
+    auto iov = iovec{.iov_base = const_cast< void* >(buf), .iov_len = len};
+    return leaf.sync_iov(UBLK_IO_OP_WRITE, &iov, 1, static_cast< off_t >(off));
+}
+
+// Parse + validate md 1.2 SB at leaf byte 4 KiB. Throws std::runtime_error on any rejection
+// (not an md array, wrong level/layout, dirty, reshape/recovery active, etc.).
+DiscoveredTopology discovered_topo_from_md(ublk_disk& leaf) {
+    AlignedBuf raw(leaf.block_size(), k_page_size);
+    if (auto r = leaf_pread(leaf, k_md_sb_offset, raw.ptr, k_page_size); !r)
+        throw std::runtime_error(fmt::format("MdDisk: failed to read md SB candidate: {}", r.error().message()));
+    auto const* sb = static_cast< uint8_t const* >(raw.ptr);
+
+    if (le32_at(sb, k_md_off_magic) != k_md_magic)
+        throw std::runtime_error("MdDisk: leaf has no md superblock magic at byte 4096 (not an md 1.2 array)");
+    if (le32_at(sb, k_md_off_major_version) != k_md_major_version)
+        throw std::runtime_error("MdDisk: md superblock is not version 1 (only 1.2 supported)");
+
+    auto const feature_map = le32_at(sb, k_md_off_feature_map);
+    if (feature_map & k_md_feature_reshape_active)
+        throw std::runtime_error("MdDisk: md array has reshape active; cannot import");
+    if (feature_map & k_md_feature_recovery_offset)
+        throw std::runtime_error("MdDisk: md array has recovery_offset set; cannot import");
+
+    if (le32_at(sb, k_md_off_level) != k_md_level_raid10) throw std::runtime_error("MdDisk: md array is not level 10");
+
+    auto const layout = le32_at(sb, k_md_off_layout);
+    auto const near_copies = static_cast< uint8_t >(layout & 0xff);
+    auto const far_copies = static_cast< uint8_t >((layout >> 8) & 0xff);
+    auto const far_offset = static_cast< uint8_t >((layout >> 16) & 1);
+    // mdadm's default for near=2 RAID-10 is layout=0x00010002 (far_copies=0, far_offset=1).
+    // The far_offset bit is ignored by the kernel when far_copies <= 1, so accept any layout
+    // where near_copies == 2 and there is no real "far" striping (far_copies <= 1).
+    if (near_copies != 2 || far_copies > 1)
+        throw std::runtime_error(
+            fmt::format("MdDisk: only near=2 RAID-10 supported (layout=0x{:08x}: near={}, far={}, far_offset={})",
+                        layout, near_copies, far_copies, far_offset));
+
+    if (le64_at(sb, k_md_off_resync_offset) != k_md_sector_clean)
+        throw std::runtime_error("MdDisk: md array is not in sync (resync_offset != MaxSector)");
+
+    auto const raid_disks = le32_at(sb, k_md_off_raid_disks);
+    if (raid_disks < 4 || raid_disks > 256 || (raid_disks & 1U) != 0)
+        throw std::runtime_error(
+            fmt::format("MdDisk: unsupported raid_disks={} (require even, >=4, <=256)", raid_disks));
+
+    auto const dev_number = le32_at(sb, k_md_off_dev_number);
+    if (dev_number >= raid_disks)
+        throw std::runtime_error(fmt::format("MdDisk: dev_number {} >= raid_disks {}", dev_number, raid_disks));
+
+    auto const dev_role = le16_at(sb, k_md_off_dev_roles + 2 * dev_number);
+    if (dev_role >= raid_disks)
+        throw std::runtime_error(
+            fmt::format("MdDisk: dev_role {} >= raid_disks {} (spare or missing slot)", dev_role, raid_disks));
+
+    DiscoveredTopology t{};
+    t.md_chunk_size = le32_at(sb, k_md_off_chunksize) << SECTOR_SHIFT;
+    t.data_offset_bytes = le64_at(sb, k_md_off_data_offset) << SECTOR_SHIFT;
+    t.raid_disks = static_cast< uint16_t >(raid_disks);
+    t.dev_role = dev_role;
+    t.layout_near = near_copies;
+    t.layout_far = far_copies;
+    t.layout_far_offset = far_offset;
+    t.events = le64_at(sb, k_md_off_events);
+    std::memcpy(t.set_uuid.data, sb + k_md_off_set_uuid, sizeof(t.set_uuid.data));
+
+    if (t.md_chunk_size == 0 || t.md_chunk_size < raid1::k_min_chunk_size)
+        throw std::runtime_error(fmt::format("MdDisk: md chunk_size {} is below ublkpp k_min_chunk_size {}",
+                                             t.md_chunk_size, raid1::k_min_chunk_size));
+    if (t.data_offset_bytes == 0)
+        throw std::runtime_error("MdDisk: md data_offset is zero (1.0 superblock or unset; not supported)");
+
+    DLOGI("MdDisk: discovered md-raid10 topology on {}: set_uuid={}, raid_disks={}, dev_role={}, "
+          "chunk={}KiB, data_offset={}MiB, events={}",
+          leaf, boost::uuids::to_string(t.set_uuid), t.raid_disks, t.dev_role, t.md_chunk_size / Ki,
+          t.data_offset_bytes / Mi, t.events);
+
+    return t;
+}
+
+} // namespace
+
+uint64_t MdDisk::__compute_raid1_reserved(uint64_t presented_size, uint64_t max_sectors_bytes) noexcept {
+    // Mirror raid1.cpp:137-145. k_min_chunk_size and sizeof(SuperBlock) come from raid1::.
+    uint64_t const bitmap_size = (presented_size / raid1::k_min_chunk_size) / 8;
+    uint64_t reserved = sizeof(raid1::SuperBlock) + bitmap_size;
+    reserved += (presented_size - reserved) % max_sectors_bytes;
+    return reserved;
+}
+
+MdDisk::MdDisk(disk_handle leaf) : ublk_disk(), _leaf(std::move(leaf)) {
+    if (!_leaf) throw std::runtime_error("MdDisk: leaf is null");
+    if (_leaf->is_missing()) throw std::runtime_error("MdDisk: leaf is missing");
+
+    __probe_and_init();
+    __populate_params();
+    _id = fmt::format("MdDisk[{}@{}MiB]", _leaf->id(), _topo.data_offset_bytes / Mi);
+}
+
+MdDisk::~MdDisk() = default;
+
+void MdDisk::__probe_and_init() {
+    // Look for our own superblock at leaf byte 0 (bypass any translation; this is BEFORE
+    // _data_band_threshold/_data_band_shift are set).
+    AlignedBuf own(_leaf->block_size(), k_page_size);
+    if (auto r = leaf_pread(*_leaf, 0, own.ptr, k_page_size); !r)
+        throw std::runtime_error(fmt::format("MdDisk: failed to read leaf SB candidate: {}", r.error().message()));
+    auto* mdsb = static_cast< SuperBlock* >(own.ptr);
+
+    if (std::memcmp(mdsb->header.magic, k_magic, k_magic_size) == 0) {
+        if (be16toh(mdsb->header.version) > k_sb_version)
+            throw std::runtime_error(fmt::format("MdDisk: unsupported MdDisk SB version {} (max {})",
+                                                 be16toh(mdsb->header.version), k_sb_version));
+        _topo.data_offset_bytes = be64toh(mdsb->fields.data_offset);
+        _topo.md_chunk_size = be32toh(mdsb->fields.md_chunk_size);
+        _topo.raid_disks = be16toh(mdsb->fields.raid_disks);
+        _topo.dev_role = be16toh(mdsb->fields.dev_role);
+        _topo.layout_near = mdsb->fields.layout_near;
+        _topo.layout_far = mdsb->fields.layout_far;
+        _topo.layout_far_offset = mdsb->fields.layout_far_offset;
+        _topo.events = be64toh(mdsb->fields.events_at_import);
+        std::memcpy(_topo.set_uuid.data, mdsb->header.md_set_uuid, sizeof(mdsb->header.md_set_uuid));
+        DLOGI("MdDisk: re-attached existing wrapper on {}: set_uuid={}, dev_role={}, data_offset={}MiB", _leaf->id(),
+              boost::uuids::to_string(_topo.set_uuid), _topo.dev_role, _topo.data_offset_bytes / Mi);
+    } else {
+        // Fresh import path: parse md SB, write our own SB, scrub md SB to prevent kernel auto-assemble.
+        _topo = discovered_topo_from_md(*_leaf);
+
+        std::memset(own.ptr, 0, k_page_size);
+        std::memcpy(mdsb->header.magic, k_magic, k_magic_size);
+        mdsb->header.version = htobe16(k_sb_version);
+        std::memcpy(mdsb->header.md_set_uuid, _topo.set_uuid.data, sizeof(mdsb->header.md_set_uuid));
+        mdsb->fields.data_offset = htobe64(_topo.data_offset_bytes);
+        mdsb->fields.md_chunk_size = htobe32(_topo.md_chunk_size);
+        mdsb->fields.raid_disks = htobe16(_topo.raid_disks);
+        mdsb->fields.dev_role = htobe16(_topo.dev_role);
+        mdsb->fields.layout_near = _topo.layout_near;
+        mdsb->fields.layout_far = _topo.layout_far;
+        mdsb->fields.layout_far_offset = _topo.layout_far_offset;
+        mdsb->fields.events_at_import = htobe64(_topo.events);
+        if (auto w = leaf_pwrite(*_leaf, 0, own.ptr, k_page_size); !w)
+            throw std::runtime_error(fmt::format("MdDisk: failed to write own SB: {}", w.error().message()));
+
+        // Scrub md SB at byte 4 KiB so the kernel will not auto-assemble it on next boot.
+        std::memset(own.ptr, 0, k_page_size);
+        if (auto w = leaf_pwrite(*_leaf, k_md_sb_offset, own.ptr, k_page_size); !w)
+            throw std::runtime_error(fmt::format("MdDisk: failed to scrub md SB: {}", w.error().message()));
+        DLOGI("MdDisk: stamped wrapper SB on {}; md superblock at byte {} scrubbed", _leaf->id(), k_md_sb_offset);
+    }
+
+    // Compute the address translation. We solve for R = RAID1's _reserved_size that RAID1
+    // will compute when MdDisk presents capacity = D + md_chunk_size + R. RAID1 aligns its
+    // user-data area to its members' block_size for O_DIRECT, so (D + md_chunk_size) must be
+    // a multiple of block_size. md_chunk_size is always a multiple of 512 (sectors) and md
+    // aligns data_offset to >= 4 KiB, so on real arrays the residue is zero. We still trim
+    // defensively, bounded by block_size - 1 (typically <= 4095 bytes).
+    auto const leaf_size = _leaf->capacity();
+    if (leaf_size <= _topo.data_offset_bytes)
+        throw std::runtime_error(
+            fmt::format("MdDisk: leaf capacity {} <= data_offset {}", leaf_size, _topo.data_offset_bytes));
+    auto const align = static_cast< uint64_t >(_leaf->block_size());
+    auto const D_raw = leaf_size - _topo.data_offset_bytes;
+    auto const D_plus_chunk_aligned = ((D_raw + _topo.md_chunk_size) / align) * align;
+    if (D_plus_chunk_aligned <= _topo.md_chunk_size)
+        throw std::runtime_error(fmt::format("MdDisk: leaf too small after alignment (D_raw={}, md_chunk={}, align={})",
+                                             D_raw, _topo.md_chunk_size, align));
+    uint64_t const D = D_plus_chunk_aligned - _topo.md_chunk_size;
+    _data_band_size = D;
+
+    uint64_t R = sizeof(raid1::SuperBlock); // initial estimate
+    for (int iter = 0; iter < 16; ++iter) {
+        auto const presented = D + _topo.md_chunk_size + R;
+        auto const new_R = __compute_raid1_reserved(presented, align);
+        if (new_R == R) break;
+        R = new_R;
+    }
+    if (auto const final_check = __compute_raid1_reserved(D + _topo.md_chunk_size + R, align); final_check != R) {
+        throw std::runtime_error(
+            fmt::format("MdDisk: failed to converge on RAID1 reserved size (R={}, recomputed={})", R, final_check));
+    }
+
+    _data_band_threshold = R + _topo.md_chunk_size;
+    if (_topo.data_offset_bytes < k_head_zone_shift + _data_band_threshold)
+        throw std::runtime_error(
+            fmt::format("MdDisk: md data_offset ({} bytes) is too small for ublkpp metadata (need >= {})",
+                        _topo.data_offset_bytes, k_head_zone_shift + _data_band_threshold));
+    _data_band_shift = _topo.data_offset_bytes - _data_band_threshold;
+}
+
+void MdDisk::__populate_params() {
+    auto& our_params = *params();
+
+    // Inherit physical / logical block size and direct-io capability from the leaf.
+    our_params.basic.logical_bs_shift = static_cast< uint8_t >(ilog2(_leaf->block_size()));
+    our_params.basic.physical_bs_shift = static_cast< uint8_t >(ilog2(_leaf->physical_block_size()));
+    our_params.basic.max_sectors = _leaf->max_tx() >> SECTOR_SHIFT;
+    if (_leaf->can_discard())
+        our_params.types |= UBLK_PARAM_TYPE_DISCARD;
+    else
+        our_params.types &= ~UBLK_PARAM_TYPE_DISCARD;
+    _direct_io = _leaf->direct_io();
+
+    // presented = D + md_chunk + R, where R = _data_band_threshold - md_chunk.
+    auto const presented_size = _data_band_size + _data_band_threshold;
+    our_params.basic.dev_sectors = presented_size >> SECTOR_SHIFT;
+    if (can_discard())
+        our_params.discard.discard_granularity = std::max(our_params.discard.discard_granularity, _leaf->block_size());
+}
+
+ublk_disk::prepare_result MdDisk::prepare(ublksrv_queue const* q, int const iouring_device_start) {
+    return _leaf->prepare(q, iouring_device_start);
+}
+
+void MdDisk::probe_tick(ublksrv_queue const* q) noexcept { _leaf->probe_tick(q); }
+
+disk_task< int > MdDisk::async_iov(ublksrv_queue const* q, ublk_io_data const* data, iovec* iovecs, uint32_t nr_vecs,
+                                   uint64_t addr) {
+    auto const op = ublksrv_get_op(data->iod);
+    if (op == UBLK_IO_OP_FLUSH) co_return co_await _leaf->async_iov(q, data, iovecs, nr_vecs, addr).start();
+
+    auto const len = static_cast< uint64_t >(iovec_len(iovecs, iovecs + nr_vecs));
+    uint64_t leaf_addr;
+    if (addr + len <= _data_band_threshold) {
+        leaf_addr = addr + k_head_zone_shift;
+    } else if (addr >= _data_band_threshold) {
+        leaf_addr = addr + _data_band_shift;
+    } else {
+        // I/O straddling the head zone / data band boundary. Should not happen in practice
+        // because RAID1 metadata writes are aligned to k_page_size and never cross _reserved_size,
+        // and RAID0/RAID1 user-data writes are aligned to chunk_size. Defensive failure.
+        DLOGE("MdDisk: I/O straddles head-zone boundary [addr={:#x}, len={:#x}, threshold={:#x}]", addr, len,
+              _data_band_threshold);
+        co_return -EINVAL;
+    }
+    co_return co_await _leaf->async_iov(q, data, iovecs, nr_vecs, leaf_addr).start();
+}
+
+io_result MdDisk::sync_iov(uint8_t op, iovec* iovecs, uint32_t nr_vecs, off_t addr) noexcept {
+    auto const len = iovec_len(iovecs, iovecs + nr_vecs);
+    auto const uaddr = static_cast< uint64_t >(addr);
+    off_t leaf_addr;
+    if (uaddr + len <= _data_band_threshold) {
+        leaf_addr = static_cast< off_t >(uaddr + k_head_zone_shift);
+    } else if (uaddr >= _data_band_threshold) {
+        leaf_addr = static_cast< off_t >(uaddr + _data_band_shift);
+    } else {
+        DLOGE("MdDisk: sync_iov straddles head-zone boundary [addr={:#x}, len={:#x}, threshold={:#x}]", uaddr, len,
+              _data_band_threshold);
+        return std::unexpected(std::make_error_condition(std::errc::invalid_argument));
+    }
+    return _leaf->sync_iov(op, iovecs, nr_vecs, leaf_addr);
+}
+
+// ---------------------------------------------------------------------------------------------
+// Factories
+// ---------------------------------------------------------------------------------------------
+
+namespace {
+
+// Validate two MdDisks (a, b) form a complementary near=2 mirror pair.
+// `a_topo` MUST have lower dev_role than `b_topo`; caller is responsible for ordering.
+void __validate_pair_topology(DiscoveredTopology const& a, DiscoveredTopology const& b) {
+    if (a.set_uuid != b.set_uuid)
+        throw std::runtime_error(fmt::format("MdRaid1 import: set_uuid mismatch ({} vs {})",
+                                             boost::uuids::to_string(a.set_uuid), boost::uuids::to_string(b.set_uuid)));
+    if (a.md_chunk_size != b.md_chunk_size)
+        throw std::runtime_error(
+            fmt::format("MdRaid1 import: md_chunk_size mismatch ({} vs {})", a.md_chunk_size, b.md_chunk_size));
+    if (a.data_offset_bytes != b.data_offset_bytes)
+        throw std::runtime_error(
+            fmt::format("MdRaid1 import: data_offset mismatch ({} vs {})", a.data_offset_bytes, b.data_offset_bytes));
+    if (a.raid_disks != b.raid_disks)
+        throw std::runtime_error(
+            fmt::format("MdRaid1 import: raid_disks mismatch ({} vs {})", a.raid_disks, b.raid_disks));
+    if (a.layout_near != b.layout_near || a.layout_far != b.layout_far || a.layout_far_offset != b.layout_far_offset)
+        throw std::runtime_error("MdRaid1 import: layout fields differ between legs");
+    if (a.events != b.events)
+        throw std::runtime_error(fmt::format(
+            "MdRaid1 import: events counter mismatch ({} vs {}); array was not cleanly stopped", a.events, b.events));
+    // a.dev_role < b.dev_role enforced by caller; verify pair index match.
+    if ((a.dev_role / 2) != (b.dev_role / 2) || a.dev_role + 1 != b.dev_role)
+        throw std::runtime_error(
+            fmt::format("MdRaid1 import: dev_roles {} and {} are not a near=2 pair", a.dev_role, b.dev_role));
+}
+
+} // namespace
+
+disk_handle make_md_disk(disk_handle leaf) { return std::make_shared< MdDisk >(std::move(leaf)); }
+
+disk_handle make_md_raid1_disk(boost::uuids::uuid const& uuid, std::pair< disk_handle, disk_handle > legs,
+                               std::string const& parent_id) {
+    auto md_a = std::make_shared< MdDisk >(std::move(legs.first));
+    auto md_b = std::make_shared< MdDisk >(std::move(legs.second));
+    auto topo_a = md_a->topology();
+    auto topo_b = md_b->topology();
+
+    // Order so that the leg with the smaller dev_role is "a".
+    if (topo_a.dev_role > topo_b.dev_role) {
+        std::swap(md_a, md_b);
+        std::swap(topo_a, topo_b);
+    }
+    __validate_pair_topology(topo_a, topo_b);
+
+    return make_raid1_disk(uuid, std::move(md_a), std::move(md_b), parent_id);
+}
+
+disk_handle make_md_raid10_disk(boost::uuids::uuid const& uuid, std::vector< disk_handle >&& legs,
+                                std::string const& parent_id) {
+    if (legs.size() < 4 || (legs.size() & 1U) != 0)
+        throw std::runtime_error(fmt::format("MdRaid10 import: legs.size()={} (require even, >= 4)", legs.size()));
+
+    // Wrap each leg in MdDisk, capture topology.
+    std::vector< std::shared_ptr< MdDisk > > wrapped;
+    wrapped.reserve(legs.size());
+    for (auto& leg : legs)
+        wrapped.emplace_back(std::make_shared< MdDisk >(std::move(leg)));
+    legs.clear();
+
+    // Reference topology = first leg's. All others must match (other than dev_role).
+    auto const& ref = wrapped.front()->topology();
+    if (ref.raid_disks != wrapped.size())
+        throw std::runtime_error(
+            fmt::format("MdRaid10 import: md raid_disks={} but {} legs were provided", ref.raid_disks, wrapped.size()));
+    for (size_t i = 1; i < wrapped.size(); ++i) {
+        auto const& t = wrapped[i]->topology();
+        if (t.set_uuid != ref.set_uuid || t.md_chunk_size != ref.md_chunk_size ||
+            t.data_offset_bytes != ref.data_offset_bytes || t.raid_disks != ref.raid_disks ||
+            t.layout_near != ref.layout_near || t.layout_far != ref.layout_far ||
+            t.layout_far_offset != ref.layout_far_offset || t.events != ref.events)
+            throw std::runtime_error(fmt::format("MdRaid10 import: leg {} topology disagrees with leg 0", i));
+    }
+
+    // Group legs by dev_role / 2 into pairs. Each pair must contain roles 2K and 2K+1.
+    auto const num_pairs = static_cast< size_t >(ref.raid_disks / 2);
+    std::map< uint16_t, std::pair< std::shared_ptr< MdDisk >, std::shared_ptr< MdDisk > > > pairs;
+    for (auto& md : wrapped) {
+        auto const role = md->topology().dev_role;
+        auto const pair_k = static_cast< uint16_t >(role / 2);
+        auto& slot = pairs[pair_k];
+        if ((role & 1U) == 0) {
+            if (slot.first) throw std::runtime_error(fmt::format("MdRaid10 import: duplicate role {}", role));
+            slot.first = std::move(md);
+        } else {
+            if (slot.second) throw std::runtime_error(fmt::format("MdRaid10 import: duplicate role {}", role));
+            slot.second = std::move(md);
+        }
+    }
+    if (pairs.size() != num_pairs)
+        throw std::runtime_error(
+            fmt::format("MdRaid10 import: found {} pair(s), expected {}", pairs.size(), num_pairs));
+
+    // Build the RAID1 mirrors in ascending pair-K order so md's chunk-to-pair mapping
+    // (kernel uses chunk_index % (raid_disks / 2)) is preserved byte-identical.
+    auto name_gen = boost::uuids::name_generator(ref.set_uuid);
+    std::vector< disk_handle > mirrors;
+    mirrors.reserve(num_pairs);
+    for (uint16_t k = 0; k < num_pairs; ++k) {
+        auto it = pairs.find(k);
+        if (it == pairs.end() || !it->second.first || !it->second.second)
+            throw std::runtime_error(fmt::format("MdRaid10 import: missing legs for pair index {}", k));
+        auto pair_uuid = name_gen(fmt::format("partition_{}", k));
+        mirrors.emplace_back(
+            make_raid1_disk(pair_uuid, std::move(it->second.first), std::move(it->second.second), parent_id));
+    }
+
+    auto const stripe_uuid = uuid; // caller may want to use ref.set_uuid for this; we keep them distinct.
+    return make_raid0_disk(stripe_uuid, ref.md_chunk_size, std::move(mirrors));
+}
+
+} // namespace ublkpp::md

--- a/src/raid/md/md_disk.cpp
+++ b/src/raid/md/md_disk.cpp
@@ -35,6 +35,7 @@ constexpr uint32_t k_md_magic = 0xa92b4efc;
 constexpr uint32_t k_md_major_version = 1;
 constexpr uint32_t k_md_feature_reshape_active = 0x4;
 constexpr uint32_t k_md_feature_recovery_offset = 0x10;
+constexpr uint32_t k_md_level_raid1 = 1;
 constexpr uint32_t k_md_level_raid10 = 10;
 constexpr uint64_t k_md_sector_clean = ~uint64_t{0}; // MaxSector
 
@@ -118,16 +119,18 @@ DiscoveredTopology discovered_topo_from_md(ublk_disk& leaf) {
     if (feature_map & k_md_feature_recovery_offset)
         throw std::runtime_error("MdDisk: md array has recovery_offset set; cannot import");
 
-    if (le32_at(sb, k_md_off_level) != k_md_level_raid10) throw std::runtime_error("MdDisk: md array is not level 10");
+    auto const md_level = le32_at(sb, k_md_off_level);
+    if (md_level != k_md_level_raid1 && md_level != k_md_level_raid10)
+        throw std::runtime_error(fmt::format("MdDisk: md array level {} is not supported (require 1 or 10)", md_level));
 
     auto const layout = le32_at(sb, k_md_off_layout);
     auto const near_copies = static_cast< uint8_t >(layout & 0xff);
     auto const far_copies = static_cast< uint8_t >((layout >> 8) & 0xff);
     auto const far_offset = static_cast< uint8_t >((layout >> 16) & 1);
-    // mdadm's default for near=2 RAID-10 is layout=0x00010002 (far_copies=0, far_offset=1).
-    // The far_offset bit is ignored by the kernel when far_copies <= 1, so accept any layout
-    // where near_copies == 2 and there is no real "far" striping (far_copies <= 1).
-    if (near_copies != 2 || far_copies > 1)
+    // For md raid 10 (level 10), layout field is meaningful. mdadm's default for near=2 is
+    // 0x00010002 (far_copies=0, far_offset=1; the kernel ignores far_offset when far_copies<=1).
+    // For md raid 1 (level 1), layout is unused by md and may be anything; don't validate.
+    if (md_level == k_md_level_raid10 && (near_copies != 2 || far_copies > 1))
         throw std::runtime_error(
             fmt::format("MdDisk: only near=2 RAID-10 supported (layout=0x{:08x}: near={}, far={}, far_offset={})",
                         layout, near_copies, far_copies, far_offset));
@@ -136,9 +139,16 @@ DiscoveredTopology discovered_topo_from_md(ublk_disk& leaf) {
         throw std::runtime_error("MdDisk: md array is not in sync (resync_offset != MaxSector)");
 
     auto const raid_disks = le32_at(sb, k_md_off_raid_disks);
-    if (raid_disks < 4 || raid_disks > 256 || (raid_disks & 1U) != 0)
-        throw std::runtime_error(
-            fmt::format("MdDisk: unsupported raid_disks={} (require even, >=4, <=256)", raid_disks));
+    if (md_level == k_md_level_raid10) {
+        if (raid_disks < 4 || raid_disks > 256 || (raid_disks & 1U) != 0)
+            throw std::runtime_error(
+                fmt::format("MdDisk: unsupported md-raid 10 raid_disks={} (require even, >=4, <=256)", raid_disks));
+    } else {
+        // md raid 1: ublkpp RAID1 is strictly 2-way; reject N-way mirrors.
+        if (raid_disks != 2)
+            throw std::runtime_error(
+                fmt::format("MdDisk: md-raid 1 with raid_disks={} is unsupported (ublkpp RAID1 is 2-way)", raid_disks));
+    }
 
     auto const dev_number = le32_at(sb, k_md_off_dev_number);
     if (dev_number >= raid_disks)
@@ -157,18 +167,21 @@ DiscoveredTopology discovered_topo_from_md(ublk_disk& leaf) {
     t.layout_near = near_copies;
     t.layout_far = far_copies;
     t.layout_far_offset = far_offset;
+    t.md_level = static_cast< uint8_t >(md_level);
     t.events = le64_at(sb, k_md_off_events);
     std::memcpy(t.set_uuid.data, sb + k_md_off_set_uuid, sizeof(t.set_uuid.data));
 
-    if (t.md_chunk_size == 0 || t.md_chunk_size < raid1::k_min_chunk_size)
+    // chunk_size only matters for md raid 10 (it becomes the RAID0 stripe size in the import
+    // stack). md raid 1 has no striping, so chunk_size is meaningless and may be 0.
+    if (md_level == k_md_level_raid10 && (t.md_chunk_size == 0 || t.md_chunk_size < raid1::k_min_chunk_size))
         throw std::runtime_error(fmt::format("MdDisk: md chunk_size {} is below ublkpp k_min_chunk_size {}",
                                              t.md_chunk_size, raid1::k_min_chunk_size));
     if (t.data_offset_bytes == 0)
         throw std::runtime_error("MdDisk: md data_offset is zero (1.0 superblock or unset; not supported)");
 
-    DLOGI("MdDisk: discovered md-raid10 topology on {}: set_uuid={}, raid_disks={}, dev_role={}, "
+    DLOGI("MdDisk: discovered md-raid {} topology on {}: set_uuid={}, raid_disks={}, dev_role={}, "
           "chunk={}KiB, data_offset={}MiB, events={}",
-          leaf, boost::uuids::to_string(t.set_uuid), t.raid_disks, t.dev_role, t.md_chunk_size / Ki,
+          t.md_level, leaf, boost::uuids::to_string(t.set_uuid), t.raid_disks, t.dev_role, t.md_chunk_size / Ki,
           t.data_offset_bytes / Mi, t.events);
 
     return t;
@@ -184,18 +197,18 @@ uint64_t MdDisk::__compute_raid1_reserved(uint64_t presented_size, uint64_t max_
     return reserved;
 }
 
-MdDisk::MdDisk(disk_handle leaf) : ublk_disk(), _leaf(std::move(leaf)) {
+MdDisk::MdDisk(disk_handle leaf, boost::uuids::uuid const& uuid) : ublk_disk(), _leaf(std::move(leaf)) {
     if (!_leaf) throw std::runtime_error("MdDisk: leaf is null");
     if (_leaf->is_missing()) throw std::runtime_error("MdDisk: leaf is missing");
 
-    __probe_and_init();
+    __probe_and_init(uuid);
     __populate_params();
     _id = fmt::format("MdDisk[{}@{}MiB]", _leaf->id(), _topo.data_offset_bytes / Mi);
 }
 
 MdDisk::~MdDisk() = default;
 
-void MdDisk::__probe_and_init() {
+void MdDisk::__probe_and_init(boost::uuids::uuid const& expected_uuid) {
     // Look for our own superblock at leaf byte 0 (bypass any translation; this is BEFORE
     // _data_band_threshold/_data_band_shift are set).
     AlignedBuf own(_leaf->block_size(), k_page_size);
@@ -214,13 +227,33 @@ void MdDisk::__probe_and_init() {
         _topo.layout_near = mdsb->fields.layout_near;
         _topo.layout_far = mdsb->fields.layout_far;
         _topo.layout_far_offset = mdsb->fields.layout_far_offset;
+        // md_level field was added after the initial MdDisk SB layout (where its byte was
+        // _pad0=0). A zero on disk means a legacy v1 wrapper that only ever accepted level 10,
+        // so back-fill that interpretation here.
+        _topo.md_level = (mdsb->fields.md_level == 0) ? 10 : mdsb->fields.md_level;
         _topo.events = be64toh(mdsb->fields.events_at_import);
         std::memcpy(_topo.set_uuid.data, mdsb->header.md_set_uuid, sizeof(mdsb->header.md_set_uuid));
+
+        // Verify the stored set_uuid matches the caller-provided volume uuid. Refuses to
+        // attach a leg that belongs to a different array than the caller expects.
+        if (_topo.set_uuid != expected_uuid)
+            throw std::runtime_error(fmt::format(
+                "MdDisk: stored set_uuid {} does not match expected volume uuid {} on {}",
+                boost::uuids::to_string(_topo.set_uuid), boost::uuids::to_string(expected_uuid), _leaf->id()));
+
         DLOGI("MdDisk: re-attached existing wrapper on {}: set_uuid={}, dev_role={}, data_offset={}MiB", _leaf->id(),
               boost::uuids::to_string(_topo.set_uuid), _topo.dev_role, _topo.data_offset_bytes / Mi);
     } else {
         // Fresh import path: parse md SB, write our own SB, scrub md SB to prevent kernel auto-assemble.
         _topo = discovered_topo_from_md(*_leaf);
+
+        // Verify md's set_uuid matches the caller-provided volume uuid. Production md arrays
+        // are created with the volume uuid as the array set_uuid, so this check refuses to
+        // import legs that don't belong to the expected volume.
+        if (_topo.set_uuid != expected_uuid)
+            throw std::runtime_error(fmt::format(
+                "MdDisk: md array set_uuid {} does not match expected volume uuid {} on {}",
+                boost::uuids::to_string(_topo.set_uuid), boost::uuids::to_string(expected_uuid), _leaf->id()));
 
         std::memset(own.ptr, 0, k_page_size);
         std::memcpy(mdsb->header.magic, k_magic, k_magic_size);
@@ -233,6 +266,7 @@ void MdDisk::__probe_and_init() {
         mdsb->fields.layout_near = _topo.layout_near;
         mdsb->fields.layout_far = _topo.layout_far;
         mdsb->fields.layout_far_offset = _topo.layout_far_offset;
+        mdsb->fields.md_level = _topo.md_level;
         mdsb->fields.events_at_import = htobe64(_topo.events);
         if (auto w = leaf_pwrite(*_leaf, 0, own.ptr, k_page_size); !w)
             throw std::runtime_error(fmt::format("MdDisk: failed to write own SB: {}", w.error().message()));
@@ -353,40 +387,42 @@ io_result MdDisk::sync_iov(uint8_t op, iovec* iovecs, uint32_t nr_vecs, off_t ad
 
 namespace {
 
-// Validate two MdDisks (a, b) form a complementary near=2 mirror pair.
-// `a_topo` MUST have lower dev_role than `b_topo`; caller is responsible for ordering.
+// Validate two MdDisks (a, b) form a mirror pair. For md raid 10 (near=2): pair is roles
+// 2K and 2K+1 for some K. For md raid 1: pair is roles 0 and 1 (2-way mirror).
+// `a` MUST have lower dev_role than `b`; caller is responsible for ordering.
 void __validate_pair_topology(DiscoveredTopology const& a, DiscoveredTopology const& b) {
     if (a.set_uuid != b.set_uuid)
-        throw std::runtime_error(fmt::format("MdRaid1 import: set_uuid mismatch ({} vs {})",
+        throw std::runtime_error(fmt::format("MdImport: set_uuid mismatch ({} vs {})",
                                              boost::uuids::to_string(a.set_uuid), boost::uuids::to_string(b.set_uuid)));
+    if (a.md_level != b.md_level)
+        throw std::runtime_error(fmt::format("MdImport: md level mismatch ({} vs {})", a.md_level, b.md_level));
     if (a.md_chunk_size != b.md_chunk_size)
         throw std::runtime_error(
-            fmt::format("MdRaid1 import: md_chunk_size mismatch ({} vs {})", a.md_chunk_size, b.md_chunk_size));
+            fmt::format("MdImport: md_chunk_size mismatch ({} vs {})", a.md_chunk_size, b.md_chunk_size));
     if (a.data_offset_bytes != b.data_offset_bytes)
         throw std::runtime_error(
-            fmt::format("MdRaid1 import: data_offset mismatch ({} vs {})", a.data_offset_bytes, b.data_offset_bytes));
+            fmt::format("MdImport: data_offset mismatch ({} vs {})", a.data_offset_bytes, b.data_offset_bytes));
     if (a.raid_disks != b.raid_disks)
-        throw std::runtime_error(
-            fmt::format("MdRaid1 import: raid_disks mismatch ({} vs {})", a.raid_disks, b.raid_disks));
+        throw std::runtime_error(fmt::format("MdImport: raid_disks mismatch ({} vs {})", a.raid_disks, b.raid_disks));
     if (a.layout_near != b.layout_near || a.layout_far != b.layout_far || a.layout_far_offset != b.layout_far_offset)
-        throw std::runtime_error("MdRaid1 import: layout fields differ between legs");
+        throw std::runtime_error("MdImport: layout fields differ between legs");
     if (a.events != b.events)
         throw std::runtime_error(fmt::format(
-            "MdRaid1 import: events counter mismatch ({} vs {}); array was not cleanly stopped", a.events, b.events));
-    // a.dev_role < b.dev_role enforced by caller; verify pair index match.
+            "MdImport: events counter mismatch ({} vs {}); array was not cleanly stopped", a.events, b.events));
+    // a.dev_role < b.dev_role enforced by caller; verify pair index match. For md raid 10
+    // pair K is roles {2K, 2K+1}; for md raid 1 the only pair is {0, 1}. Both check the same
+    // way: roles differ by 1 and share the same pair index (role/2).
     if ((a.dev_role / 2) != (b.dev_role / 2) || a.dev_role + 1 != b.dev_role)
         throw std::runtime_error(
-            fmt::format("MdRaid1 import: dev_roles {} and {} are not a near=2 pair", a.dev_role, b.dev_role));
+            fmt::format("MdImport: dev_roles {} and {} are not a mirror pair", a.dev_role, b.dev_role));
 }
 
 } // namespace
 
-disk_handle make_md_disk(disk_handle leaf) { return std::make_shared< MdDisk >(std::move(leaf)); }
-
 disk_handle make_md_raid1_disk(boost::uuids::uuid const& uuid, std::pair< disk_handle, disk_handle > legs,
                                std::string const& parent_id) {
-    auto md_a = std::make_shared< MdDisk >(std::move(legs.first));
-    auto md_b = std::make_shared< MdDisk >(std::move(legs.second));
+    auto md_a = std::make_shared< MdDisk >(std::move(legs.first), uuid);
+    auto md_b = std::make_shared< MdDisk >(std::move(legs.second), uuid);
     auto topo_a = md_a->topology();
     auto topo_b = md_b->topology();
 
@@ -405,21 +441,25 @@ disk_handle make_md_raid10_disk(boost::uuids::uuid const& uuid, std::vector< dis
     if (legs.size() < 4 || (legs.size() & 1U) != 0)
         throw std::runtime_error(fmt::format("MdRaid10 import: legs.size()={} (require even, >= 4)", legs.size()));
 
-    // Wrap each leg in MdDisk, capture topology.
+    // Wrap each leg in MdDisk; each MdDisk verifies the caller's uuid against its md /
+    // wrapper SB. A leg from another array will throw here.
     std::vector< std::shared_ptr< MdDisk > > wrapped;
     wrapped.reserve(legs.size());
     for (auto& leg : legs)
-        wrapped.emplace_back(std::make_shared< MdDisk >(std::move(leg)));
+        wrapped.emplace_back(std::make_shared< MdDisk >(std::move(leg), uuid));
     legs.clear();
 
     // Reference topology = first leg's. All others must match (other than dev_role).
     auto const& ref = wrapped.front()->topology();
+    if (ref.md_level != 10)
+        throw std::runtime_error(fmt::format(
+            "MdRaid10 import: source array is md level {}, not 10 (use make_md_raid1_disk for level 1)", ref.md_level));
     if (ref.raid_disks != wrapped.size())
         throw std::runtime_error(
             fmt::format("MdRaid10 import: md raid_disks={} but {} legs were provided", ref.raid_disks, wrapped.size()));
     for (size_t i = 1; i < wrapped.size(); ++i) {
         auto const& t = wrapped[i]->topology();
-        if (t.set_uuid != ref.set_uuid || t.md_chunk_size != ref.md_chunk_size ||
+        if (t.set_uuid != ref.set_uuid || t.md_level != ref.md_level || t.md_chunk_size != ref.md_chunk_size ||
             t.data_offset_bytes != ref.data_offset_bytes || t.raid_disks != ref.raid_disks ||
             t.layout_near != ref.layout_near || t.layout_far != ref.layout_far ||
             t.layout_far_offset != ref.layout_far_offset || t.events != ref.events)
@@ -446,8 +486,10 @@ disk_handle make_md_raid10_disk(boost::uuids::uuid const& uuid, std::vector< dis
             fmt::format("MdRaid10 import: found {} pair(s), expected {}", pairs.size(), num_pairs));
 
     // Build the RAID1 mirrors in ascending pair-K order so md's chunk-to-pair mapping
-    // (kernel uses chunk_index % (raid_disks / 2)) is preserved byte-identical.
-    auto name_gen = boost::uuids::name_generator(ref.set_uuid);
+    // (kernel uses chunk_index % (raid_disks / 2)) is preserved byte-identical. The pair
+    // UUIDs are derived from the caller-supplied volume uuid (== md set_uuid after MdDisk
+    // verification), which is what the analogous fresh-create raid10 would have produced.
+    auto name_gen = boost::uuids::name_generator(uuid);
     std::vector< disk_handle > mirrors;
     mirrors.reserve(num_pairs);
     for (uint16_t k = 0; k < num_pairs; ++k) {
@@ -459,8 +501,8 @@ disk_handle make_md_raid10_disk(boost::uuids::uuid const& uuid, std::vector< dis
             make_raid1_disk(pair_uuid, std::move(it->second.first), std::move(it->second.second), parent_id));
     }
 
-    auto const stripe_uuid = uuid; // caller may want to use ref.set_uuid for this; we keep them distinct.
-    return make_raid0_disk(stripe_uuid, ref.md_chunk_size, std::move(mirrors));
+    // raid0 SB carries the volume uuid; verified on every reattach.
+    return make_raid0_disk(uuid, ref.md_chunk_size, std::move(mirrors));
 }
 
 } // namespace ublkpp::md

--- a/src/raid/md/md_disk.hpp
+++ b/src/raid/md/md_disk.hpp
@@ -1,0 +1,82 @@
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <string>
+
+#include <boost/uuid/uuid.hpp>
+
+#include "ublkpp/lib/ublk_disk.hpp"
+
+#include "md_superblock.hpp"
+
+namespace ublkpp::md {
+
+// Topology captured from md's 1.2 superblock at first migration. Persisted in MdDisk's own
+// SB so subsequent attaches can re-derive the address translation without re-parsing md
+// metadata (which RAID1 above will have already overwritten).
+struct DiscoveredTopology {
+    boost::uuids::uuid set_uuid; // md array set_uuid
+    uint64_t data_offset_bytes;  // md data_offset, in bytes (md sectors << 9)
+    uint32_t md_chunk_size;      // md chunksize, in bytes
+    uint16_t raid_disks;         // md raid_disks
+    uint16_t dev_role;           // md dev_role[N] for this leg
+    uint8_t layout_near;         // 2 (near=2 only)
+    uint8_t layout_far;          // 0
+    uint8_t layout_far_offset;   // 0
+    uint64_t events;             // md events counter at import time
+};
+
+// MdDisk wraps a leaf and applies a piecewise address translation so user data continues to
+// live at md's data_offset on the leaf. Inserted only between leaves and RAID1 for legs
+// imported from md-raid; fresh ublkpp arrays do not use this wrapper.
+//
+// Per-leg layout (after migration):
+//   [0,                    4 KiB)              MdDisk SB
+//   [4 KiB,                8 KiB)              upper RAID1 SB (lands here via head-zone shift)
+//   [8 KiB,                8 KiB + bmp)        upper RAID1 bitmap
+//   [8 KiB + bmp,          12 KiB + bmp + pad) upper RAID0 SB (member offset 0 in RAID0)
+//   [..., data_offset_md)                      DEAD ZONE (alignment slack)
+//   [data_offset_md, leaf_size)                user data, byte-identical to md
+class MdDisk : public ublk_disk {
+public:
+    explicit MdDisk(disk_handle leaf);
+    ~MdDisk() override;
+
+    DiscoveredTopology const& topology() const noexcept { return _topo; }
+    disk_handle const& leaf() const noexcept { return _leaf; }
+    // Upper-layer offset where the user-data band begins. Anything below this is the
+    // RAID1 metadata band; anything at/above maps into md's user data on the leaf.
+    uint64_t data_band_threshold() const noexcept { return _data_band_threshold; }
+    // Byte width of the user-data band (rounded down for max_sectors alignment; may be
+    // up to max_sectors_bytes - 1 less than `leaf_capacity - data_offset_md`).
+    uint64_t data_band_size() const noexcept { return _data_band_size; }
+
+    std::string id() const noexcept override { return _id; }
+    prepare_result prepare(ublksrv_queue const* q, int const iouring_device_start) override;
+    void probe_tick(ublksrv_queue const* q) noexcept override;
+    disk_task< int > async_iov(ublksrv_queue const* q, ublk_io_data const* data, iovec* iovecs, uint32_t nr_vecs,
+                               uint64_t addr) override;
+    io_result sync_iov(uint8_t op, iovec* iovecs, uint32_t nr_vecs, off_t addr) noexcept override;
+
+private:
+    disk_handle _leaf;
+    DiscoveredTopology _topo{};
+    std::string _id;
+
+    // Boundary between RAID1's metadata band (uses head-zone shift) and the user-data band
+    // (uses data-band shift). Equals what RAID1 will compute as its own _reserved_size.
+    uint64_t _data_band_threshold{0};
+    // Constant: skip past MdDisk's own SB (one page at leaf byte 0).
+    static constexpr uint64_t k_head_zone_shift = k_page_size;
+    // Adds the dead-zone width so user data lands exactly at md's data_offset.
+    uint64_t _data_band_shift{0};
+    // Effective data-band size (= leaf_size - data_offset_md, possibly aligned-down).
+    uint64_t _data_band_size{0};
+
+    void __probe_and_init();
+    void __populate_params();
+    static uint64_t __compute_raid1_reserved(uint64_t presented_size, uint64_t max_sectors_bytes) noexcept;
+};
+
+} // namespace ublkpp::md

--- a/src/raid/md/md_disk.hpp
+++ b/src/raid/md/md_disk.hpp
@@ -18,12 +18,13 @@ namespace ublkpp::md {
 struct DiscoveredTopology {
     boost::uuids::uuid set_uuid; // md array set_uuid
     uint64_t data_offset_bytes;  // md data_offset, in bytes (md sectors << 9)
-    uint32_t md_chunk_size;      // md chunksize, in bytes
+    uint32_t md_chunk_size;      // md chunksize, in bytes (0 for level 1)
     uint16_t raid_disks;         // md raid_disks
     uint16_t dev_role;           // md dev_role[N] for this leg
-    uint8_t layout_near;         // 2 (near=2 only)
+    uint8_t layout_near;         // md raid 10: 2 (near=2 only); md raid 1: 0
     uint8_t layout_far;          // 0
     uint8_t layout_far_offset;   // 0
+    uint8_t md_level;            // 1 or 10
     uint64_t events;             // md events counter at import time
 };
 
@@ -40,7 +41,12 @@ struct DiscoveredTopology {
 //   [data_offset_md, leaf_size)                user data, byte-identical to md
 class MdDisk : public ublk_disk {
 public:
-    explicit MdDisk(disk_handle leaf);
+    // `uuid` is the volume identity (== md array set_uuid by construction in production).
+    // On first import: the md SB's set_uuid on the leaf must equal `uuid` or the constructor
+    // throws. On reattach: the MdDisk-stamped SB's stored uuid must equal `uuid` or the
+    // constructor throws. This is the "don't consume this disk unless it belongs to the
+    // array you think it does" guard, mirroring how raid0 / raid1 use their SB uuids.
+    MdDisk(disk_handle leaf, boost::uuids::uuid const& uuid);
     ~MdDisk() override;
 
     DiscoveredTopology const& topology() const noexcept { return _topo; }
@@ -74,7 +80,7 @@ private:
     // Effective data-band size (= leaf_size - data_offset_md, possibly aligned-down).
     uint64_t _data_band_size{0};
 
-    void __probe_and_init();
+    void __probe_and_init(boost::uuids::uuid const& expected_uuid);
     void __populate_params();
     static uint64_t __compute_raid1_reserved(uint64_t presented_size, uint64_t max_sectors_bytes) noexcept;
 };

--- a/src/raid/md/md_superblock.cpp
+++ b/src/raid/md/md_superblock.cpp
@@ -1,0 +1,9 @@
+#include "md_superblock.hpp"
+
+namespace ublkpp::md {
+
+// 128-bit magic. Independent of raid0/raid1 magic constants by inspection.
+uint8_t const k_magic[k_magic_size] = {0x6d, 0x64, 0x70, 0x70, 0x53, 0x42, 0x00, 0x01,
+                                       0xfe, 0xed, 0xfa, 0xce, 0xde, 0xad, 0xbe, 0xef};
+
+} // namespace ublkpp::md

--- a/src/raid/md/md_superblock.hpp
+++ b/src/raid/md/md_superblock.hpp
@@ -1,0 +1,51 @@
+#pragma once
+
+extern "C" {
+#include <endian.h>
+}
+
+#include <cstddef>
+#include <cstdint>
+
+#include "lib/common.hpp"
+
+namespace ublkpp::md {
+
+constexpr auto k_page_size = 4 * Ki;
+constexpr uint16_t k_sb_version = 1;
+constexpr size_t k_magic_size = 16;
+
+// 128-bit magic identifying an MdDisk-stamped leg. Distinct from raid0::magic_bytes
+// and raid1::magic_bytes; if any of those collide we want a clean parse failure rather
+// than misidentifying the wrapper.
+extern uint8_t const k_magic[k_magic_size];
+
+#ifdef __LITTLE_ENDIAN
+struct __attribute__((__packed__)) SuperBlock {
+    static constexpr size_t SIZE = k_page_size;
+    struct {
+        uint8_t magic[k_magic_size];
+        uint16_t version;        // BE16
+        uint8_t md_set_uuid[16]; // md set_uuid; cross-leg sanity
+    } header;                    // 34 bytes
+    struct {
+        uint64_t data_offset;      // BE64. bytes (md sectors << 9)
+        uint32_t md_chunk_size;    // BE32. bytes
+        uint16_t raid_disks;       // BE16
+        uint16_t dev_role;         // BE16. this leg's md dev_role[N]
+        uint8_t layout_near;       // 2
+        uint8_t layout_far;        // 0
+        uint8_t layout_far_offset; // 0
+        uint8_t _pad0;
+        uint64_t events_at_import; // BE64. diagnostic
+    } fields;                      // 32 bytes
+    uint8_t _reserved[k_page_size - sizeof(header) - sizeof(fields)];
+};
+static_assert(k_page_size == sizeof(SuperBlock), "Size of md::SuperBlock must equal k_page_size");
+static_assert(sizeof(SuperBlock::header) == 34, "md::SuperBlock::header size mismatch");
+static_assert(sizeof(((SuperBlock*)nullptr)->fields) == 32, "md::SuperBlock::fields size mismatch");
+#else
+#error "Big Endian not supported!"
+#endif
+
+} // namespace ublkpp::md

--- a/src/raid/md/md_superblock.hpp
+++ b/src/raid/md/md_superblock.hpp
@@ -30,13 +30,15 @@ struct __attribute__((__packed__)) SuperBlock {
     } header;                    // 34 bytes
     struct {
         uint64_t data_offset;      // BE64. bytes (md sectors << 9)
-        uint32_t md_chunk_size;    // BE32. bytes
+        uint32_t md_chunk_size;    // BE32. bytes (0 for md raid 1)
         uint16_t raid_disks;       // BE16
         uint16_t dev_role;         // BE16. this leg's md dev_role[N]
-        uint8_t layout_near;       // 2
+        uint8_t layout_near;       // near=2 for md raid 10; 0 for md raid 1
         uint8_t layout_far;        // 0
         uint8_t layout_far_offset; // 0
-        uint8_t _pad0;
+        uint8_t md_level;          // 1 or 10. Was _pad0 in MdDisk SB v1; legacy v1 arrays
+                                   // read 0 here and are treated as level 10 (the only
+                                   // level v1 ever accepted).
         uint64_t events_at_import; // BE64. diagnostic
     } fields;                      // 32 bytes
     uint8_t _reserved[k_page_size - sizeof(header) - sizeof(fields)];

--- a/src/raid/md/tests/CMakeLists.txt
+++ b/src/raid/md/tests/CMakeLists.txt
@@ -1,0 +1,26 @@
+cmake_minimum_required (VERSION 3.11)
+enable_testing()
+
+find_package(GTest QUIET REQUIRED)
+
+include_directories(BEFORE ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_executable(test_md_disk)
+target_sources(test_md_disk PRIVATE
+    md_test.cpp
+    $<TARGET_OBJECTS:ublk_disk>
+    $<TARGET_OBJECTS:ublk_metrics>
+    $<TARGET_OBJECTS:logging>
+    $<TARGET_OBJECTS:md_disk>
+    $<TARGET_OBJECTS:raid0>
+    $<TARGET_OBJECTS:raid1>
+)
+target_link_libraries (test_md_disk
+    GTest::gmock
+    mock_ublksrv
+    isa-l::isa-l
+    sisl::cache
+    ublksrv::ublksrv
+    $<$<PLATFORM_ID:Linux>:atomic>
+)
+add_test(NAME MdDiskTest COMMAND test_md_disk -cv warning)

--- a/src/raid/md/tests/md_test.cpp
+++ b/src/raid/md/tests/md_test.cpp
@@ -51,6 +51,24 @@ std::shared_ptr< BufferedDisk > make_clean_md_leg(std::string id, uint16_t dev_r
     return d;
 }
 
+// Stage an md raid 1 (level 1, 2-way mirror) leg. mdadm doesn't use chunk_size or layout for
+// pure mirrors, so chunksize_sectors=0 and layout=0 here.
+std::shared_ptr< BufferedDisk > make_clean_md1_leg(std::string id, uint16_t dev_role, uint64_t events = 42) {
+    auto d = std::make_shared< BufferedDisk >(k_leg_size, std::move(id));
+    MdSbBuilder b{};
+    b.level = 1;
+    b.layout = 0;
+    b.chunksize_sectors = 0;
+    b.raid_disks = 2;
+    b.dev_number = dev_role;
+    b.dev_roles[0] = 0;
+    b.dev_roles[1] = 1;
+    b.events = events;
+    b.data_offset_sectors = k_default_data_offset_bytes >> ublkpp::SECTOR_SHIFT;
+    stage_md_sb(*d, b);
+    return d;
+}
+
 } // namespace
 
 // -- discovered_topo: rejection paths --------------------------------------------------------
@@ -58,15 +76,29 @@ std::shared_ptr< BufferedDisk > make_clean_md_leg(std::string id, uint16_t dev_r
 TEST(MdDiscovery, RejectsMissingMdMagic) {
     auto d = std::make_shared< BufferedDisk >(k_leg_size, "leg0");
     // No SB staged
-    EXPECT_THROW(ublkpp::md::make_md_disk(d), std::runtime_error);
+    EXPECT_THROW(std::make_shared< ublkpp::md::MdDisk >(d, ublkpp::md::test::default_md_uuid()), std::runtime_error);
 }
 
 TEST(MdDiscovery, RejectsWrongLevel) {
     auto d = std::make_shared< BufferedDisk >(k_leg_size, "leg0");
     MdSbBuilder b{};
-    b.level = 5; // not RAID-10
+    b.level = 5; // not RAID-1 or RAID-10
     stage_md_sb(*d, b);
-    EXPECT_THROW(ublkpp::md::make_md_disk(d), std::runtime_error);
+    EXPECT_THROW(std::make_shared< ublkpp::md::MdDisk >(d, ublkpp::md::test::default_md_uuid()), std::runtime_error);
+}
+
+TEST(MdDiscovery, RejectsLevel1NonTwoWayMirror) {
+    auto d = std::make_shared< BufferedDisk >(k_leg_size, "leg0");
+    MdSbBuilder b{};
+    b.level = 1;
+    b.layout = 0;
+    b.chunksize_sectors = 0;
+    b.raid_disks = 3; // 3-way mirror not supported by ublkpp RAID1
+    b.dev_roles[0] = 0;
+    b.dev_roles[1] = 1;
+    b.dev_roles[2] = 2;
+    stage_md_sb(*d, b);
+    EXPECT_THROW(std::make_shared< ublkpp::md::MdDisk >(d, ublkpp::md::test::default_md_uuid()), std::runtime_error);
 }
 
 TEST(MdDiscovery, RejectsFarLayout) {
@@ -74,7 +106,7 @@ TEST(MdDiscovery, RejectsFarLayout) {
     MdSbBuilder b{};
     b.layout = 0x00020001; // far_copies=2, near_copies=1
     stage_md_sb(*d, b);
-    EXPECT_THROW(ublkpp::md::make_md_disk(d), std::runtime_error);
+    EXPECT_THROW(std::make_shared< ublkpp::md::MdDisk >(d, ublkpp::md::test::default_md_uuid()), std::runtime_error);
 }
 
 TEST(MdDiscovery, RejectsDirty) {
@@ -82,7 +114,7 @@ TEST(MdDiscovery, RejectsDirty) {
     MdSbBuilder b{};
     b.resync_offset = 0; // not clean
     stage_md_sb(*d, b);
-    EXPECT_THROW(ublkpp::md::make_md_disk(d), std::runtime_error);
+    EXPECT_THROW(std::make_shared< ublkpp::md::MdDisk >(d, ublkpp::md::test::default_md_uuid()), std::runtime_error);
 }
 
 TEST(MdDiscovery, RejectsReshapeActive) {
@@ -90,7 +122,7 @@ TEST(MdDiscovery, RejectsReshapeActive) {
     MdSbBuilder b{};
     b.feature_map = 0x4; // RESHAPE_ACTIVE
     stage_md_sb(*d, b);
-    EXPECT_THROW(ublkpp::md::make_md_disk(d), std::runtime_error);
+    EXPECT_THROW(std::make_shared< ublkpp::md::MdDisk >(d, ublkpp::md::test::default_md_uuid()), std::runtime_error);
 }
 
 TEST(MdDiscovery, RejectsRecoveryOffset) {
@@ -98,7 +130,7 @@ TEST(MdDiscovery, RejectsRecoveryOffset) {
     MdSbBuilder b{};
     b.feature_map = 0x10; // RECOVERY_OFFSET
     stage_md_sb(*d, b);
-    EXPECT_THROW(ublkpp::md::make_md_disk(d), std::runtime_error);
+    EXPECT_THROW(std::make_shared< ublkpp::md::MdDisk >(d, ublkpp::md::test::default_md_uuid()), std::runtime_error);
 }
 
 TEST(MdDiscovery, RejectsSpareDevRole) {
@@ -106,7 +138,7 @@ TEST(MdDiscovery, RejectsSpareDevRole) {
     MdSbBuilder b{};
     b.dev_roles[0] = 0xFFFE; // faulty / spare marker (>= raid_disks)
     stage_md_sb(*d, b);
-    EXPECT_THROW(ublkpp::md::make_md_disk(d), std::runtime_error);
+    EXPECT_THROW(std::make_shared< ublkpp::md::MdDisk >(d, ublkpp::md::test::default_md_uuid()), std::runtime_error);
 }
 
 TEST(MdDiscovery, RejectsTinyDataOffset) {
@@ -114,7 +146,7 @@ TEST(MdDiscovery, RejectsTinyDataOffset) {
     MdSbBuilder b{};
     b.data_offset_sectors = 8; // 4 KiB; way too small for ublkpp metadata
     stage_md_sb(*d, b);
-    EXPECT_THROW(ublkpp::md::make_md_disk(d), std::runtime_error);
+    EXPECT_THROW(std::make_shared< ublkpp::md::MdDisk >(d, ublkpp::md::test::default_md_uuid()), std::runtime_error);
 }
 
 TEST(MdDiscovery, RejectsOddDataOffset) {
@@ -123,17 +155,37 @@ TEST(MdDiscovery, RejectsOddDataOffset) {
     MdSbBuilder b{};
     b.data_offset_sectors = 0;
     stage_md_sb(*d, b);
-    EXPECT_THROW(ublkpp::md::make_md_disk(d), std::runtime_error);
+    EXPECT_THROW(std::make_shared< ublkpp::md::MdDisk >(d, ublkpp::md::test::default_md_uuid()), std::runtime_error);
+}
+
+TEST(MdDiscovery, RejectsWrongVolumeUuid) {
+    // md SB carries the default set_uuid {0xa0..0xaf}; caller passes a totally different
+    // uuid. MdDisk must refuse to consume the leg (the "this leg doesn't belong to your
+    // volume" guard).
+    auto d = std::make_shared< BufferedDisk >(k_leg_size, "leg0");
+    stage_md_sb(*d, MdSbBuilder{});
+    boost::uuids::uuid wrong_uuid{}; // all zeros
+    EXPECT_THROW(std::make_shared< ublkpp::md::MdDisk >(d, wrong_uuid), std::runtime_error);
+}
+
+TEST(MdDiscovery, ReattachRejectsWrongVolumeUuid) {
+    auto leaf = make_clean_md_leg("leg0", 0);
+    // First attach with the correct uuid succeeds and stamps the MdDisk SB.
+    {
+        auto md = std::make_shared< ublkpp::md::MdDisk >(leaf, ublkpp::md::test::default_md_uuid());
+        ASSERT_NE(md, nullptr);
+    }
+    // Reattach with a different uuid must fail at the stored-uuid verification step.
+    boost::uuids::uuid wrong_uuid{};
+    EXPECT_THROW(std::make_shared< ublkpp::md::MdDisk >(leaf, wrong_uuid), std::runtime_error);
 }
 
 // -- successful single-leg wrap + topology persistence ---------------------------------------
 
 TEST(MdDiscovery, WrapsCleanLeg) {
     auto leaf = make_clean_md_leg("leg0", /*dev_role=*/1);
-    auto md = ublkpp::md::make_md_disk(leaf);
-    auto* mdimpl = dynamic_cast< ublkpp::md::MdDisk* >(md.get());
-    ASSERT_NE(mdimpl, nullptr);
-    auto const& t = mdimpl->topology();
+    auto md = std::make_shared< ublkpp::md::MdDisk >(leaf, ublkpp::md::test::default_md_uuid());
+    auto const& t = md->topology();
     EXPECT_EQ(t.dev_role, 1);
     EXPECT_EQ(t.raid_disks, 4);
     EXPECT_EQ(t.md_chunk_size, k_default_chunk_bytes);
@@ -151,7 +203,7 @@ TEST(MdDiscovery, ScrubsMdSbAfterWrap) {
     // Pre-import: md magic at byte 4 KiB
     EXPECT_EQ(leaf->data()[4 * Ki], 0xfc); // 0xa92b4efc LE first byte
     {
-        auto md = ublkpp::md::make_md_disk(leaf);
+        auto md = std::make_shared< ublkpp::md::MdDisk >(leaf, ublkpp::md::test::default_md_uuid());
         ASSERT_NE(md, nullptr);
     }
     // Post-import: md SB must be zeroed; MdDisk magic must be at byte 0.
@@ -163,22 +215,20 @@ TEST(MdDiscovery, ScrubsMdSbAfterWrap) {
 TEST(MdDiscovery, ReattachReadsOwnSbWithoutMdSb) {
     auto leaf = make_clean_md_leg("leg0", /*dev_role=*/2);
     {
-        auto md1 = ublkpp::md::make_md_disk(leaf);
+        auto md1 = std::make_shared< ublkpp::md::MdDisk >(leaf, ublkpp::md::test::default_md_uuid());
         ASSERT_NE(md1, nullptr);
     }
     // First wrap scrubbed md SB. Second wrap must succeed by reading our own SB at byte 0.
-    auto md2 = ublkpp::md::make_md_disk(leaf);
-    auto* mdimpl = dynamic_cast< ublkpp::md::MdDisk* >(md2.get());
-    ASSERT_NE(mdimpl, nullptr);
-    EXPECT_EQ(mdimpl->topology().dev_role, 2);
-    EXPECT_EQ(mdimpl->topology().raid_disks, 4);
+    auto md2 = std::make_shared< ublkpp::md::MdDisk >(leaf, ublkpp::md::test::default_md_uuid());
+    EXPECT_EQ(md2->topology().dev_role, 2);
+    EXPECT_EQ(md2->topology().raid_disks, 4);
 }
 
 // -- piecewise translation -------------------------------------------------------------------
 
 TEST(MdTranslation, HeadZoneShiftsByOnePage) {
     auto leaf = make_clean_md_leg("leg0", 0);
-    auto md = ublkpp::md::make_md_disk(leaf);
+    auto md = std::make_shared< ublkpp::md::MdDisk >(leaf, ublkpp::md::test::default_md_uuid());
 
     // Write a distinctive byte at upper offset 0; expect it at leaf byte 4 KiB.
     uint8_t pattern[ublkpp::md::k_page_size];
@@ -200,14 +250,12 @@ TEST(MdTranslation, DataBandLandsAtMdDataOffset) {
     constexpr size_t k_pattern_len = 64 * Ki;
     ublkpp::md::test::fill_pattern(leaf->data() + k_default_data_offset_bytes, k_pattern_len, k_pattern_seed);
 
-    auto md = ublkpp::md::make_md_disk(leaf);
-    auto* mdimpl = dynamic_cast< ublkpp::md::MdDisk* >(md.get());
-    ASSERT_NE(mdimpl, nullptr);
+    auto md = std::make_shared< ublkpp::md::MdDisk >(leaf, ublkpp::md::test::default_md_uuid());
 
     // The first byte of "user data" from MdDisk's view is at upper offset
     // _data_band_threshold. Read 64 KiB starting there and compare with the leaf bytes
     // at data_offset.
-    auto const upper_user_start = mdimpl->data_band_threshold();
+    auto const upper_user_start = md->data_band_threshold();
     // Sanity: upper_user_start should equal _data_band_threshold (R + chunk).
     // We can't read R from outside, but we can verify the read returns md's bytes.
     std::vector< uint8_t > read_buf(k_pattern_len, 0);
@@ -222,22 +270,40 @@ TEST(MdTranslation, DataBandLandsAtMdDataOffset) {
 TEST(MdRaid1Factory, AcceptsComplementaryPair) {
     auto a = make_clean_md_leg("leg0", 0);
     auto b = make_clean_md_leg("leg1", 1);
-    auto uuid = boost::uuids::random_generator()();
+    auto const& uuid = ublkpp::md::test::default_md_uuid();
     auto raid1 = ublkpp::md::make_md_raid1_disk(uuid, {a, b});
     EXPECT_NE(raid1, nullptr);
+}
+
+TEST(MdRaid1Factory, AcceptsLevel1Array) {
+    // Pure md level 1, no chunking, no layout. The factory must accept this just like a
+    // 2-leg near=2 md raid 10.
+    auto a = make_clean_md1_leg("md1_leg0", 0);
+    auto b = make_clean_md1_leg("md1_leg1", 1);
+    auto const& uuid = ublkpp::md::test::default_md_uuid();
+    auto raid1 = ublkpp::md::make_md_raid1_disk(uuid, {a, b});
+    EXPECT_NE(raid1, nullptr);
+}
+
+TEST(MdRaid1Factory, RejectsMixedLevels) {
+    // One leg from md level 1, one from md level 10 - explicit cross-leg level mismatch.
+    auto a = make_clean_md_leg("leg0_l10", 0);
+    auto b = make_clean_md1_leg("leg1_l1", 1);
+    auto const& uuid = ublkpp::md::test::default_md_uuid();
+    EXPECT_THROW(ublkpp::md::make_md_raid1_disk(uuid, {a, b}), std::runtime_error);
 }
 
 TEST(MdRaid1Factory, RejectsEventsMismatch) {
     auto a = make_clean_md_leg("leg0", 0, 4, /*events=*/42);
     auto b = make_clean_md_leg("leg1", 1, 4, /*events=*/43);
-    auto uuid = boost::uuids::random_generator()();
+    auto const& uuid = ublkpp::md::test::default_md_uuid();
     EXPECT_THROW(ublkpp::md::make_md_raid1_disk(uuid, {a, b}), std::runtime_error);
 }
 
 TEST(MdRaid1Factory, RejectsNonComplementaryRoles) {
     auto a = make_clean_md_leg("leg0", 0); // dev_role 0 (pair 0)
     auto b = make_clean_md_leg("leg1", 2); // dev_role 2 (pair 1) - not pair 0's mate
-    auto uuid = boost::uuids::random_generator()();
+    auto const& uuid = ublkpp::md::test::default_md_uuid();
     EXPECT_THROW(ublkpp::md::make_md_raid1_disk(uuid, {a, b}), std::runtime_error);
 }
 
@@ -245,7 +311,7 @@ TEST(MdRaid1Factory, ReordersPair) {
     // Provide legs in (1, 0) order; factory should swap so 0 is "a".
     auto leg0 = make_clean_md_leg("leg0", 0);
     auto leg1 = make_clean_md_leg("leg1", 1);
-    auto uuid = boost::uuids::random_generator()();
+    auto const& uuid = ublkpp::md::test::default_md_uuid();
     auto raid1 = ublkpp::md::make_md_raid1_disk(uuid, {leg1, leg0}); // swapped
     EXPECT_NE(raid1, nullptr);
 }
@@ -256,7 +322,7 @@ TEST(MdRaid10Factory, FourDiskHappyPath) {
     std::vector< ublkpp::disk_handle > legs;
     for (uint16_t i = 0; i < 4; ++i)
         legs.push_back(make_clean_md_leg(fmt::format("leg{}", i), i, 4));
-    auto uuid = boost::uuids::random_generator()();
+    auto const& uuid = ublkpp::md::test::default_md_uuid();
     auto stack = ublkpp::md::make_md_raid10_disk(uuid, std::move(legs));
     EXPECT_NE(stack, nullptr);
 }
@@ -268,7 +334,7 @@ TEST(MdRaid10Factory, FourDiskShuffledOrder) {
     legs.push_back(make_clean_md_leg("leg1", 1, 4));
     legs.push_back(make_clean_md_leg("leg0", 0, 4));
     legs.push_back(make_clean_md_leg("leg2", 2, 4));
-    auto uuid = boost::uuids::random_generator()();
+    auto const& uuid = ublkpp::md::test::default_md_uuid();
     auto stack = ublkpp::md::make_md_raid10_disk(uuid, std::move(legs));
     EXPECT_NE(stack, nullptr);
 }
@@ -277,9 +343,21 @@ TEST(MdRaid10Factory, SixDiskHappyPath) {
     std::vector< ublkpp::disk_handle > legs;
     for (uint16_t i = 0; i < 6; ++i)
         legs.push_back(make_clean_md_leg(fmt::format("leg{}", i), i, 6));
-    auto uuid = boost::uuids::random_generator()();
+    auto const& uuid = ublkpp::md::test::default_md_uuid();
     auto stack = ublkpp::md::make_md_raid10_disk(uuid, std::move(legs));
     EXPECT_NE(stack, nullptr);
+}
+
+TEST(MdRaid10Factory, RejectsLevel1Source) {
+    // Building a RAID10 from md level 1 legs makes no sense (no striping in the source);
+    // factory should refuse with a clear error rather than silently treating it as raid 10.
+    std::vector< ublkpp::disk_handle > legs;
+    legs.push_back(make_clean_md1_leg("md1_leg0", 0));
+    legs.push_back(make_clean_md1_leg("md1_leg1", 1));
+    legs.push_back(make_clean_md1_leg("md1_leg2", 0));
+    legs.push_back(make_clean_md1_leg("md1_leg3", 1));
+    auto const& uuid = ublkpp::md::test::default_md_uuid();
+    EXPECT_THROW(ublkpp::md::make_md_raid10_disk(uuid, std::move(legs)), std::runtime_error);
 }
 
 TEST(MdRaid10Factory, RejectsRaidDisksMismatch) {
@@ -287,7 +365,7 @@ TEST(MdRaid10Factory, RejectsRaidDisksMismatch) {
     std::vector< ublkpp::disk_handle > legs;
     for (uint16_t i = 0; i < 3; ++i)
         legs.push_back(make_clean_md_leg(fmt::format("leg{}", i), i, 4));
-    auto uuid = boost::uuids::random_generator()();
+    auto const& uuid = ublkpp::md::test::default_md_uuid();
     EXPECT_THROW(ublkpp::md::make_md_raid10_disk(uuid, std::move(legs)), std::runtime_error);
 }
 
@@ -298,7 +376,7 @@ TEST(MdRaid10Factory, RejectsDuplicateDevRole) {
     legs.push_back(make_clean_md_leg("leg0_dup", 0, 4));
     legs.push_back(make_clean_md_leg("leg2", 2, 4));
     legs.push_back(make_clean_md_leg("leg3", 3, 4));
-    auto uuid = boost::uuids::random_generator()();
+    auto const& uuid = ublkpp::md::test::default_md_uuid();
     EXPECT_THROW(ublkpp::md::make_md_raid10_disk(uuid, std::move(legs)), std::runtime_error);
 }
 

--- a/src/raid/md/tests/md_test.cpp
+++ b/src/raid/md/tests/md_test.cpp
@@ -1,0 +1,312 @@
+#include "test_md_common.hpp"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <sisl/logging/logging.h>
+#include <sisl/options/options.h>
+
+#include "ublkpp/raid.hpp"
+
+#include "raid/md/md_disk.hpp"
+#include "raid/md/md_superblock.hpp"
+
+#define ENABLED_OPTIONS logging, raid1
+
+SISL_LOGGING_INIT(ublk_raid)
+SISL_OPTIONS_ENABLE(ENABLED_OPTIONS)
+
+extern "C" {
+struct ublksrv_queue;
+extern int ublksrv_queue_send_event(ublksrv_queue const*) { return 0; }
+}
+
+using ublkpp::Gi;
+using ublkpp::Ki;
+using ublkpp::Mi;
+using ublkpp::md::test::BufferedDisk;
+using ublkpp::md::test::MdSbBuilder;
+using ublkpp::md::test::stage_md_sb;
+
+namespace {
+
+// Kept small so the BufferedDisk in-memory backing (and ASan shadow memory) stays modest.
+// MdRaid10Factory.SixDiskHappyPath instantiates 6 of these concurrently, which would be
+// many GiB of allocation if k_leg_size were realistic.
+constexpr uint64_t k_leg_size = 16UL * Mi;
+constexpr uint64_t k_default_data_offset_bytes = 1UL * Mi;
+constexpr uint32_t k_default_chunk_bytes = 64 * Ki;
+
+std::shared_ptr< BufferedDisk > make_clean_md_leg(std::string id, uint16_t dev_role, uint16_t raid_disks = 4,
+                                                  uint64_t events = 42) {
+    auto d = std::make_shared< BufferedDisk >(k_leg_size, std::move(id));
+    MdSbBuilder b{};
+    b.raid_disks = raid_disks;
+    b.dev_number = dev_role;
+    for (uint16_t i = 0; i < raid_disks; ++i)
+        b.dev_roles[i] = i;
+    b.events = events;
+    b.data_offset_sectors = k_default_data_offset_bytes >> ublkpp::SECTOR_SHIFT;
+    b.chunksize_sectors = k_default_chunk_bytes >> ublkpp::SECTOR_SHIFT;
+    stage_md_sb(*d, b);
+    return d;
+}
+
+} // namespace
+
+// -- discovered_topo: rejection paths --------------------------------------------------------
+
+TEST(MdDiscovery, RejectsMissingMdMagic) {
+    auto d = std::make_shared< BufferedDisk >(k_leg_size, "leg0");
+    // No SB staged
+    EXPECT_THROW(ublkpp::md::make_md_disk(d), std::runtime_error);
+}
+
+TEST(MdDiscovery, RejectsWrongLevel) {
+    auto d = std::make_shared< BufferedDisk >(k_leg_size, "leg0");
+    MdSbBuilder b{};
+    b.level = 5; // not RAID-10
+    stage_md_sb(*d, b);
+    EXPECT_THROW(ublkpp::md::make_md_disk(d), std::runtime_error);
+}
+
+TEST(MdDiscovery, RejectsFarLayout) {
+    auto d = std::make_shared< BufferedDisk >(k_leg_size, "leg0");
+    MdSbBuilder b{};
+    b.layout = 0x00020001; // far_copies=2, near_copies=1
+    stage_md_sb(*d, b);
+    EXPECT_THROW(ublkpp::md::make_md_disk(d), std::runtime_error);
+}
+
+TEST(MdDiscovery, RejectsDirty) {
+    auto d = std::make_shared< BufferedDisk >(k_leg_size, "leg0");
+    MdSbBuilder b{};
+    b.resync_offset = 0; // not clean
+    stage_md_sb(*d, b);
+    EXPECT_THROW(ublkpp::md::make_md_disk(d), std::runtime_error);
+}
+
+TEST(MdDiscovery, RejectsReshapeActive) {
+    auto d = std::make_shared< BufferedDisk >(k_leg_size, "leg0");
+    MdSbBuilder b{};
+    b.feature_map = 0x4; // RESHAPE_ACTIVE
+    stage_md_sb(*d, b);
+    EXPECT_THROW(ublkpp::md::make_md_disk(d), std::runtime_error);
+}
+
+TEST(MdDiscovery, RejectsRecoveryOffset) {
+    auto d = std::make_shared< BufferedDisk >(k_leg_size, "leg0");
+    MdSbBuilder b{};
+    b.feature_map = 0x10; // RECOVERY_OFFSET
+    stage_md_sb(*d, b);
+    EXPECT_THROW(ublkpp::md::make_md_disk(d), std::runtime_error);
+}
+
+TEST(MdDiscovery, RejectsSpareDevRole) {
+    auto d = std::make_shared< BufferedDisk >(k_leg_size, "leg0");
+    MdSbBuilder b{};
+    b.dev_roles[0] = 0xFFFE; // faulty / spare marker (>= raid_disks)
+    stage_md_sb(*d, b);
+    EXPECT_THROW(ublkpp::md::make_md_disk(d), std::runtime_error);
+}
+
+TEST(MdDiscovery, RejectsTinyDataOffset) {
+    auto d = std::make_shared< BufferedDisk >(k_leg_size, "leg0");
+    MdSbBuilder b{};
+    b.data_offset_sectors = 8; // 4 KiB; way too small for ublkpp metadata
+    stage_md_sb(*d, b);
+    EXPECT_THROW(ublkpp::md::make_md_disk(d), std::runtime_error);
+}
+
+TEST(MdDiscovery, RejectsOddDataOffset) {
+    // data_offset = 0 is the special signal for unset/1.0; reject explicitly.
+    auto d = std::make_shared< BufferedDisk >(k_leg_size, "leg0");
+    MdSbBuilder b{};
+    b.data_offset_sectors = 0;
+    stage_md_sb(*d, b);
+    EXPECT_THROW(ublkpp::md::make_md_disk(d), std::runtime_error);
+}
+
+// -- successful single-leg wrap + topology persistence ---------------------------------------
+
+TEST(MdDiscovery, WrapsCleanLeg) {
+    auto leaf = make_clean_md_leg("leg0", /*dev_role=*/1);
+    auto md = ublkpp::md::make_md_disk(leaf);
+    auto* mdimpl = dynamic_cast< ublkpp::md::MdDisk* >(md.get());
+    ASSERT_NE(mdimpl, nullptr);
+    auto const& t = mdimpl->topology();
+    EXPECT_EQ(t.dev_role, 1);
+    EXPECT_EQ(t.raid_disks, 4);
+    EXPECT_EQ(t.md_chunk_size, k_default_chunk_bytes);
+    EXPECT_EQ(t.data_offset_bytes, k_default_data_offset_bytes);
+    EXPECT_EQ(t.layout_near, 2);
+    EXPECT_EQ(t.layout_far, 0);
+    // layout_far_offset is captured verbatim from md SB; mdadm sets bit 16 even when
+    // far_copies=0 (default near=2 layout = 0x00010002), so this can be 0 or 1 depending
+    // on which mdadm wrote the array. Don't assert on it.
+    EXPECT_EQ(t.events, 42);
+}
+
+TEST(MdDiscovery, ScrubsMdSbAfterWrap) {
+    auto leaf = make_clean_md_leg("leg0", 0);
+    // Pre-import: md magic at byte 4 KiB
+    EXPECT_EQ(leaf->data()[4 * Ki], 0xfc); // 0xa92b4efc LE first byte
+    {
+        auto md = ublkpp::md::make_md_disk(leaf);
+        ASSERT_NE(md, nullptr);
+    }
+    // Post-import: md SB must be zeroed; MdDisk magic must be at byte 0.
+    for (size_t i = 0; i < 4 * Ki; ++i)
+        EXPECT_EQ(leaf->data()[4 * Ki + i], 0u) << "byte " << i;
+    EXPECT_EQ(std::memcmp(leaf->data(), ublkpp::md::k_magic, ublkpp::md::k_magic_size), 0);
+}
+
+TEST(MdDiscovery, ReattachReadsOwnSbWithoutMdSb) {
+    auto leaf = make_clean_md_leg("leg0", /*dev_role=*/2);
+    {
+        auto md1 = ublkpp::md::make_md_disk(leaf);
+        ASSERT_NE(md1, nullptr);
+    }
+    // First wrap scrubbed md SB. Second wrap must succeed by reading our own SB at byte 0.
+    auto md2 = ublkpp::md::make_md_disk(leaf);
+    auto* mdimpl = dynamic_cast< ublkpp::md::MdDisk* >(md2.get());
+    ASSERT_NE(mdimpl, nullptr);
+    EXPECT_EQ(mdimpl->topology().dev_role, 2);
+    EXPECT_EQ(mdimpl->topology().raid_disks, 4);
+}
+
+// -- piecewise translation -------------------------------------------------------------------
+
+TEST(MdTranslation, HeadZoneShiftsByOnePage) {
+    auto leaf = make_clean_md_leg("leg0", 0);
+    auto md = ublkpp::md::make_md_disk(leaf);
+
+    // Write a distinctive byte at upper offset 0; expect it at leaf byte 4 KiB.
+    uint8_t pattern[ublkpp::md::k_page_size];
+    std::memset(pattern, 0x5a, sizeof(pattern));
+    iovec iov{.iov_base = pattern, .iov_len = sizeof(pattern)};
+    auto r = md->sync_iov(UBLK_IO_OP_WRITE, &iov, 1, 0);
+    ASSERT_TRUE(r) << r.error().message();
+    EXPECT_EQ(leaf->data()[4 * Ki], 0x5a);
+    EXPECT_EQ(leaf->data()[4 * Ki + 4095], 0x5a);
+    // MdDisk SB still intact at byte 0
+    EXPECT_EQ(std::memcmp(leaf->data(), ublkpp::md::k_magic, ublkpp::md::k_magic_size), 0);
+}
+
+TEST(MdTranslation, DataBandLandsAtMdDataOffset) {
+    auto leaf = make_clean_md_leg("leg0", 0);
+
+    // Pre-stage user data at the md data_offset on the leaf (simulate bytes md wrote).
+    constexpr uint64_t k_pattern_seed = 0xDEADBEEFCAFEBABEULL;
+    constexpr size_t k_pattern_len = 64 * Ki;
+    ublkpp::md::test::fill_pattern(leaf->data() + k_default_data_offset_bytes, k_pattern_len, k_pattern_seed);
+
+    auto md = ublkpp::md::make_md_disk(leaf);
+    auto* mdimpl = dynamic_cast< ublkpp::md::MdDisk* >(md.get());
+    ASSERT_NE(mdimpl, nullptr);
+
+    // The first byte of "user data" from MdDisk's view is at upper offset
+    // _data_band_threshold. Read 64 KiB starting there and compare with the leaf bytes
+    // at data_offset.
+    auto const upper_user_start = mdimpl->data_band_threshold();
+    // Sanity: upper_user_start should equal _data_band_threshold (R + chunk).
+    // We can't read R from outside, but we can verify the read returns md's bytes.
+    std::vector< uint8_t > read_buf(k_pattern_len, 0);
+    iovec iov{.iov_base = read_buf.data(), .iov_len = k_pattern_len};
+    auto r = md->sync_iov(UBLK_IO_OP_READ, &iov, 1, static_cast< off_t >(upper_user_start));
+    ASSERT_TRUE(r) << r.error().message();
+    EXPECT_EQ(std::memcmp(read_buf.data(), leaf->data() + k_default_data_offset_bytes, k_pattern_len), 0);
+}
+
+// -- factory: make_md_raid1_disk ----------------------------------------------------------
+
+TEST(MdRaid1Factory, AcceptsComplementaryPair) {
+    auto a = make_clean_md_leg("leg0", 0);
+    auto b = make_clean_md_leg("leg1", 1);
+    auto uuid = boost::uuids::random_generator()();
+    auto raid1 = ublkpp::md::make_md_raid1_disk(uuid, {a, b});
+    EXPECT_NE(raid1, nullptr);
+}
+
+TEST(MdRaid1Factory, RejectsEventsMismatch) {
+    auto a = make_clean_md_leg("leg0", 0, 4, /*events=*/42);
+    auto b = make_clean_md_leg("leg1", 1, 4, /*events=*/43);
+    auto uuid = boost::uuids::random_generator()();
+    EXPECT_THROW(ublkpp::md::make_md_raid1_disk(uuid, {a, b}), std::runtime_error);
+}
+
+TEST(MdRaid1Factory, RejectsNonComplementaryRoles) {
+    auto a = make_clean_md_leg("leg0", 0); // dev_role 0 (pair 0)
+    auto b = make_clean_md_leg("leg1", 2); // dev_role 2 (pair 1) - not pair 0's mate
+    auto uuid = boost::uuids::random_generator()();
+    EXPECT_THROW(ublkpp::md::make_md_raid1_disk(uuid, {a, b}), std::runtime_error);
+}
+
+TEST(MdRaid1Factory, ReordersPair) {
+    // Provide legs in (1, 0) order; factory should swap so 0 is "a".
+    auto leg0 = make_clean_md_leg("leg0", 0);
+    auto leg1 = make_clean_md_leg("leg1", 1);
+    auto uuid = boost::uuids::random_generator()();
+    auto raid1 = ublkpp::md::make_md_raid1_disk(uuid, {leg1, leg0}); // swapped
+    EXPECT_NE(raid1, nullptr);
+}
+
+// -- factory: make_md_raid10_disk ------------------------------------------------------------
+
+TEST(MdRaid10Factory, FourDiskHappyPath) {
+    std::vector< ublkpp::disk_handle > legs;
+    for (uint16_t i = 0; i < 4; ++i)
+        legs.push_back(make_clean_md_leg(fmt::format("leg{}", i), i, 4));
+    auto uuid = boost::uuids::random_generator()();
+    auto stack = ublkpp::md::make_md_raid10_disk(uuid, std::move(legs));
+    EXPECT_NE(stack, nullptr);
+}
+
+TEST(MdRaid10Factory, FourDiskShuffledOrder) {
+    // Provide legs in order (3, 1, 0, 2); factory should rebuild pairs (0,1) and (2,3).
+    std::vector< ublkpp::disk_handle > legs;
+    legs.push_back(make_clean_md_leg("leg3", 3, 4));
+    legs.push_back(make_clean_md_leg("leg1", 1, 4));
+    legs.push_back(make_clean_md_leg("leg0", 0, 4));
+    legs.push_back(make_clean_md_leg("leg2", 2, 4));
+    auto uuid = boost::uuids::random_generator()();
+    auto stack = ublkpp::md::make_md_raid10_disk(uuid, std::move(legs));
+    EXPECT_NE(stack, nullptr);
+}
+
+TEST(MdRaid10Factory, SixDiskHappyPath) {
+    std::vector< ublkpp::disk_handle > legs;
+    for (uint16_t i = 0; i < 6; ++i)
+        legs.push_back(make_clean_md_leg(fmt::format("leg{}", i), i, 6));
+    auto uuid = boost::uuids::random_generator()();
+    auto stack = ublkpp::md::make_md_raid10_disk(uuid, std::move(legs));
+    EXPECT_NE(stack, nullptr);
+}
+
+TEST(MdRaid10Factory, RejectsRaidDisksMismatch) {
+    // Three legs claiming raid_disks=4 (not enough)
+    std::vector< ublkpp::disk_handle > legs;
+    for (uint16_t i = 0; i < 3; ++i)
+        legs.push_back(make_clean_md_leg(fmt::format("leg{}", i), i, 4));
+    auto uuid = boost::uuids::random_generator()();
+    EXPECT_THROW(ublkpp::md::make_md_raid10_disk(uuid, std::move(legs)), std::runtime_error);
+}
+
+TEST(MdRaid10Factory, RejectsDuplicateDevRole) {
+    // Two legs both claim role 0
+    std::vector< ublkpp::disk_handle > legs;
+    legs.push_back(make_clean_md_leg("leg0", 0, 4));
+    legs.push_back(make_clean_md_leg("leg0_dup", 0, 4));
+    legs.push_back(make_clean_md_leg("leg2", 2, 4));
+    legs.push_back(make_clean_md_leg("leg3", 3, 4));
+    auto uuid = boost::uuids::random_generator()();
+    EXPECT_THROW(ublkpp::md::make_md_raid10_disk(uuid, std::move(legs)), std::runtime_error);
+}
+
+int main(int argc, char* argv[]) {
+    int parsed_argc = argc;
+    ::testing::InitGoogleTest(&parsed_argc, argv);
+    SISL_OPTIONS_LOAD(parsed_argc, argv, ENABLED_OPTIONS);
+    sisl::logging::SetLogger(std::string(argv[0]));
+    spdlog::set_pattern("[%D %T.%e] [%n] [%^%l%$] [%t] %v");
+    return RUN_ALL_TESTS();
+}

--- a/src/raid/md/tests/test_md_common.hpp
+++ b/src/raid/md/tests/test_md_common.hpp
@@ -133,6 +133,15 @@ inline MdSbBuilder stage_md_sb(BufferedDisk& d, MdSbBuilder builder = {}) {
     return builder;
 }
 
+// The default set_uuid baked into MdSbBuilder, as a boost::uuids::uuid. Tests that stage
+// legs with the builder's defaults should pass this value as the volume uuid to make_md_*
+// factories so MdDisk's verification succeeds.
+inline boost::uuids::uuid const& default_md_uuid() {
+    static boost::uuids::uuid const u{
+        {0xa0, 0xa1, 0xa2, 0xa3, 0xa4, 0xa5, 0xa6, 0xa7, 0xa8, 0xa9, 0xaa, 0xab, 0xac, 0xad, 0xae, 0xaf}};
+    return u;
+}
+
 // Fill a region with a deterministic byte pattern so cross-translation tests can verify
 // that ublkpp reads the same bytes md wrote.
 inline void fill_pattern(uint8_t* p, size_t len, uint64_t seed) {

--- a/src/raid/md/tests/test_md_common.hpp
+++ b/src/raid/md/tests/test_md_common.hpp
@@ -1,0 +1,146 @@
+#pragma once
+
+extern "C" {
+#include <endian.h>
+}
+
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <random>
+#include <utility>
+#include <vector>
+
+#include <boost/uuid/random_generator.hpp>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <ublk_cmd.h>
+#include <ublksrv.h>
+
+#include "ublkpp/lib/ublk_disk.hpp"
+
+#include "lib/common.hpp"
+
+namespace ublkpp::md::test {
+
+// md superblock 1.2 builder. Defaults produce a clean, near=2 RAID-10 leg.
+struct MdSbBuilder {
+    uint32_t magic{0xa92b4efc};
+    uint32_t major_version{1};
+    uint32_t feature_map{0};
+    uint8_t set_uuid[16]{};
+    uint32_t level{10};
+    uint32_t layout{0x00010002};     // near_copies=2, far_copies=0, far_offset=0
+    uint32_t chunksize_sectors{128}; // 64 KiB / 512
+    uint32_t raid_disks{4};
+    uint64_t data_offset_sectors{262144}; // 128 MiB / 512
+    uint32_t dev_number{0};
+    uint64_t events{42};
+    uint64_t resync_offset{~uint64_t{0}}; // clean
+    uint16_t dev_roles[256]{0, 1, 2, 3};
+
+    MdSbBuilder() {
+        // Distinct repeatable set_uuid so cross-leg checks pass.
+        for (size_t i = 0; i < 16; ++i)
+            set_uuid[i] = static_cast< uint8_t >(0xa0 + i);
+    }
+
+    void emit(uint8_t* page) const {
+        std::memset(page, 0, 4 * Ki);
+        auto put32 = [&](size_t off, uint32_t v) {
+            v = htole32(v);
+            std::memcpy(page + off, &v, sizeof(v));
+        };
+        auto put64 = [&](size_t off, uint64_t v) {
+            v = htole64(v);
+            std::memcpy(page + off, &v, sizeof(v));
+        };
+        auto put16 = [&](size_t off, uint16_t v) {
+            v = htole16(v);
+            std::memcpy(page + off, &v, sizeof(v));
+        };
+
+        put32(0x00, magic);
+        put32(0x04, major_version);
+        put32(0x08, feature_map);
+        std::memcpy(page + 0x10, set_uuid, 16);
+        put32(0x48, level);
+        put32(0x4C, layout);
+        put32(0x58, chunksize_sectors);
+        put32(0x5C, raid_disks);
+        put64(0x80, data_offset_sectors);
+        put32(0xA0, dev_number);
+        put64(0xC8, events);
+        put64(0xD0, resync_offset);
+        for (uint32_t i = 0; i < raid_disks && i < 256; ++i)
+            put16(0x100 + 2 * i, dev_roles[i]);
+    }
+};
+
+// In-memory backing for a leaf. Behaves like a regular block device via sync_iov; async_iov
+// is not exercised by MdDisk's own SB read/write or by the discovered_topo parser. RAID1 above
+// us issues async_iov but we don't unit-test that path here.
+class BufferedDisk : public ublk_disk {
+public:
+    BufferedDisk(uint64_t capacity, std::string id, uint32_t logical_bs = ublkpp::DEFAULT_BLOCK_SIZE) :
+            ublk_disk(), _id(std::move(id)) {
+        _buf.assign(capacity, 0xa5); // distinct fill so unwritten reads are noticeable
+        auto& p = *params();
+        p.basic.dev_sectors = capacity >> SECTOR_SHIFT;
+        p.basic.logical_bs_shift = ilog2(logical_bs);
+        p.basic.physical_bs_shift = p.basic.logical_bs_shift;
+        p.basic.max_sectors = (512 * Ki) >> SECTOR_SHIFT;
+        p.types |= UBLK_PARAM_TYPE_DISCARD;
+        _direct_io = true;
+    }
+
+    std::string id() const noexcept override { return _id; }
+
+    uint8_t* data() noexcept { return _buf.data(); }
+    uint8_t const* data() const noexcept { return _buf.data(); }
+    size_t size() const noexcept { return _buf.size(); }
+
+    io_result sync_iov(uint8_t op, iovec* iovecs, uint32_t nr_vecs, off_t addr) noexcept override {
+        if (addr < 0) return std::unexpected(std::make_error_condition(std::errc::invalid_argument));
+        size_t off = static_cast< size_t >(addr);
+        size_t total = 0;
+        for (uint32_t i = 0; i < nr_vecs; ++i) {
+            if (off + iovecs[i].iov_len > _buf.size())
+                return std::unexpected(std::make_error_condition(std::errc::io_error));
+            if (op == UBLK_IO_OP_READ) {
+                std::memcpy(iovecs[i].iov_base, _buf.data() + off, iovecs[i].iov_len);
+            } else if (op == UBLK_IO_OP_WRITE) {
+                std::memcpy(_buf.data() + off, iovecs[i].iov_base, iovecs[i].iov_len);
+            } else {
+                return std::unexpected(std::make_error_condition(std::errc::invalid_argument));
+            }
+            off += iovecs[i].iov_len;
+            total += iovecs[i].iov_len;
+        }
+        return total;
+    }
+
+private:
+    std::string _id;
+    std::vector< uint8_t > _buf;
+};
+
+// Stage an md 1.2 SB at byte 4 KiB on a BufferedDisk. Returns the SB builder used so callers
+// can mutate fields and re-stage if needed.
+inline MdSbBuilder stage_md_sb(BufferedDisk& d, MdSbBuilder builder = {}) {
+    builder.emit(d.data() + 4 * Ki);
+    return builder;
+}
+
+// Fill a region with a deterministic byte pattern so cross-translation tests can verify
+// that ublkpp reads the same bytes md wrote.
+inline void fill_pattern(uint8_t* p, size_t len, uint64_t seed) {
+    std::mt19937_64 rng(seed);
+    for (size_t i = 0; i < len; i += sizeof(uint64_t)) {
+        uint64_t v = rng();
+        std::memcpy(p + i, &v, std::min(sizeof(uint64_t), len - i));
+    }
+}
+
+} // namespace ublkpp::md::test

--- a/src/raid/raid1/raid1.cpp
+++ b/src/raid/raid1/raid1.cpp
@@ -640,7 +640,9 @@ io_result Raid1Disk::__become_degraded(bool failed_is_active, RouteState const* 
 disk_task< int > Raid1Disk::__failover_read_async(ublksrv_queue const* q, ublk_io_data const* data, iovec* iovecs,
                                                   uint32_t nr_vecs, uint64_t addr, uint32_t len) {
     auto const state = __capture_route_state();
-    auto const [primary_dev, failover_dev] = __select_read_devices(state, addr, len);
+    auto devices = __select_read_devices(state, addr, len);
+    auto& primary_dev = devices.first;
+    auto& failover_dev = devices.second;
 
     auto primary_task = primary_dev->disk->async_iov(q, data, iovecs, nr_vecs, addr + _reserved_size).start();
     auto const r = co_await primary_task;

--- a/src/raid/raid1/raid1.cpp
+++ b/src/raid/raid1/raid1.cpp
@@ -86,11 +86,11 @@ Raid1Disk::Raid1Disk(boost::uuids::uuid const& uuid, std::shared_ptr< ublk_disk 
     // Create metrics with parent_id for correlation
     if (!parent_id.empty()) _raid_metrics = std::make_unique< UblkRaidMetrics >(parent_id, _str_uuid);
 
-    // Discover parameters and calculate reserved space
-    __init_params(dev_a, dev_b);
-
-    // Load devices, select best superblock, initialize route
+    // Load devices and select best superblock first so __init_params can branch on SB version.
     __load_and_select_superblock(uuid, std::move(dev_a), std::move(dev_b), parent_id);
+
+    // Discover parameters and calculate reserved space (uses _device_a/_device_b/_sb).
+    __init_params();
 
     // Initialize bitmap and handle initial degradation based on route determination
     __init_bitmap_and_degraded_route();
@@ -101,51 +101,6 @@ Raid1Disk::Raid1Disk(boost::uuids::uuid const& uuid, std::shared_ptr< ublk_disk 
 
     // Write the up-to-date superblocks and mark devices as in use
     __become_active();
-}
-
-void Raid1Disk::__init_params(std::shared_ptr< ublk_disk > const& dev_a, std::shared_ptr< ublk_disk > const& dev_b) {
-    RLOGI("Initializing RAID-1 [uuid:{}] from devices {} and {}", _str_uuid, dev_a, dev_b)
-
-    _direct_io = true; // RAID-1 prefers DIO; downgraded below if any member doesn't support it
-
-    // Discover overall Device parameters
-    auto& our_params = *params();
-    our_params.types |= UBLK_PARAM_TYPE_DISCARD;
-    our_params.basic.io_opt_shift = ilog2(k_min_chunk_size);
-
-    // Set largest underlying user-data size we support as starting point
-    our_params.basic.dev_sectors = k_max_user_data >> SECTOR_SHIFT;
-
-    // Now find the what size we should actually set based on the smallest provided device
-    for (auto device_array = std::set< std::shared_ptr< ublk_disk > >{dev_a, dev_b};
-         auto const& device : device_array) {
-        if (!device->direct_io()) {
-            RLOGW("Device {} does not support O_DIRECT - RAID-1 will use buffered I/O (backend caching not bypassed!)",
-                  device)
-            _direct_io = false; // LCOV_EXCL_LINE
-        }
-        our_params.basic.dev_sectors =
-            std::min< uint64_t >(our_params.basic.dev_sectors, device->capacity() >> SECTOR_SHIFT);
-        our_params.basic.logical_bs_shift =
-            std::max(our_params.basic.logical_bs_shift, static_cast< uint8_t >(ilog2(device->block_size())));
-        our_params.basic.physical_bs_shift =
-            std::max(our_params.basic.physical_bs_shift, static_cast< uint8_t >(ilog2(device->physical_block_size())));
-
-        if (!device->can_discard()) our_params.types &= ~UBLK_PARAM_TYPE_DISCARD;
-    }
-
-    auto const bitmap_size = ((our_params.basic.dev_sectors << SECTOR_SHIFT) / k_min_chunk_size) / k_bits_in_byte;
-    _reserved_size = sizeof(SuperBlock) + bitmap_size;
-
-    // Align user-data to max_sector size
-    _reserved_size += ((our_params.basic.dev_sectors << SECTOR_SHIFT) - _reserved_size) %
-        (our_params.basic.max_sectors << SECTOR_SHIFT);
-
-    // Reserve space for the superblock/bitmap
-    our_params.basic.dev_sectors -= (_reserved_size >> SECTOR_SHIFT);
-
-    if (can_discard())
-        our_params.discard.discard_granularity = std::max(our_params.discard.discard_granularity, block_size());
 }
 
 void Raid1Disk::__load_and_select_superblock(boost::uuids::uuid const& uuid, std::shared_ptr< ublk_disk > dev_a,
@@ -183,6 +138,58 @@ void Raid1Disk::__load_and_select_superblock(boost::uuids::uuid const& uuid, std
 
     // Initialize Age if New
     if (_device_a->new_device && _device_b->new_device) _sb->fields.bitmap.age = htobe64(1);
+}
+
+void Raid1Disk::__init_params() {
+    RLOGI("Initializing RAID-1 [uuid:{}] from devices {} and {}", _str_uuid, _device_a->disk, _device_b->disk)
+
+    _direct_io = true; // RAID-1 prefers DIO; downgraded below if any member doesn't support it
+
+    // Discover overall Device parameters
+    auto& our_params = *params();
+    our_params.types |= UBLK_PARAM_TYPE_DISCARD;
+    our_params.basic.io_opt_shift = ilog2(k_min_chunk_size);
+
+    // Set largest underlying user-data size we support as starting point
+    our_params.basic.dev_sectors = k_max_user_data >> SECTOR_SHIFT;
+
+    // Now find the what size we should actually set based on the smallest provided device
+    for (auto device_array = std::set< std::shared_ptr< ublk_disk > >{_device_a->disk, _device_b->disk};
+         auto const& device : device_array) {
+        if (!device->direct_io()) {
+            RLOGW("Device {} does not support O_DIRECT - RAID-1 will use buffered I/O (backend caching not bypassed!)",
+                  device)
+            _direct_io = false; // LCOV_EXCL_LINE
+        }
+        our_params.basic.dev_sectors =
+            std::min< uint64_t >(our_params.basic.dev_sectors, device->capacity() >> SECTOR_SHIFT);
+        our_params.basic.logical_bs_shift =
+            std::max(our_params.basic.logical_bs_shift, static_cast< uint8_t >(ilog2(device->block_size())));
+        our_params.basic.physical_bs_shift =
+            std::max(our_params.basic.physical_bs_shift, static_cast< uint8_t >(ilog2(device->physical_block_size())));
+
+        if (!device->can_discard()) our_params.types &= ~UBLK_PARAM_TYPE_DISCARD;
+    }
+
+    auto const bitmap_size = ((our_params.basic.dev_sectors << SECTOR_SHIFT) / k_min_chunk_size) / k_bits_in_byte;
+    _reserved_size = sizeof(SuperBlock) + bitmap_size;
+
+    // Pad _reserved_size for alignment. Unit depends on the SB version:
+    //  v1: pad to max_sectors_bytes so user-data is a multiple of max_sectors. This was added
+    //      defensively against an observed kernel-dispatch artifact at end-of-device. Preserved
+    //      verbatim for v1 arrays so their on-disk layout is unchanged.
+    //  v2: pad to logical_bs only - the minimum required for O_DIRECT preadv/pwritev. Frees
+    //      the ~511 KiB tail loss v1 imposed.
+    auto const sb_version = be16toh(_sb->header.version);
+    auto const align = (sb_version >= 2) ? (static_cast< uint64_t >(1) << our_params.basic.logical_bs_shift)
+                                         : (static_cast< uint64_t >(our_params.basic.max_sectors) << SECTOR_SHIFT);
+    _reserved_size += ((our_params.basic.dev_sectors << SECTOR_SHIFT) - _reserved_size) % align;
+
+    // Reserve space for the superblock/bitmap
+    our_params.basic.dev_sectors -= (_reserved_size >> SECTOR_SHIFT);
+
+    if (can_discard())
+        our_params.discard.discard_granularity = std::max(our_params.discard.discard_granularity, block_size());
 }
 
 void Raid1Disk::__init_bitmap_and_degraded_route() {

--- a/src/raid/raid1/raid1_impl.hpp
+++ b/src/raid/raid1/raid1_impl.hpp
@@ -70,10 +70,12 @@ class Raid1Disk : public ublk_disk {
     bool __swap_device(std::string const& outgoing_device_id, std::shared_ptr< MirrorDevice >& incoming_mirror,
                        raid1::read_route const& cur_route);
 
-    // Constructor helpers
-    void __init_params(std::shared_ptr< ublk_disk > const& dev_a, std::shared_ptr< ublk_disk > const& dev_b);
+    // Constructor helpers. Order matters: __load_and_select_superblock must run first to
+    // populate _device_a/_device_b/_sb; __init_params then reads _sb->header.version to
+    // decide the user-data alignment policy.
     void __load_and_select_superblock(boost::uuids::uuid const& uuid, std::shared_ptr< ublk_disk > dev_a,
                                       std::shared_ptr< ublk_disk > dev_b, std::string const& parent_id);
+    void __init_params();
     void __init_bitmap_and_degraded_route();
     void __become_active();
 

--- a/src/raid/raid1/raid1_superblock.cpp
+++ b/src/raid/raid1/raid1_superblock.cpp
@@ -35,7 +35,12 @@ raid1::SuperBlock* pick_superblock(raid1::SuperBlock* dev_a, raid1::SuperBlock* 
 static const uint8_t magic_bytes[16] = {0123, 045, 0377, 012, 064,  0231, 076, 0305,
                                         0147, 072, 0310, 027, 0111, 0256, 033, 0144};
 
-constexpr auto SB_VERSION = 1;
+// SB v1: _reserved_size padded so user-data is a multiple of max_sectors_bytes.
+// SB v2: _reserved_size padded only to logical_bs (sufficient for O_DIRECT). Frees the
+//        ~511 KiB tail loss that v1 imposed on the array's user-data band.
+// The SB version is set on first init and never auto-upgraded; existing v1 arrays keep
+// their on-disk data layout exactly. New arrays (and md-import-created arrays) get v2.
+constexpr auto SB_VERSION = 2;
 
 static raid1::SuperBlock* read_superblock(ublk_disk& device) {
     auto const sb_size = sizeof(raid1::SuperBlock);
@@ -81,6 +86,7 @@ load_superblock(ublk_disk& device, boost::uuids::uuid const& uuid, uint32_t cons
         memset(sb, 0x00, raid1::k_page_size);
         memcpy(sb->header.magic, magic_bytes, sizeof(magic_bytes));
         memcpy(sb->header.uuid, uuid.data, sizeof(sb->header.uuid));
+        sb->header.version = htobe16(SB_VERSION);
         sb->fields.clean_unmount = 1;
         sb->fields.bitmap.chunk_size = htobe32(chunk_size);
         sb->fields.bitmap.age = 0;
@@ -104,7 +110,14 @@ load_superblock(ublk_disk& device, boost::uuids::uuid const& uuid, uint32_t cons
               be32toh(sb->fields.bitmap.chunk_size), chunk_size, to_string(uuid))
     }
 
-    if (SB_VERSION > be16toh(sb->header.version)) { sb->header.version = htobe16(SB_VERSION); }
+    // Do NOT auto-upgrade the version: the alignment of _reserved_size on disk depends on it,
+    // and rewriting it without relocating data would corrupt the array. v1 arrays stay v1.
+    if (be16toh(sb->header.version) > SB_VERSION) {
+        RLOGE("Superblock version {} is newer than supported version {} on {}", be16toh(sb->header.version), SB_VERSION,
+              device)
+        free(sb);
+        return std::unexpected(std::make_error_condition(std::errc::invalid_argument));
+    }
     return std::make_pair(sb, was_new);
 }
 } // namespace ublkpp::raid1

--- a/src/raid/raid1/tests/superblock/CMakeLists.txt
+++ b/src/raid/raid1/tests/superblock/CMakeLists.txt
@@ -3,6 +3,7 @@ cmake_minimum_required (VERSION 3.11)
 list(APPEND RAID1_TEST_SRCS
   superblock/init.cpp
   superblock/init_issues.cpp
+  superblock/legacy_v1_alignment.cpp
   superblock/new_device.cpp
   superblock/missing_disk.cpp
   superblock/pick_super.cpp

--- a/src/raid/raid1/tests/superblock/legacy_v1_alignment.cpp
+++ b/src/raid/raid1/tests/superblock/legacy_v1_alignment.cpp
@@ -1,0 +1,47 @@
+#include "test_raid1_common.hpp"
+
+// Brief: legacy (v1) on-disk superblocks must keep their original max_sectors-aligned
+// _reserved_size formula, so existing production arrays never see their data shift.
+//
+// New (v2) arrays use block-aligned _reserved_size; v1 arrays must continue to use the
+// old max_sectors_bytes-aligned formula. This is verified indirectly: under v1, the
+// effective capacity reported by Raid1Disk must be a multiple of (max_sectors << 9) - the
+// formula's defining invariant.
+TEST(Raid1, LegacyV1KeepsMaxSectorsAlignment) {
+    constexpr uint64_t k_capacity = Gi;
+    auto device_a = std::make_shared< ublkpp::TestDisk >(TestParams{.capacity = k_capacity});
+    auto device_b = std::make_shared< ublkpp::TestDisk >(TestParams{.capacity = k_capacity});
+
+    // Stage a v1 SB on each leg so RAID1 takes the legacy alignment branch.
+    auto stage_v1 = [](auto* dev, bool side_b) {
+        EXPECT_CALL(*dev, sync_iov(UBLK_IO_OP_READ, _, _, _))
+            .Times(1)
+            .WillOnce([side_b](uint8_t, iovec* iovecs, uint32_t nr_vecs, off_t addr) -> io_result {
+                EXPECT_EQ(1U, nr_vecs);
+                EXPECT_EQ(ublkpp::raid1::k_page_size, ublkpp::iovec_len(iovecs, iovecs + nr_vecs));
+                EXPECT_EQ(0UL, addr);
+                memcpy(iovecs->iov_base, &legacy_v1_superblock, ublkpp::raid1::k_page_size);
+                if (side_b) static_cast< ublkpp::raid1::SuperBlock* >(iovecs->iov_base)->fields.device_b = 1;
+                return ublkpp::raid1::k_page_size;
+            });
+        // Allow any number of subsequent writes (RAID1 may rewrite the SB at __become_active
+        // and again on shutdown). We don't care about their content, only that the capacity
+        // calculation honors v1 alignment.
+        EXPECT_CALL(*dev, sync_iov(UBLK_IO_OP_WRITE, _, _, _))
+            .Times(::testing::AnyNumber())
+            .WillRepeatedly([](uint8_t, iovec* iovecs, uint32_t, off_t) -> io_result { return iovecs->iov_len; });
+    };
+    stage_v1(device_a.get(), false);
+    stage_v1(device_b.get(), true);
+
+    auto uuid = boost::uuids::string_generator{}(test_uuid);
+    auto raid = ublkpp::make_raid1_disk(uuid, device_a, device_b);
+    ASSERT_NE(raid, nullptr);
+
+    // V1 invariant: capacity (= dev_sectors << 9 after _reserved_size subtraction) must be
+    // a multiple of max_sectors_bytes. The default max_io is 512 KiB (TestParams default).
+    constexpr uint64_t k_max_sectors_bytes = 512 * Ki;
+    EXPECT_EQ(0u, raid->capacity() % k_max_sectors_bytes)
+        << "v1 capacity " << raid->capacity() << " is not a multiple of max_sectors_bytes " << k_max_sectors_bytes
+        << " - legacy alignment regressed and existing on-disk arrays would shift";
+}

--- a/src/raid/raid1/tests/test_raid1_common.hpp
+++ b/src/raid/raid1/tests/test_raid1_common.hpp
@@ -24,6 +24,21 @@ using ::ublkpp::Mi;
 static const ublkpp::raid1::SuperBlock normal_superblock = {
     .header = {.magic = {0x53, 0x25, 0xff, 0x0a, 0x34, 0x99, 0x3e, 0xc5, 0x67, 0x3a, 0xc8, 0x17, 0x49, 0xae, 0x1b,
                          0x64},
+               .version = htobe16(2),
+               .uuid = {0xad, 0xa4, 0x07, 0x37, 0x30, 0xe3, 0x49, 0xfe, 0x99, 0x42, 0x5a, 0x28, 0x7d, 0x71, 0xeb,
+                        0x3f}},
+    .fields = {.clean_unmount = 1,
+               .read_route = static_cast< uint8_t >(ublkpp::raid1::read_route::EITHER),
+               .device_b = 0,
+               .bitmap = {._reserved = {0x00}, .chunk_size = htobe32(32 * Ki), .age = 0}},
+    .superbitmap_reserved = {0x00}};
+
+// Same UUID/magic as normal_superblock, but with the legacy v1 version. Used to verify
+// that arrays created under the old (max_sectors-aligned) reservation formula keep their
+// on-disk layout exactly when re-attached by the new code.
+static const ublkpp::raid1::SuperBlock legacy_v1_superblock = {
+    .header = {.magic = {0x53, 0x25, 0xff, 0x0a, 0x34, 0x99, 0x3e, 0xc5, 0x67, 0x3a, 0xc8, 0x17, 0x49, 0xae, 0x1b,
+                         0x64},
                .version = htobe16(1),
                .uuid = {0xad, 0xa4, 0x07, 0x37, 0x30, 0xe3, 0x49, 0xfe, 0x99, 0x42, 0x5a, 0x28, 0x7d, 0x71, 0xeb,
                         0x3f}},


### PR DESCRIPTION
Closes #248.

## Summary

Adds a one-way, lossless migration path from md-raid level 10 (near=2, superblock 1.2) onto ublkpp's RAID-10 stack. Per-leg user data stays at md's `data_offset`; ublkpp metadata is written into the dead zone md left in front of it.

- `MdDisk` shim wraps each leaf with its own 4 KiB SB at byte 0 and applies a piecewise address translation: RAID1 metadata writes shift forward 4 KiB so the new RAID1 SB lands on byte 4 KiB and overwrites the old md superblock; user-data writes shift by `(data_offset_md - threshold)` so they land at md's data area byte-for-byte.
- Public surface in `include/ublkpp/raid.hpp` under `namespace ublkpp::md`: `make_md_disk`, `make_md_raid1_disk`, `make_md_raid10_disk`. RAID0 stripe size is taken from md's chunk_size at fresh init.
- Cross-leg validation enforces matching `set_uuid`, `chunk_size`, `data_offset`, `raid_disks`, layout, and `events`; pair grouping is by `dev_role / 2`.

## RAID1 superblock v2

While here, the user-data alignment formula in RAID1 was version-gated:

- v1 arrays continue to pad `_reserved_size` to `max_sectors_bytes` (existing on-disk layouts unchanged).
- v2 arrays pad to `logical_bs` only, freeing the ~511 KiB tail loss v1 imposed.

The SB version is set on first init and never auto-upgraded; existing v1 arrays keep their on-disk layout exactly. New arrays (and migrated arrays via MdDisk) get v2. `Raid1Disk` constructor was reordered so `__init_params` can branch on `_sb->header.version`.

Real-kernel verification of the v2 alignment relaxation against `bs=max_sectors_bytes` workloads at end-of-device is not covered by the mock-pathed harness and is a manual follow-up.

## Test plan

- [x] `MdDiskTest`: 23 cases - parser rejection paths, single-leg wrap and reattach, piecewise translation, cross-leg validation, 4/6-disk pair grouping (incl. shuffled input order).
- [x] `Raid1.LegacyV1KeepsMaxSectorsAlignment`: regression test that asserts v1 capacity stays a multiple of `max_sectors_bytes`.
- [x] All existing unit suites: `LoggingTest`, `CqeStateTest`, `Raid0Test`, `Raid1Test`, `FSDiskTest`, `TgtTest`.
- [x] All functional fio tests: `FunctionalFSDisk`, `FunctionalRAID0`, `FunctionalRAID1`, `FunctionalRAID10`, `FunctionalRAID0CrossStripe`, `FunctionalRAID10CrossStripe`.
- [ ] **Real-device follow-up (manual, your call):** create a v2 RAID1 on `/dev/ublkb*`, hammer with `bs=max_sectors`-sized I/O across the whole device (sequential and random) to validate the kernel clips tail I/O to `dev_sectors` correctly under the relaxed alignment.
- [ ] **Real md-import follow-up (manual):** `mdadm --create` a 4-disk near=2 array, populate with XFS + files, stop, run through `make_md_raid10_disk`, mount on the resulting ublk volume, verify files intact and reattach without re-import.