### PR TITLE
[Draft] raid1: Replace global pause with per-region write tracking for resync

### DIFF
--- a/src/raid/raid1/raid1.cpp
+++ b/src/raid/raid1/raid1.cpp
@@ -95,7 +95,8 @@ Raid1DiskImpl::Raid1DiskImpl(boost::uuids::uuid const& uuid, std::shared_ptr< Ub
 
     // Initialize resync_task
     _resync_task = std::make_shared< Raid1ResyncTask >(_dirty_bitmap, reserved_size, block_size(),
-                                                       params()->basic.max_sectors << SECTOR_SHIFT, _raid_metrics);
+                                                       params()->basic.max_sectors << SECTOR_SHIFT,
+                                                       2 * SISL_OPTIONS["qdepth"].as< uint16_t >(), _raid_metrics);
 
     // Write the up-to-date superblocks and mark devices as in use
     __become_active();
@@ -244,8 +245,7 @@ void Raid1DiskImpl::__become_active() {
 
 Raid1DiskImpl::~Raid1DiskImpl() {
     RLOGD("Shutting down; [uuid:{}]", _str_uuid)
-    [[maybe_unused]] auto cnt_at_stop = _resync_task->stop();
-    DEBUG_ASSERT_EQ(0, cnt_at_stop, "Outstanding Write Count is Non-Zero!");
+    _resync_task->stop();
 
     if (!_sb) return;
 
@@ -636,9 +636,9 @@ io_result Raid1DiskImpl::__handle_async_retry(sub_cmd_t sub_cmd, uint64_t addr, 
     // No Synchronous operations retry
     DEBUG_ASSERT_NOTNULL(async_data, "Retry on an synchronous I/O!"); // LCOV_EXCL_LINE
 
-    // Record this degraded operation in the bitmap, then unblock _resync_task (if exists)
+    // Record this degraded operation in the bitmap, then unregister from region tracker
     _dirty_bitmap->dirty_region(addr, len);
-    _resync_task->dequeue_write();
+    _resync_task->dequeue_write(addr, len);
 
     // Check if this sub_cmd went to what we currently consider Clean, if we're also dirty this is a fatal error
     auto const state = __capture_route_state();
@@ -686,7 +686,7 @@ io_result Raid1DiskImpl::__replicate(sub_cmd_t sub_cmd, auto&& func, uint64_t ad
     }
 
     // Sync IOVs have to track this differently as the do not receive on_io_complete
-    if (async_data) _resync_task->enqueue_write();
+    if (async_data) _resync_task->enqueue_write(addr, len);
 
     // Determine where we're going
     auto cur_subcmd = second_write ? captured_state->backup_subcmd : captured_state->active_subcmd;
@@ -695,12 +695,12 @@ io_result Raid1DiskImpl::__replicate(sub_cmd_t sub_cmd, auto&& func, uint64_t ad
     // Queue the I/O on the active device
     auto active_res = func(*cur_disk, cur_subcmd);
     // Inline completion (sync fallback returns 0): on_io_complete won't fire, balance the enqueue now.
-    if (async_data && active_res.has_value() && active_res.value() == 0) _resync_task->dequeue_write();
+    if (async_data && active_res.has_value() && active_res.value() == 0) _resync_task->dequeue_write(addr, len);
 
     // If not-degraded and sub_cmd failed immediately, dirty bitmap and return result of op on alternate-path
     // This condition always returns before the nested call!
     if (!active_res) {
-        if (async_data) _resync_task->dequeue_write();
+        if (async_data) _resync_task->dequeue_write(addr, len);
         if (captured_state->is_degraded && !second_write) {
             RLOGE("Double failure! [tag:{:#0x},sub_cmd:{}]", async_data->tag, ublkpp::to_string(sub_cmd))
             return active_res;
@@ -714,13 +714,13 @@ io_result Raid1DiskImpl::__replicate(sub_cmd_t sub_cmd, auto&& func, uint64_t ad
         if (second_write) return backup_res;
 
         // Queue the I/O on the backup device after active failed
-        if (async_data) _resync_task->enqueue_write();
+        if (async_data) _resync_task->enqueue_write(addr, len);
         if (active_res = func(*captured_state->backup_dev->disk, captured_state->backup_subcmd); !active_res) {
-            if (async_data) _resync_task->dequeue_write();
+            if (async_data) _resync_task->dequeue_write(addr, len);
             return active_res;
         }
         // Inline completion on backup write: on_io_complete won't fire, balance the enqueue.
-        if (async_data && active_res.value() == 0) _resync_task->dequeue_write();
+        if (async_data && active_res.value() == 0) _resync_task->dequeue_write(addr, len);
         return active_res.value() + backup_res.value();
     }
     if (second_write) return active_res;
@@ -837,7 +837,7 @@ io_result Raid1DiskImpl::handle_internal(ublksrv_queue const*, ublk_io_data cons
         RLOGW("Dirtied: {:#0x}Ki Inline! @ lba:{:#0x} [uuid:{}]", len / Ki, lba, _str_uuid)
         _dirty_bitmap->dirty_region(addr, len);
     }
-    _resync_task->dequeue_write();
+    _resync_task->dequeue_write(addr, len);
     return io_result(0);
 }
 
@@ -914,7 +914,7 @@ io_result Raid1DiskImpl::sync_iov(uint8_t op, iovec* iovecs, uint32_t nr_vecs, o
             },
             addr, len);
 
-    _resync_task->enqueue_write();
+    _resync_task->enqueue_write(static_cast< uint64_t >(addr), len);
     size_t res{0};
     auto io_res = __replicate(
         0U,
@@ -925,7 +925,7 @@ io_result Raid1DiskImpl::sync_iov(uint8_t op, iovec* iovecs, uint32_t nr_vecs, o
             return p_res;
         },
         addr, len);
-    _resync_task->dequeue_write();
+    _resync_task->dequeue_write(static_cast< uint64_t >(addr), len);
 
     if (!io_res) return io_res;
     return res;
@@ -954,13 +954,15 @@ void Raid1DiskImpl::on_io_complete(ublk_io_data const* data, sub_cmd_t sub_cmd, 
         }
     }
 
-    // Decrement outstanding write counter for writes (not reads), but only if it was a
-    // success.
-    // Error cases will be handled by __handle_async_retry
-    // as they need to dirty the BITMAP prior to unblocking the resync task.
+    // Unregister from region tracker for writes (not reads), but only on success.
+    // Error cases are handled by __handle_async_retry which dirties the BITMAP first.
     if (UBLK_IO_OP_READ != ublksrv_get_op(data->iod)) {
         DEBUG_ASSERT(!is_retry(sub_cmd), "Retried a WRITE command?!");
-        if (0 <= res && !is_internal(sub_cmd)) _resync_task->dequeue_write();
+        if (0 <= res && !is_internal(sub_cmd)) {
+            auto const w_addr = static_cast< uint64_t >(data->iod->start_sector) << 9u;
+            auto const w_len = static_cast< uint32_t >(data->iod->nr_sectors) << 9u;
+            _resync_task->dequeue_write(w_addr, w_len);
+        }
     }
 }
 

--- a/src/raid/raid1/raid1_resync_task.cpp
+++ b/src/raid/raid1/raid1_resync_task.cpp
@@ -11,14 +11,15 @@
 namespace ublkpp::raid1 {
 
 Raid1ResyncTask::Raid1ResyncTask(std::shared_ptr< raid1::Bitmap >& bitmap, uint64_t offset, uint32_t io_size,
-                                 uint32_t max_io, std::shared_ptr< ublkpp::UblkRaidMetrics > metrics) :
+                                 uint32_t max_io, uint32_t slot_count,
+                                 std::shared_ptr< ublkpp::UblkRaidMetrics > metrics) :
         _dirty_bitmap(bitmap),
         _metrics(metrics),
         _io_size(io_size),
         _max_size(max_io),
         _offset(offset),
         _resync_state(static_cast< uint8_t >(resync_state::IDLE)), // Initial store, can't use helper
-        _outstanding_writes(0U),
+        _region_tracker(slot_count),
         _resync_task() {
     if (!_dirty_bitmap) throw std::runtime_error("No Bitmap");
 }
@@ -135,7 +136,6 @@ void Raid1ResyncTask::launch(std::string const& str_uuid, std::shared_ptr< Mirro
                 return {state, transition_action::SUCCESS};
             case resync_state::ACTIVE:
             case resync_state::SLEEPING:
-            case resync_state::PAUSE:
                 return {state, transition_action::EARLY_EXIT};
             case resync_state::STOPPING:
                 return {resync_state::IDLE, transition_action::RETRY_WITH_SLEEP};
@@ -216,13 +216,33 @@ resync_state Raid1ResyncTask::__run(auto& clean_mirror, auto& dirty_mirror, iove
         auto copies_left = ((std::min(32U, SISL_OPTIONS["resync_level"].as< uint32_t >()) * 100U) / 32U) * 5U;
         auto [logical_off, sz] = _dirty_bitmap->next_dirty();
         while (0 < sz && 0U < copies_left--) {
-            iov->iov_len = std::min(sz, _max_size);
+            auto const iov_len = std::min(sz, _max_size);
+
+            // Phase 1: pre-copy conflict check — skip conflicting segment within dirty run.
+            // next_dirty() always scans from bit 0 so we advance manually within the run.
+            if (_region_tracker.overlaps(logical_off, iov_len)) {
+                sz = (sz > iov_len) ? sz - iov_len : 0;
+                logical_off += iov_len;
+                if (0 == sz) {
+                    // TODO: next_dirty() always scans from bit 0, so other dirty regions at
+                    // higher LBAs are unreachable while this conflicted region remains. A
+                    // next_dirty(start_offset) API on Bitmap would allow skipping past it.
+                    break;
+                }
+                continue;
+            }
+
+            iov->iov_len = iov_len;
             // Copy Region from clean to dirty
             if (auto res = __copy_region(iov, 1, logical_off + _offset, *clean_mirror->disk, *dirty_mirror->disk);
                 res) {
-                clean_region(logical_off, iov->iov_len, *clean_mirror);
+                // Phase 2: post-copy conflict check — write arrived during READ window.
+                // If a write is still in-flight for this region, skip clean_region so the
+                // bitmap stays dirty and the next sweep re-copies with fresh data.
+                if (!_region_tracker.overlaps(logical_off, iov_len)) clean_region(logical_off, iov_len, *clean_mirror);
+
                 // Record resync progress
-                if (_metrics) { _metrics->record_resync_progress(iov->iov_len); }
+                if (_metrics) { _metrics->record_resync_progress(iov_len); }
             } else {
                 dirty_mirror->unavail.test_and_set(std::memory_order_acquire);
                 break;
@@ -243,27 +263,10 @@ resync_state Raid1ResyncTask::__run(auto& clean_mirror, auto& dirty_mirror, iove
     return cur_state;
 }
 
-void Raid1ResyncTask::__pause() noexcept {
-    __transition_to(resync_state::SLEEPING, resync_state::PAUSE, [](resync_state state) -> transition_result {
-        switch (state) {
-        case resync_state::IDLE:
-        case resync_state::PAUSE:
-        case resync_state::STOPPING:
-            return {state, transition_action::EARLY_EXIT};
-        case resync_state::SLEEPING:
-            return {state, transition_action::RETRY};
-        case resync_state::ACTIVE:
-            return {resync_state::SLEEPING, transition_action::RETRY_WITH_SLEEP};
-        }
-        std::unreachable();
-    });
-}
-
 // Abort any on-going resync task by moving to STOPPING and rejoin the thread
-uint32_t Raid1ResyncTask::stop() noexcept {
+void Raid1ResyncTask::stop() noexcept {
     RLOGI("Terminating Resync Task")
-    // Terminate any ongoing resync task
-    __transition_to(resync_state::PAUSE, resync_state::STOPPING, [](resync_state state) -> transition_result {
+    __transition_to(resync_state::SLEEPING, resync_state::STOPPING, [](resync_state state) -> transition_result {
         switch (state) {
         case resync_state::IDLE:
         case resync_state::STOPPING:
@@ -271,13 +274,12 @@ uint32_t Raid1ResyncTask::stop() noexcept {
         case resync_state::ACTIVE:
             return {resync_state::SLEEPING, transition_action::RETRY_WITH_SLEEP};
         case resync_state::SLEEPING:
-        case resync_state::PAUSE:
             return {state, transition_action::RETRY};
         }
         std::unreachable();
     });
     if (_resync_task.joinable()) _resync_task.join();
-    return _outstanding_writes.load(std::memory_order_acquire);
+    DEBUG_ASSERT(_region_tracker.all_free(), "RegionTracker: in-flight writes remain after stop");
 }
 
 resync_state Raid1ResyncTask::__yield(std::chrono::microseconds const yield_for,
@@ -298,16 +300,10 @@ resync_state Raid1ResyncTask::__yield(std::chrono::microseconds const yield_for,
     }
 
     // Phase 3: Transition SLEEPING→ACTIVE (resume resync)
+    cur_state = resync_state::SLEEPING;
     while (!__cas_state_weak(cur_state, resync_state::ACTIVE)) {
         if (resync_state::STOPPING == cur_state) return cur_state;
-
-        if (resync_state::PAUSE == cur_state) {
-            // I/O started during sleep - wait for it to complete
-            // Set to IDLE anticipating __resume() will transition PAUSE→ACTIVE
-            // This prevents busy-spinning and gives I/O threads priority
-            cur_state = resync_state::IDLE;
-            std::this_thread::sleep_for(yield_for);
-        }
+        cur_state = resync_state::SLEEPING; // reset after spurious CAS failure
     }
     return resync_state::ACTIVE;
 }

--- a/src/raid/raid1/raid1_resync_task.hpp
+++ b/src/raid/raid1/raid1_resync_task.hpp
@@ -7,6 +7,7 @@
 #include "ublkpp/raid/raid1.hpp"
 #include "metrics/ublk_raid_metrics.hpp"
 #include "raid1_superblock.hpp"
+#include "region_tracker.hpp"
 
 namespace ublkpp::raid1 {
 
@@ -18,12 +19,10 @@ class MirrorDevice;
 
 // State transitions:
 //   IDLE → ACTIVE (launch())
-//   ACTIVE ⟷ SLEEPING (yield for I/O)
-//   SLEEPING → PAUSE (I/O started, block resync)
-//   PAUSE → ACTIVE (I/O finished, resync can proceed)
+//   ACTIVE ⟷ SLEEPING (yield between copy batches)
 //   any → STOPPING (shutdown requested)
 //   STOPPING → IDLE (shutdown complete)
-ENUM(resync_state, uint8_t, IDLE = 0, ACTIVE = 1, SLEEPING = 2, PAUSE = 3, STOPPING = 4);
+ENUM(resync_state, uint8_t, IDLE = 0, ACTIVE = 1, SLEEPING = 2, STOPPING = 3);
 
 // State transition actions for __transition_to helper
 enum class transition_action : uint8_t {
@@ -55,7 +54,7 @@ class Raid1ResyncTask {
     uint64_t const _offset;
 
     std::atomic_uint8_t _resync_state;
-    std::atomic_uint32_t _outstanding_writes;
+    RegionTracker _region_tracker;
     std::thread _resync_task;
 
     // State access helpers to eliminate casting noise
@@ -89,13 +88,6 @@ class Raid1ResyncTask {
     template < typename StateHandler >
     bool __transition_to(resync_state initial, resync_state target, StateHandler&& handler) noexcept;
 
-    // This most happen, so we wait till the resync job becomes sleeping, then move it quickly to
-    // PAUSE to prevent any resync opeartions from continuing to run (will block in __yield)
-    void __pause() noexcept;
-    inline void __resume() noexcept {
-        auto cur_state = resync_state::PAUSE;
-        __cas_state_strong(cur_state, resync_state::ACTIVE);
-    }
     void _start(std::string str_uuid, std::shared_ptr< MirrorDevice >& clean_mirror,
                 std::shared_ptr< MirrorDevice >& dirty_mirror, std::function< void() >&& complete);
 
@@ -103,7 +95,7 @@ class Raid1ResyncTask {
 
 public:
     Raid1ResyncTask(std::shared_ptr< raid1::Bitmap >& bitmap, uint64_t offset, uint32_t io_size, uint32_t max_io,
-                    std::shared_ptr< ublkpp::UblkRaidMetrics > metrics = nullptr);
+                    uint32_t slot_count, std::shared_ptr< ublkpp::UblkRaidMetrics > metrics = nullptr);
     ~Raid1ResyncTask() noexcept;
 
     void clean_region(uint64_t addr, uint32_t len, MirrorDevice& clean_device);
@@ -112,18 +104,10 @@ public:
                 std::shared_ptr< MirrorDevice > dirty_mirror, std::function< void() >&& complete);
 
     // Generic method to move Resync StateMachine to STOPPING
-    uint32_t stop() noexcept; // Returns the _outstanding_writes cnt here
+    void stop() noexcept;
 
-    inline void enqueue_write() noexcept {
-        auto const old_val = _outstanding_writes.fetch_add(1, std::memory_order_release);
-        if (0 == old_val) __pause();
-        DEBUG_ASSERT_LT(old_val, UINT32_MAX, "Outstanding Write Count Overflowed!");
-    }
+    inline void enqueue_write(uint64_t lba, uint32_t len) noexcept { _region_tracker.register_write(lba, len); }
 
-    inline void dequeue_write() noexcept {
-        auto const old_val = _outstanding_writes.fetch_sub(1, std::memory_order_acquire);
-        if (1 == old_val) __resume();
-        DEBUG_ASSERT_GT(old_val, 0, "Outstanding Write Count Underflowed!");
-    }
+    inline void dequeue_write(uint64_t lba, uint32_t len) noexcept { _region_tracker.unregister_write(lba, len); }
 };
 } // namespace ublkpp::raid1

--- a/src/raid/raid1/region_tracker.hpp
+++ b/src/raid/raid1/region_tracker.hpp
@@ -1,0 +1,117 @@
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+#include <thread>
+#include <vector>
+
+#include <sisl/logging/logging.h>
+
+#include "lib/logging.hpp"
+
+namespace ublkpp::raid1 {
+
+// Lock-free bounded array tracking in-flight write LBA ranges.
+// Sized to 2 × queue_depth to accommodate one slot per primary and one per replica leg.
+// Resync checks for overlap before and after each copy to avoid racing with writes.
+class RegionTracker {
+public:
+    static constexpr uint64_t k_free = ~0ULL;
+
+    explicit RegionTracker(uint32_t max_slots) : _slots(max_slots) {}
+
+    // Register an in-flight write. Called on the I/O thread before submitting async I/O.
+    // CAS on lba (relaxed) claims the slot; len is then published with release ordering.
+    // There is a narrow window between those two instructions where slot_len reads as 0.
+    // overlaps() handles this conservatively: a claimed slot with len=0 whose LBA falls
+    // within the queried range is treated as an overlap (see overlaps() comment).
+    //
+    // If both Phase 1 and Phase 2 in __run() observe len=0 (extremely unlikely — two
+    // consecutive instructions), the resync copy writes stale data to the dirty mirror.
+    // Correctness is still guaranteed: the in-flight write overwrites it on both mirrors
+    // (success path) or dirties the bitmap via __handle_async_retry (error path).
+    void register_write(uint64_t lba, uint32_t len) noexcept {
+        while (true) {
+            for (auto& slot : _slots) {
+                uint64_t expected = k_free;
+                if (slot.lba.compare_exchange_weak(expected, lba, std::memory_order_relaxed,
+                                                   std::memory_order_relaxed)) {
+                    slot.len.store(len, std::memory_order_release);
+                    return;
+                }
+            }
+            // Slot exhaustion: should never happen if sized to 2 × queue_depth.
+            TLOGE("RegionTracker slot exhaustion — spinning (lba={:#x} len={})", lba, len)
+            std::this_thread::yield();
+        }
+    }
+
+    // Deregister a completed write. Finds the first matching slot and clears it.
+    // Two registrations for the same (lba, len) — primary and replica legs — are
+    // cleared independently, one per call.
+    // len is reset to 0 before freeing lba so that any concurrent overlaps() call that
+    // sees the slot mid-transition reads 0 and takes the conservative path rather than
+    // seeing a stale non-zero value from a prior use.
+    //
+    // INVARIANT: block-device ordering guarantees no two concurrent writes to the same
+    // LBA with different sizes, so (lba, len) uniquely identifies the slot pair and the
+    // len-then-CAS sequence cannot accidentally free a slot belonging to a different write.
+    void unregister_write(uint64_t lba, uint32_t len) noexcept {
+        for (auto& slot : _slots) {
+            if (slot.lba.load(std::memory_order_relaxed) != lba) continue;
+            if (slot.len.load(std::memory_order_relaxed) != len) continue;
+            uint64_t expected = lba;
+            slot.len.store(0, std::memory_order_relaxed);
+            if (slot.lba.compare_exchange_strong(expected, k_free, std::memory_order_release,
+                                                 std::memory_order_relaxed))
+                return;
+            // CAS failed: another thread freed this slot; leave len=0, it will be
+            // overwritten by the next register_write that claims the slot.
+        }
+        DEBUG_ASSERT(false, "RegionTracker: no slot found for lba={:#x} len={}", lba, len);
+    }
+
+    // Returns true if any in-flight write overlaps [lba, lba+len).
+    //
+    // Memory ordering: slot_len is loaded with acquire, synchronizing-with the release store
+    // in register_write — but only when the load actually reads the stored value.  There is a
+    // narrow window (between the relaxed CAS that claims a slot and the subsequent len.store)
+    // where slot_len reads as 0.  unregister_write also resets len to 0 before freeing lba,
+    // creating a symmetric window on teardown.
+    //
+    // Both windows are handled conservatively: slot_len==0 on a non-free slot is treated as
+    // a potential conflict (return true).  This can cause at most one spurious resync yield;
+    // it never causes a false negative, so no data corruption is possible.
+    [[nodiscard]] bool overlaps(uint64_t lba, uint32_t len) const noexcept {
+        for (auto const& slot : _slots) {
+            auto const slot_lba = slot.lba.load(std::memory_order_acquire);
+            if (k_free == slot_lba) continue;
+            auto const slot_len = slot.len.load(std::memory_order_acquire);
+            // slot_len==0: transitional window — real len not yet published.
+            // Be conservative only when slot_lba is inside the query range; an unrelated
+            // slot at a distant LBA is not a conflict regardless of its transitional state.
+            if (slot_lba < lba + len && (0 == slot_len || slot_lba + slot_len > lba)) return true;
+        }
+        return false;
+    }
+
+    // Returns true if no slots are occupied. Used as a post-stop integrity check.
+    [[nodiscard]] bool all_free() const noexcept {
+        for (auto const& slot : _slots)
+            if (k_free != slot.lba.load(std::memory_order_relaxed)) return false;
+        return true;
+    }
+
+private:
+    struct alignas(16) Slot {
+        std::atomic< uint64_t > lba{k_free};
+        std::atomic< uint32_t > len{0};
+        uint32_t _pad{0};
+    };
+    static_assert(std::atomic< uint64_t >::is_always_lock_free);
+    static_assert(std::atomic< uint32_t >::is_always_lock_free);
+
+    std::vector< Slot > _slots;
+};
+
+} // namespace ublkpp::raid1

--- a/src/raid/raid1/tests/bitmap/CMakeLists.txt
+++ b/src/raid/raid1/tests/bitmap/CMakeLists.txt
@@ -15,6 +15,7 @@ list(APPEND RAID1_TEST_SRCS
   bitmap/next_dirty.cpp
   bitmap/roundtrip_sync_load.cpp
   bitmap/super_bitmap_test.cpp
+  bitmap/region_tracker_test.cpp
   bitmap/sync_to_batching.cpp
   bitmap/sync_to_crash_scenarios.cpp
   bitmap/update_fail.cpp

--- a/src/raid/raid1/tests/bitmap/concurrent_io_resync.cpp
+++ b/src/raid/raid1/tests/bitmap/concurrent_io_resync.cpp
@@ -5,8 +5,8 @@
 
 using namespace std::chrono_literals;
 
-// Test that writes arriving DURING active resync correctly pause/resume the outstanding_writes counter
-// This is the critical synchronization test for the atomic counter fixes
+// Test that writes arriving DURING active resync do not corrupt data.
+// With per-region tracking, resync skips only conflicting LBA ranges; unrelated regions proceed.
 TEST(Raid1, ConcurrentIODuringResync) {
     auto device_a = CREATE_DISK_A(TestParams{.capacity = Gi});
     auto device_b = CREATE_DISK_B(TestParams{.capacity = Gi});

--- a/src/raid/raid1/tests/bitmap/region_tracker_test.cpp
+++ b/src/raid/raid1/tests/bitmap/region_tracker_test.cpp
@@ -1,0 +1,139 @@
+#include <atomic>
+#include <thread>
+#include <vector>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "raid/raid1/region_tracker.hpp"
+
+using ublkpp::Ki;
+using ublkpp::raid1::RegionTracker;
+
+TEST(Raid1, RegionTrackerEmptyNoOverlap) {
+    RegionTracker tracker(16);
+    EXPECT_FALSE(tracker.overlaps(0, 512 * Ki));
+    EXPECT_FALSE(tracker.overlaps(100, 512));
+    EXPECT_TRUE(tracker.all_free());
+}
+
+TEST(Raid1, RegionTrackerRegisterAndOverlapExact) {
+    RegionTracker tracker(16);
+    tracker.register_write(100, 512);
+    EXPECT_TRUE(tracker.overlaps(100, 512));
+    EXPECT_FALSE(tracker.all_free());
+}
+
+TEST(Raid1, RegionTrackerOverlapPartialLeft) {
+    RegionTracker tracker(16);
+    tracker.register_write(200, 512);        // [200, 712)
+    EXPECT_TRUE(tracker.overlaps(100, 200)); // [100, 300) overlaps at [200, 300)
+}
+
+TEST(Raid1, RegionTrackerOverlapPartialRight) {
+    RegionTracker tracker(16);
+    tracker.register_write(100, 512);        // [100, 612)
+    EXPECT_TRUE(tracker.overlaps(500, 200)); // [500, 700) overlaps at [500, 612)
+}
+
+TEST(Raid1, RegionTrackerOverlapContained) {
+    RegionTracker tracker(16);
+    tracker.register_write(100, 512);        // [100, 612)
+    EXPECT_TRUE(tracker.overlaps(200, 100)); // [200, 300) fully inside registered range
+}
+
+TEST(Raid1, RegionTrackerAdjacentNoOverlap) {
+    RegionTracker tracker(16);
+    tracker.register_write(100, 512);         // [100, 612)
+    EXPECT_FALSE(tracker.overlaps(612, 100)); // [612, 712) — adjacent, not overlapping
+    EXPECT_FALSE(tracker.overlaps(0, 100));   // [0, 100) — adjacent on the other side
+}
+
+TEST(Raid1, RegionTrackerUnregisterClearsSlot) {
+    RegionTracker tracker(16);
+    tracker.register_write(100, 512);
+    EXPECT_TRUE(tracker.overlaps(100, 512));
+    tracker.unregister_write(100, 512);
+    EXPECT_FALSE(tracker.overlaps(100, 512));
+    EXPECT_TRUE(tracker.all_free());
+}
+
+TEST(Raid1, RegionTrackerDuplicateLba_TwoSlots) {
+    // Primary and replica legs of the same write register independently
+    RegionTracker tracker(16);
+    tracker.register_write(100, 512);
+    tracker.register_write(100, 512); // same range, separate slot
+    EXPECT_TRUE(tracker.overlaps(100, 512));
+
+    tracker.unregister_write(100, 512);      // clears one slot
+    EXPECT_TRUE(tracker.overlaps(100, 512)); // second slot still occupied
+
+    tracker.unregister_write(100, 512); // clears second slot
+    EXPECT_FALSE(tracker.overlaps(100, 512));
+    EXPECT_TRUE(tracker.all_free());
+}
+
+TEST(Raid1, RegionTrackerMultipleDistinctRanges) {
+    RegionTracker tracker(16);
+    tracker.register_write(0, 512);
+    tracker.register_write(1024, 512);
+    tracker.register_write(4096, 512);
+
+    EXPECT_TRUE(tracker.overlaps(0, 512));
+    EXPECT_TRUE(tracker.overlaps(1024, 512));
+    EXPECT_TRUE(tracker.overlaps(4096, 512));
+    EXPECT_FALSE(tracker.overlaps(512, 512));   // gap between first and second
+    EXPECT_FALSE(tracker.overlaps(1536, 2560)); // gap between second and third
+
+    tracker.unregister_write(1024, 512);
+    EXPECT_FALSE(tracker.overlaps(1024, 512));
+    EXPECT_TRUE(tracker.overlaps(0, 512));
+    EXPECT_TRUE(tracker.overlaps(4096, 512));
+}
+
+TEST(Raid1, RegionTrackerFillAndDrain) {
+    constexpr uint32_t k_slots = 8;
+    RegionTracker tracker(k_slots);
+
+    for (uint32_t i = 0; i < k_slots; ++i)
+        tracker.register_write(static_cast< uint64_t >(i) * 1024, 512);
+
+    EXPECT_FALSE(tracker.all_free());
+
+    // Unregister one, verify a new register can take its place
+    tracker.unregister_write(0, 512);
+    tracker.register_write(k_slots * 1024, 512); // new range, should fit
+    EXPECT_TRUE(tracker.overlaps(k_slots * 1024, 512));
+
+    // Drain remaining
+    for (uint32_t i = 1; i < k_slots; ++i)
+        tracker.unregister_write(static_cast< uint64_t >(i) * 1024, 512);
+    tracker.unregister_write(k_slots * 1024, 512);
+    EXPECT_TRUE(tracker.all_free());
+}
+
+TEST(Raid1, RegionTrackerConcurrentRegisterUnregister) {
+    constexpr uint32_t k_threads = 8;
+    constexpr uint32_t k_iters = 200;
+    // Slot count sized to 2× threads so no exhaustion occurs
+    RegionTracker tracker(k_threads * 2);
+
+    std::vector< std::thread > threads;
+    threads.reserve(k_threads);
+
+    for (uint32_t t = 0; t < k_threads; ++t) {
+        threads.emplace_back([&tracker, t] {
+            for (uint32_t i = 0; i < k_iters; ++i) {
+                // Each thread operates on its own non-overlapping LBA range
+                auto const lba = static_cast< uint64_t >(t) * 1024 * 1024;
+                tracker.register_write(lba, 512);
+                tracker.unregister_write(lba, 512);
+            }
+        });
+    }
+
+    for (auto& th : threads)
+        th.join();
+
+    EXPECT_TRUE(tracker.all_free());
+}

--- a/src/raid/raid1/tests/bitmap/region_tracker_test.cpp
+++ b/src/raid/raid1/tests/bitmap/region_tracker_test.cpp
@@ -6,6 +6,7 @@
 #include <gtest/gtest.h>
 
 #include "raid/raid1/region_tracker.hpp"
+#include "ublkpp/lib/common.hpp"
 
 using ublkpp::Ki;
 using ublkpp::raid1::RegionTracker;

--- a/src/raid/raid1/tests/concurrency/CMakeLists.txt
+++ b/src/raid/raid1/tests/concurrency/CMakeLists.txt
@@ -6,5 +6,6 @@ list(APPEND RAID1_TEST_SRCS
   concurrency/failover_retry_during_swap.cpp
   concurrency/api_calls_during_swap.cpp
   concurrency/multi_reader_swap.cpp
+  concurrency/write_resync_no_pause.cpp
 )
 set(RAID1_TEST_SRCS "${RAID1_TEST_SRCS}" PARENT_SCOPE)

--- a/src/raid/raid1/tests/concurrency/write_resync_no_pause.cpp
+++ b/src/raid/raid1/tests/concurrency/write_resync_no_pause.cpp
@@ -1,0 +1,306 @@
+#include "test_raid1_common.hpp"
+
+#include <atomic>
+#include <future>
+#include <thread>
+
+using namespace std::chrono_literals;
+
+// Sets up standard resync I/O expectations on both devices.
+// device_a is the clean mirror (source of resync reads).
+// device_b is the dirty mirror (target of resync writes + bitmap page writes).
+static void expect_resync_io(std::shared_ptr< ublkpp::TestDisk >& device_a,
+                             std::shared_ptr< ublkpp::TestDisk >& device_b,
+                             std::atomic< int >* resync_reads_out = nullptr,
+                             std::atomic< int >* resync_writes_out = nullptr) {
+    EXPECT_CALL(*device_a, sync_iov(UBLK_IO_OP_READ, _, _, _))
+        .Times(::testing::AnyNumber())
+        .WillRepeatedly([resync_reads_out](uint8_t, iovec* iovecs, uint32_t nr_vecs, off_t) -> io_result {
+            if (resync_reads_out) resync_reads_out->fetch_add(1, std::memory_order_relaxed);
+            if (iovecs->iov_base) memset(iovecs->iov_base, 0xAA, iovecs->iov_len);
+            return ublkpp::__iovec_len(iovecs, iovecs + nr_vecs);
+        });
+    EXPECT_CALL(*device_b, sync_iov(UBLK_IO_OP_WRITE, _, _, _))
+        .Times(::testing::AnyNumber())
+        .WillRepeatedly([resync_writes_out](uint8_t, iovec* iovecs, uint32_t nr_vecs, off_t) -> io_result {
+            if (resync_writes_out) resync_writes_out->fetch_add(1, std::memory_order_relaxed);
+            return ublkpp::__iovec_len(iovecs, iovecs + nr_vecs);
+        });
+    EXPECT_CALL(*device_a, sync_iov(UBLK_IO_OP_WRITE, _, _, _))
+        .Times(::testing::AnyNumber())
+        .WillRepeatedly([](uint8_t, iovec* iovecs, uint32_t nr_vecs, off_t) -> io_result {
+            return ublkpp::__iovec_len(iovecs, iovecs + nr_vecs);
+        });
+    EXPECT_CALL(*device_b, sync_iov(UBLK_IO_OP_READ, _, _, _))
+        .Times(::testing::AnyNumber())
+        .WillRepeatedly([](uint8_t, iovec* iovecs, uint32_t nr_vecs, off_t) -> io_result {
+            return ublkpp::__iovec_len(iovecs, iovecs + nr_vecs);
+        });
+    EXPECT_CALL(*device_a, async_iov(_, _, _, _, _, _))
+        .Times(::testing::AnyNumber())
+        .WillRepeatedly([](ublksrv_queue const*, ublk_io_data const*, ublkpp::sub_cmd_t, iovec*, uint32_t,
+                           uint64_t) -> io_result { return 1; });
+    EXPECT_CALL(*device_b, async_iov(_, _, _, _, _, _))
+        .Times(::testing::AnyNumber())
+        .WillRepeatedly([](ublksrv_queue const*, ublk_io_data const*, ublkpp::sub_cmd_t, iovec*, uint32_t,
+                           uint64_t) -> io_result { return 1; });
+}
+
+// Completes an in-flight write io_data, sending the right number of on_io_complete
+// calls based on how many async writes were queued (pending_cnt from handle_rw).
+static void complete_write(ublkpp::Raid1Disk& dev, ublk_io_data& io, int pending_cnt) {
+    dev.on_io_complete(&io, 0b100, 0);                       // primary (device_a) completion
+    if (pending_cnt >= 2) dev.on_io_complete(&io, 0b101, 0); // replica (device_b) completion
+}
+
+// Verify that a write to an unrelated LBA does not block resync of a different dirty region.
+// Old mechanism: ANY write paused ALL resync.
+// New mechanism: only conflicting LBA ranges are skipped.
+TEST(Raid1, UnrelatedWriteDoesNotBlockResync) {
+    auto device_a = CREATE_DISK_A((TestParams{.capacity = Gi, .id = "DiskA"}));
+    auto device_b = CREATE_DISK_B((TestParams{.capacity = Gi, .id = "DiskB"}));
+    auto raid_device = ublkpp::Raid1Disk(boost::uuids::string_generator()(test_uuid), device_a, device_b);
+    raid_device.toggle_resync(false);
+
+    // Step 1: Dirty LBA 0 by failing device_b's async write
+    {
+        EXPECT_CALL(*device_a, async_iov(_, _, _, _, _, _))
+            .Times(1)
+            .WillOnce([](ublksrv_queue const*, ublk_io_data const*, ublkpp::sub_cmd_t, iovec*, uint32_t,
+                         uint64_t) -> io_result { return 1; });
+        EXPECT_CALL(*device_b, async_iov(_, _, _, _, _, _))
+            .Times(1)
+            .WillOnce(
+                [](ublksrv_queue const*, ublk_io_data const*, ublkpp::sub_cmd_t, iovec*, uint32_t,
+                   uint64_t) -> io_result { return std::unexpected(std::make_error_condition(std::errc::io_error)); });
+        EXPECT_TO_WRITE_SB(device_a);
+
+        auto io = make_io_data(UBLK_IO_OP_WRITE, 32 * Ki, 0UL);
+        ASSERT_TRUE(raid_device.handle_rw(nullptr, &io, 0b10, nullptr, 32 * Ki, 0UL));
+        raid_device.on_io_complete(&io, 0b100, 0);
+        remove_io_data(io);
+    }
+
+    ASSERT_GT(raid_device.replica_states().bytes_to_sync, 0U);
+
+    // Step 2: Restore device_b
+    {
+        auto io = make_io_data(UBLK_IO_OP_READ);
+        ASSERT_TRUE(raid_device.queue_internal_resp(nullptr, &io,
+                                                    ublkpp::set_flags(0b101, ublkpp::sub_cmd_flags::INTERNAL), 0));
+        remove_io_data(io);
+    }
+
+    // Step 3: Set up resync and concurrent write expectations
+    std::atomic< int > resync_reads{0};
+    expect_resync_io(device_a, device_b, &resync_reads, nullptr);
+
+    // Step 4: Issue a write to a non-overlapping LBA (512 MiB away from dirty LBA 0).
+    // handle_rw calls enqueue_write; we hold it in-flight by not calling on_io_complete yet.
+    constexpr uint64_t k_unrelated_lba = 512 * Mi;
+    auto inflight_io = make_io_data(UBLK_IO_OP_WRITE, 32 * Ki, k_unrelated_lba);
+    auto const pending = raid_device.handle_rw(nullptr, &inflight_io, 0b10, nullptr, 32 * Ki, k_unrelated_lba);
+    ASSERT_TRUE(pending);
+
+    // Step 5: Start resync — it must copy LBA 0 despite the in-flight write at 512 MiB
+    raid_device.toggle_resync(true);
+
+    EXPECT_TRUE(wait_for_clean_state(raid_device, 2000ms))
+        << "Resync must complete even with an unrelated write held in-flight";
+
+    EXPECT_GE(resync_reads.load(), 1) << "Resync should have performed at least one read";
+
+    // Step 6: Release the in-flight write now that resync has finished
+    complete_write(raid_device, inflight_io, pending.value());
+    remove_io_data(inflight_io);
+
+    EXPECT_TO_WRITE_SB(device_a);
+    EXPECT_TO_WRITE_SB(device_b);
+}
+
+// Verify that resync skips a conflicting in-flight write (bitmap stays dirty),
+// and successfully copies the region after the write completes.
+TEST(Raid1, ConflictingWriteSkipped_ResyncRetries) {
+    auto device_a = CREATE_DISK_A((TestParams{.capacity = Gi, .id = "DiskA"}));
+    auto device_b = CREATE_DISK_B((TestParams{.capacity = Gi, .id = "DiskB"}));
+    auto raid_device = ublkpp::Raid1Disk(boost::uuids::string_generator()(test_uuid), device_a, device_b);
+    raid_device.toggle_resync(false);
+
+    // Step 1: Dirty LBA 0
+    {
+        EXPECT_CALL(*device_a, async_iov(_, _, _, _, _, _))
+            .Times(1)
+            .WillOnce([](ublksrv_queue const*, ublk_io_data const*, ublkpp::sub_cmd_t, iovec*, uint32_t,
+                         uint64_t) -> io_result { return 1; });
+        EXPECT_CALL(*device_b, async_iov(_, _, _, _, _, _))
+            .Times(1)
+            .WillOnce(
+                [](ublksrv_queue const*, ublk_io_data const*, ublkpp::sub_cmd_t, iovec*, uint32_t,
+                   uint64_t) -> io_result { return std::unexpected(std::make_error_condition(std::errc::io_error)); });
+        EXPECT_TO_WRITE_SB(device_a);
+
+        auto io = make_io_data(UBLK_IO_OP_WRITE, 32 * Ki, 0UL);
+        ASSERT_TRUE(raid_device.handle_rw(nullptr, &io, 0b10, nullptr, 32 * Ki, 0UL));
+        raid_device.on_io_complete(&io, 0b100, 0);
+        remove_io_data(io);
+    }
+
+    ASSERT_GT(raid_device.replica_states().bytes_to_sync, 0U);
+
+    // Step 2: Restore device_b
+    {
+        auto io = make_io_data(UBLK_IO_OP_READ);
+        ASSERT_TRUE(raid_device.queue_internal_resp(nullptr, &io,
+                                                    ublkpp::set_flags(0b101, ublkpp::sub_cmd_flags::INTERNAL), 0));
+        remove_io_data(io);
+    }
+
+    // Step 3: Set up resync expectations, tracking whether resync actually reads from device_a
+    std::atomic< int > resync_reads{0};
+    expect_resync_io(device_a, device_b, &resync_reads, nullptr);
+
+    // Step 4: Issue a write overlapping LBA 0 (the dirty region) and hold it in-flight.
+    // This calls enqueue_write internally; dequeue_write is only called on on_io_complete.
+    auto conflict_io = make_io_data(UBLK_IO_OP_WRITE, 32 * Ki, 0UL);
+    auto const pending = raid_device.handle_rw(nullptr, &conflict_io, 0b10, nullptr, 32 * Ki, 0UL);
+    ASSERT_TRUE(pending);
+
+    // Step 5: Start resync — it should detect the conflict and skip LBA 0 every sweep
+    raid_device.toggle_resync(true);
+
+    // Give resync several yield cycles to attempt copying — it must skip each time
+    std::this_thread::sleep_for(300ms);
+
+    // Resync must not have performed any reads (Phase 1 conflict check skips before reading)
+    EXPECT_EQ(0, resync_reads.load()) << "Resync must not read the conflicting region while write is in-flight";
+    EXPECT_GT(raid_device.replica_states().bytes_to_sync, 0U)
+        << "Bitmap must remain dirty while the conflicting write is in-flight";
+
+    // Step 6: Complete the write — dequeue_write is called, resync can now proceed
+    complete_write(raid_device, conflict_io, pending.value());
+    remove_io_data(conflict_io);
+
+    // Resync should now copy the dirty region (or the write path's handle_internal cleans it)
+    EXPECT_TRUE(wait_for_clean_state(raid_device, 2000ms))
+        << "State must become clean after the conflicting write is dequeued";
+
+    EXPECT_TO_WRITE_SB(device_a);
+    EXPECT_TO_WRITE_SB(device_b);
+}
+
+// Verify that Phase 2 (post-copy conflict check) detects a write that arrives AFTER Phase 1
+// passes but BEFORE clean_region is called, and correctly keeps the bitmap dirty.
+//
+// Sequence:
+//   Phase 1 check: no write in-flight → resync proceeds, begins copy READ
+//   [test thread registers a write while READ is in progress]
+//   Copy WRITE completes → Phase 2 detects the in-flight write → skip clean_region
+//   → bitmap stays dirty until the write completes → resync re-copies → clean
+TEST(Raid1, Phase2ConflictDetectedAfterCopy) {
+    auto device_a = CREATE_DISK_A((TestParams{.capacity = Gi, .id = "DiskA"}));
+    auto device_b = CREATE_DISK_B((TestParams{.capacity = Gi, .id = "DiskB"}));
+    auto raid_device = ublkpp::Raid1Disk(boost::uuids::string_generator()(test_uuid), device_a, device_b);
+    raid_device.toggle_resync(false);
+
+    // Step 1: Dirty LBA 0 by failing device_b's async write
+    {
+        EXPECT_CALL(*device_a, async_iov(_, _, _, _, _, _))
+            .Times(1)
+            .WillOnce([](ublksrv_queue const*, ublk_io_data const*, ublkpp::sub_cmd_t, iovec*, uint32_t,
+                         uint64_t) -> io_result { return 1; });
+        EXPECT_CALL(*device_b, async_iov(_, _, _, _, _, _))
+            .Times(1)
+            .WillOnce(
+                [](ublksrv_queue const*, ublk_io_data const*, ublkpp::sub_cmd_t, iovec*, uint32_t,
+                   uint64_t) -> io_result { return std::unexpected(std::make_error_condition(std::errc::io_error)); });
+        EXPECT_TO_WRITE_SB(device_a);
+
+        auto io = make_io_data(UBLK_IO_OP_WRITE, 32 * Ki, 0UL);
+        ASSERT_TRUE(raid_device.handle_rw(nullptr, &io, 0b10, nullptr, 32 * Ki, 0UL));
+        raid_device.on_io_complete(&io, 0b100, 0);
+        remove_io_data(io);
+    }
+
+    ASSERT_GT(raid_device.replica_states().bytes_to_sync, 0U);
+
+    // Step 2: Restore device_b
+    {
+        auto io = make_io_data(UBLK_IO_OP_READ);
+        ASSERT_TRUE(raid_device.queue_internal_resp(nullptr, &io,
+                                                    ublkpp::set_flags(0b101, ublkpp::sub_cmd_flags::INTERNAL), 0));
+        remove_io_data(io);
+    }
+
+    // Step 3: Set up mock so the FIRST resync READ of LBA 0 signals that Phase 1 has
+    // passed, then blocks until the test thread registers a write for the same region.
+    std::promise< void > copy_read_started;
+    std::promise< void > write_registered;
+
+    EXPECT_CALL(*device_a, sync_iov(UBLK_IO_OP_READ, _, _, _))
+        .Times(::testing::AnyNumber())
+        .WillOnce([&](uint8_t, iovec* iovecs, uint32_t nr_vecs, off_t) -> io_result {
+            copy_read_started.set_value();
+            write_registered.get_future().wait();
+            if (iovecs->iov_base) memset(iovecs->iov_base, 0xAA, iovecs->iov_len);
+            return ublkpp::__iovec_len(iovecs, iovecs + nr_vecs);
+        })
+        .WillRepeatedly([](uint8_t, iovec* iovecs, uint32_t nr_vecs, off_t) -> io_result {
+            if (iovecs->iov_base) memset(iovecs->iov_base, 0xAA, iovecs->iov_len);
+            return ublkpp::__iovec_len(iovecs, iovecs + nr_vecs);
+        });
+    EXPECT_CALL(*device_b, sync_iov(UBLK_IO_OP_WRITE, _, _, _))
+        .Times(::testing::AnyNumber())
+        .WillRepeatedly([](uint8_t, iovec* iovecs, uint32_t nr_vecs, off_t) -> io_result {
+            return ublkpp::__iovec_len(iovecs, iovecs + nr_vecs);
+        });
+    EXPECT_CALL(*device_a, sync_iov(UBLK_IO_OP_WRITE, _, _, _))
+        .Times(::testing::AnyNumber())
+        .WillRepeatedly([](uint8_t, iovec* iovecs, uint32_t nr_vecs, off_t) -> io_result {
+            return ublkpp::__iovec_len(iovecs, iovecs + nr_vecs);
+        });
+    EXPECT_CALL(*device_b, sync_iov(UBLK_IO_OP_READ, _, _, _))
+        .Times(::testing::AnyNumber())
+        .WillRepeatedly([](uint8_t, iovec* iovecs, uint32_t nr_vecs, off_t) -> io_result {
+            return ublkpp::__iovec_len(iovecs, iovecs + nr_vecs);
+        });
+    EXPECT_CALL(*device_a, async_iov(_, _, _, _, _, _))
+        .Times(::testing::AnyNumber())
+        .WillRepeatedly([](ublksrv_queue const*, ublk_io_data const*, ublkpp::sub_cmd_t, iovec*, uint32_t,
+                           uint64_t) -> io_result { return 1; });
+    EXPECT_CALL(*device_b, async_iov(_, _, _, _, _, _))
+        .Times(::testing::AnyNumber())
+        .WillRepeatedly([](ublksrv_queue const*, ublk_io_data const*, ublkpp::sub_cmd_t, iovec*, uint32_t,
+                           uint64_t) -> io_result { return 1; });
+
+    // Step 4: Start resync — Phase 1 sees no write registered and proceeds into the copy
+    raid_device.toggle_resync(true);
+
+    // Step 5: Wait for resync to start reading LBA 0 (Phase 1 has already passed)
+    copy_read_started.get_future().wait();
+
+    // Step 6: Register a write to LBA 0 AFTER Phase 1 passed; Phase 2 must catch it
+    auto conflict_io = make_io_data(UBLK_IO_OP_WRITE, 32 * Ki, 0UL);
+    auto const pending = raid_device.handle_rw(nullptr, &conflict_io, 0b10, nullptr, 32 * Ki, 0UL);
+    ASSERT_TRUE(pending);
+
+    // Step 7: Unblock the resync read — Phase 2 will detect the in-flight write and skip
+    // clean_region, leaving the bitmap dirty
+    write_registered.set_value();
+
+    // Step 8: Bitmap must remain dirty while the write is still in-flight (Phase 1 also
+    // blocks all subsequent sweeps until dequeue_write fires)
+    std::this_thread::sleep_for(300ms);
+    EXPECT_GT(raid_device.replica_states().bytes_to_sync, 0U)
+        << "Bitmap must remain dirty while Phase-2-detected write is in-flight";
+
+    // Step 9: Complete the write — dequeue_write unregisters from the region tracker
+    complete_write(raid_device, conflict_io, pending.value());
+    remove_io_data(conflict_io);
+
+    // Resync can now copy the dirty region and mark it clean
+    EXPECT_TRUE(wait_for_clean_state(raid_device, 2000ms))
+        << "State must become clean after the Phase-2 write completes";
+
+    EXPECT_TO_WRITE_SB(device_a);
+    EXPECT_TO_WRITE_SB(device_b);
+}


### PR DESCRIPTION
## Problem

The old resync pause mechanism used a single global `_outstanding_writes` atomic counter. Any in-flight write — regardless of which LBA range — would pause ALL resync activity. Under 1000 IOPS this suppressed resync >90% of the time. The first write after a resync batch could also stall up to 12.4 ms (62 chunks × 200 µs) waiting for the resync thread to yield.

## Solution

Replace the counter with a lock-free bounded array (`RegionTracker`) tracking the LBA range of each in-flight write. Resync now only skips regions that **actually conflict** with an in-flight write; unrelated regions proceed without any pause.

The `PAUSE` resync state is removed entirely.

## Design

**`RegionTracker`** (`region_tracker.hpp`):
- Fixed-size slot array sized to `2 × qdepth` (one slot per primary leg + one per replica leg per write)
- CAS on `slot.lba` is the linearization point for slot allocation
- `slot.len` is published with `memory_order_release` after the CAS
- **Transitional window handling**: `unregister_write` resets `len=0` before freeing `lba`; `overlaps()` treats `slot_len==0` on a non-free slot as a conservative conflict — false positives (spurious yield) only, never false negatives

**Two-phase conflict check in `__run()`**:
- **Phase 1** (pre-copy): if `region_tracker.overlaps(chunk)`, advance `logical_off` within the dirty run and skip; no I/O issued
- **Phase 2** (post-copy): after the resync write completes, re-check `overlaps()` before calling `clean_region()` — catches writes that arrived during the READ window; bitmap stays dirty and next sweep retries

## Files Changed

| File | Change |
|------|--------|
| `src/raid/raid1/region_tracker.hpp` | **New** — lock-free per-region write tracker |
| `src/raid/raid1/raid1_resync_task.hpp` | Remove `PAUSE` state, `_outstanding_writes`, `__pause()`, `__resume()`; add `RegionTracker` |
| `src/raid/raid1/raid1_resync_task.cpp` | Two-phase conflict check; remove `__pause()` body; simplify `__yield()` and `stop()` |
| `src/raid/raid1/raid1.cpp` | Update 9 enqueue/dequeue call sites with `(addr, len)` |
| `src/raid/raid1/tests/bitmap/region_tracker_test.cpp` | **New** — 11 unit tests for `RegionTracker` |
| `src/raid/raid1/tests/concurrency/write_resync_no_pause.cpp` | **New** — integration tests: unrelated write doesn't block resync; conflicting write is skipped then retried; Phase 2 conflict detected after copy |
| `src/raid/raid1/tests/bitmap/CMakeLists.txt` | Add `region_tracker_test.cpp` |
| `src/raid/raid1/tests/concurrency/CMakeLists.txt` | Add `write_resync_no_pause.cpp` |

## Test Plan

- [ ] `RegionTrackerEmptyNoOverlap` — empty tracker never overlaps
- [ ] `RegionTrackerRegisterAndOverlapExact` / `Partial` / `Contained` / `Adjacent` — overlap geometry
- [ ] `RegionTrackerUnregisterClearsSlot` — slot freed after deregister
- [ ] `RegionTrackerDuplicateLba_TwoSlots` — primary + replica legs occupy two independent slots
- [ ] `RegionTrackerFillAndDrain` — slot exhaustion + reclaim
- [ ] `RegionTrackerConcurrentRegisterUnregister` — 8 threads × 200 iters under TSAN
- [ ] `UnrelatedWriteDoesNotBlockResync` — write at 512 MiB doesn't block resync of LBA 0
- [ ] `ConflictingWriteSkipped_ResyncRetries` — resync skips conflicting write; cleans after completion
- [ ] `Phase2ConflictDetectedAfterCopy` — write arriving during resync READ window keeps bitmap dirty; cleans after write completes
- [ ] All existing raid1 tests pass unchanged