### PR TITLE
feat(claude): add project skills and reference checklists

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -172,18 +172,4 @@ Four named jobs on `ubuntu-24.04`, triggered on push to `main` and PRs targeting
 
 ## Code Review
 
-When asked to review a PR, use `gh pr view` and `gh pr diff` to fetch details, then work through these questions before posting comments.
-
-### Questions to always ask
-- Does this code break anything?
-- Are there race conditions?
-- Are there logic issues?
-- Could this be done better or made smaller?
-- Is this part designed correctly, or could it be improved?
-- Are responsibilities correctly separated, or are two concerns coupled in one place?
-
-### How to Post Comments
-- Post comments on **specific diff lines**, not as top-level PR comments
-- Discuss critical findings with the user before posting
-- Always include a suggested fix when raising a bug, not just the problem
-- Don't reject or approve PR yourself.
+Use `/code-review` for structured PR and diff reviews. The skill covers SOLID analysis, security, code quality, removal candidates, and commit message review.

--- a/.claude/commands/code-review.md
+++ b/.claude/commands/code-review.md
@@ -1,0 +1,174 @@
+# Code Review Expert
+
+Perform a structured review of the current git changes with focus on SOLID, architecture, removal candidates, and security risks. Default to review-only output unless the user asks to implement changes.
+
+## Severity Levels
+
+| Level | Name | Description | Action |
+|---|---|---|---|
+| P0 | Critical | Security vulnerability, data loss risk, correctness bug | Must block merge |
+| P1 | High | Logic error, significant SOLID violation, performance regression | Should fix before merge |
+| P2 | Medium | Code smell, maintainability concern, minor SOLID violation | Fix in this PR or create follow-up |
+| P3 | Low | Style, naming, minor suggestion | Optional improvement |
+
+## Scope Constraint: Diff-First, Legacy-Separate, Legacy-Non-Blocking
+
+**STRICT RULE — must be followed on every review:**
+
+1. **Diff-First**: The primary review MUST focus only on the current code changes (the diff). Do not mix legacy findings into the main review findings.
+2. **Legacy-Separate**: Existing/surrounding legacy code MAY be read for context. Any issues found in legacy code MUST be placed in a separate, dedicated section titled `## Legacy Code Observations` that appears after the main findings.
+3. **Legacy-Non-Blocking**: Issues identified in legacy code MUST NOT block the current PR merge. They CANNOT be rated P0 or P1 for the current PR. They are treated as informational suggestions or tech-debt prompts only, suitable for future refactoring.
+
+## Workflow
+
+### 1) Preflight context
+
+If reviewing a PR, use `gh pr view` and `gh pr diff` to fetch PR title, description, and diff. Otherwise use `git status -sb`, `git diff --stat`, and `git diff` to scope local changes.
+
+If needed, use `rg` or `grep` to find related modules, usages, and contracts. Identify entry points, ownership boundaries, and critical paths.
+
+Edge cases:
+- **No changes**: If diff is empty, inform user and ask if they want to review staged changes or a specific commit range.
+- **Large diff (>500 lines)**: Summarize by file first, then review in batches by module/feature area.
+- **Mixed concerns**: Group findings by logical feature, not just file order.
+
+### 2) SOLID + architecture smells
+
+Read `.claude/references/solid-checklist.md` for specific prompts. Look for:
+- **SRP**: Overloaded modules with unrelated responsibilities.
+- **OCP**: Frequent edits to add behavior instead of extension points.
+- **LSP**: Subclasses that break expectations or require type checks.
+- **ISP**: Wide interfaces with unused methods.
+- **DIP**: High-level logic tied to low-level implementations.
+
+Also ask:
+- Are responsibilities correctly separated, or are two concerns coupled in one place?
+- Could this be done better or made smaller?
+- Is this part designed correctly, or could it be improved?
+
+When proposing a refactor, explain why it improves cohesion/coupling and outline a minimal, safe split. If non-trivial, propose an incremental plan instead of a large rewrite.
+
+### 3) Removal candidates + iteration plan
+
+Read `.claude/references/removal-plan.md` for template. Identify code that is unused, redundant, or feature-flagged off. Distinguish safe delete now vs defer with plan. Provide a follow-up plan with concrete steps and checkpoints.
+
+### 4) Security and reliability scan
+
+Read `.claude/references/security-checklist.md` for coverage. Check for:
+- Command injection, path traversal in any shell or file operations
+- Secret leakage or API keys in logs/env/files
+- Unbounded loops, CPU/memory hotspots, missing resource cleanup
+- Race conditions: concurrent access, check-then-act, TOCTOU, missing locks
+- Weak crypto or insecure defaults
+
+This is a C++ userspace block device driver — prioritize: memory safety, race conditions, resource leaks, and I/O correctness.
+
+Call out both exploitability and impact.
+
+### 5) Code quality scan
+
+Read `.claude/references/code-quality-checklist.md` for coverage. Also ask:
+- Does this code break anything?
+- Are there race conditions?
+- Are there logic issues?
+
+Check for:
+- **Error handling**: unchecked `std::expected` returns, missing `DLOGE` before returning errors, unhandled async errors
+- **Performance**: CPU-intensive ops on hot I/O paths, missing cache, unbounded memory growth
+- **Boundary conditions**: null/nullptr handling, empty collections, integer overflow/underflow, off-by-one, signed/unsigned mismatches (UB)
+- **Hygiene**: unused `#include`s, empty files (except .gitkeep), files containing only commented-out code
+- **Naming & conventions**: verify public API uses `lower_snake_case`, internal classes use `PascalCase`, members use `_snake_case`, constants use `k_snake_case` — per project conventions
+- **Logging**: errors logged with SISL macros (`DLOGE`, `RLOGW`, etc.) before returning, correct module tag used
+
+### 6) Commit message review
+
+Retrieve commit messages using `git log --oneline` or `git log`. For each commit verify:
+- **Clarity**: Clearly describes what was changed and why.
+- **Meaningfulness**: Not vague (e.g., "fix", "update", "WIP", "misc changes").
+- **Format**: Subject line ≤72 chars, imperative mood, not trailing off.
+- **Scope**: Each commit represents a single coherent unit of work.
+
+For unclear messages, suggest improvements:
+
+```
+❌ Original: <original message>
+✅ Suggested: <improved message that explains what changed and why>
+```
+
+### 7) Output format
+
+Structure your review as follows:
+
+```
+## Code Review Summary
+
+**Files reviewed**: X files, Y lines changed
+**Overall assessment**: [APPROVE / REQUEST_CHANGES / COMMENT]
+
+---
+
+## Findings
+
+### P0 - Critical
+(none or list)
+
+### P1 - High
+1. **[file:line]** Brief title
+   - Description of issue
+   - Suggested fix
+
+### P2 - Medium
+...
+
+### P3 - Low
+...
+
+---
+
+## Removal/Iteration Plan
+(if applicable)
+
+## Commit Message Review
+(none or list with improvements)
+
+## Additional Suggestions
+(optional, non-blocking)
+
+---
+
+## Legacy Code Observations
+<!-- NON-BLOCKING — informational tech-debt prompts only -->
+(none or list)
+```
+
+**Clean review**: If no issues found, explicitly state what was checked, areas not covered, and residual risks.
+
+### 8) Posting comments (PR reviews only)
+
+- Post comments on **specific diff lines**, not as top-level PR comments.
+- Discuss critical findings with the user **before** posting.
+- Always include a **suggested fix** when raising a bug, not just the problem.
+- Do NOT reject or approve the PR yourself.
+
+### 9) Next steps confirmation
+
+After presenting findings, ask:
+
+```
+---
+
+## Next Steps
+
+I found X issues (P0: _, P1: _, P2: _, P3: _).
+
+**How would you like to proceed?**
+
+1. **Fix all** - I'll implement all suggested fixes
+2. **Fix P0/P1 only** - Address critical and high priority issues
+3. **Fix specific items** - Tell me which issues to fix
+4. **No changes** - Review complete, no implementation needed
+
+Please choose an option or provide specific instructions.
+```
+
+**Important**: Do NOT implement any changes until user explicitly confirms. This is a review-first workflow.

--- a/.claude/commands/explain-code.md
+++ b/.claude/commands/explain-code.md
@@ -1,0 +1,38 @@
+# Explain Code
+
+Explains code with visual diagrams and analogies. Use when explaining how code works, teaching about a codebase, or when the user asks "how does this work?"
+
+When explaining code, always include:
+
+## 1) Analogy first
+
+Compare the code to something from everyday life. Make it concrete and relatable before touching implementation details. For complex concepts, use multiple analogies from different angles.
+
+## 2) Diagram
+
+Draw an ASCII diagram showing the flow, structure, or relationships — whichever is most illuminating for the concept at hand.
+
+Examples of what to draw depending on context:
+- **Data flow**: how a request/IO moves through layers
+- **State machine**: states and transitions (e.g., IDLE → SYNCING → ACTIVE)
+- **Object relationships**: ownership, composition, dependencies
+- **Sequence**: call order between components over time
+- **Memory layout**: struct fields, buffer organization
+
+## 3) Step-by-step walkthrough
+
+Walk through the code explaining what happens at each stage. Reference actual file paths and line numbers (e.g., `src/raid/raid1.cpp:42`) so the user can follow along. Stay grounded in the real code — don't invent behavior.
+
+For this codebase specifically, note relevant context where applicable:
+- Whether this is public API (`include/ublkpp/`) or internal (`src/`)
+- Which RAID type is involved (RAID0/1/10) and what that means for the logic
+- Whether coroutines / `co_await` are in play and what suspension means here
+- How `std::expected<T, std::error_condition>` / `io_result` is threaded through
+
+## 4) The gotcha
+
+Call out one common mistake or misconception about this code. What trips people up? What looks obvious but isn't? What assumption does the code rely on that a reader might miss?
+
+## Tone
+
+Keep explanations conversational. Avoid dense walls of text — prefer short paragraphs, bullet points, and the diagram doing heavy lifting. If the concept is genuinely complex, layer the explanation: simple analogy first, then mechanics, then edge cases.

--- a/.claude/references/code-quality-checklist.md
+++ b/.claude/references/code-quality-checklist.md
@@ -1,0 +1,66 @@
+# Code Quality Checklist
+
+## Error Handling
+
+- [ ] Are `std::expected` / `io_result` return values checked at every call site?
+- [ ] Are errors logged with `DLOGE`/`TLOGE` (with context) before being returned?
+- [ ] Are catch blocks specific — no bare `catch (...)` that hides the error type?
+- [ ] In coroutines: are all `co_await` error paths handled, not just the happy path?
+- [ ] Are destructors and RAII types used to guarantee cleanup, not just happy-path `free`?
+- [ ] Are error messages actionable — do they say what failed and with what input?
+- [ ] Is the correct SISL logging module tag used (`ublksrv`, `ublk_tgt`, `ublk_raid`, `ublk_drivers`)?
+
+## Performance
+
+- [ ] Are CPU-intensive operations (hashing, compression, bitmap scanning) on the hot I/O path?
+- [ ] Are large allocations or buffer copies inside tight loops (should be outside or pooled)?
+- [ ] Are memory-mapped or zero-copy paths used where appropriate for large I/O?
+- [ ] Are lock contention hotspots visible (global mutex, coarse-grained lock on hot path)?
+- [ ] Is bitmap dirty-tracking efficient — are chunk boundaries aligned, avoiding spurious write amplification?
+- [ ] Are coroutine suspensions minimal on the critical I/O path?
+
+## Boundary Conditions
+
+- [ ] Is behavior defined for null/nullptr inputs?
+- [ ] Are empty collections handled without panicking (e.g., `front()` on empty vector)?
+- [ ] Are integer overflows, underflows, and wrap-around possible (especially with sizes and offsets)?
+- [ ] Are off-by-one errors possible in range loops, chunk boundaries, or size comparisons?
+- [ ] Are signed/unsigned comparison mismatches present (UB in C++)?
+- [ ] Are division-by-zero paths possible (e.g., stripe width, chunk size as divisors)?
+- [ ] Are I/O offset + length combinations validated to not exceed device bounds?
+
+## Code Hygiene
+
+- [ ] Are there unused `#include`s or forward declarations?
+- [ ] Are there purely empty files (except intentional `.gitkeep`)?
+- [ ] Are there files containing only commented-out code?
+- [ ] Are there unreachable code blocks (after `return`, infinite loops, dead branches)?
+- [ ] Are there TODO/FIXME/HACK comments that should be resolved or tracked?
+- [ ] Are there magic numbers that should be named `k_` constants?
+- [ ] Is dead code (unused functions, variables, types) present in the diff?
+
+## Naming & Conventions
+
+- [ ] Public API types in `include/ublkpp/`: `lower_snake_case` for classes and free functions.
+- [ ] Internal classes in `src/`: `PascalCase`.
+- [ ] Functions and methods: `snake_case`.
+- [ ] Members: `_snake_case`.
+- [ ] Constants: `k_snake_case`.
+- [ ] Macros and enums: `SCREAMING_SNAKE_CASE`.
+- [ ] Namespaces: lowercase (`ublkpp`, `ublkpp::raid1`).
+
+## Testing
+
+- [ ] Are the new code paths covered by tests in `src/<component>/tests/`?
+- [ ] Do the tests exercise error/failure paths, not just the happy path?
+- [ ] Are race conditions or async paths tested (e.g., resync completion races)?
+- [ ] Are tests deterministic — no reliance on timing or external state?
+- [ ] Are test names descriptive enough to diagnose a failure without reading the body?
+- [ ] Coverage target: 100% for new code; 80% high, 65% medium for existing.
+
+## Readability & Maintainability
+
+- [ ] Are function/variable names self-explanatory without needing a comment?
+- [ ] Are functions short enough to read in one screen (~40 lines guideline)?
+- [ ] Is complex logic accompanied by a brief WHY comment — non-obvious invariants, lock ordering, workarounds?
+- [ ] Is duplicated logic extracted into a shared utility?

--- a/.claude/references/removal-plan.md
+++ b/.claude/references/removal-plan.md
@@ -1,0 +1,57 @@
+# Removal / Iteration Plan Template
+
+Use this template when identifying code that may be candidates for deletion or phase-out.
+
+---
+
+## Removal Candidate
+
+**Location**: `path/to/file.cpp:line`
+**Type**: `[ ] Unused code  [ ] Redundant duplicate  [ ] Dead feature flag  [ ] Obsolete workaround`
+
+**Description**: What is this code, and why does it appear to be safe to remove?
+
+**Evidence of non-use**:
+- No callers found via `grep -r`
+- Feature flag evaluates to `false` in all environments
+- Replaced by `<new symbol>` in commit `<sha>`
+
+**Risk assessment**:
+- `[ ] Safe to delete now` — no callers, no side effects, test coverage confirms
+- `[ ] Defer with plan` — callers exist but are themselves candidates; remove as a group
+
+---
+
+## Iteration Plan (for deferred removals)
+
+Use when safe-delete-now is not possible: the code is entangled with other live code that must be migrated first.
+
+### Step 1 — Deprecate
+- Add a deprecation marker / log warning at call sites.
+- Target date: `YYYY-MM-DD`
+- Owner: `<name>`
+
+### Step 2 — Migrate callers
+- List each call site and the replacement:
+  | Call site | Replacement |
+  |---|---|
+  | `foo.cpp:42` | `new_foo()` |
+- Checkpoint: all tests green after migration, no remaining direct calls.
+
+### Step 3 — Delete
+- Remove the deprecated code.
+- Remove the deprecation markers.
+- Update any related documentation or CHANGELOG.
+- Checkpoint: CI passes, coverage unchanged or improved.
+
+### Step 4 — Verify
+- Run integration tests or staging smoke tests.
+- Confirm no runtime errors in logs for 1 deployment cycle.
+
+---
+
+## Notes
+
+- Prefer deleting in a dedicated PR (not bundled with a feature) so the diff is reviewable.
+- If deletion touches a public API, check downstream consumers and semver implications.
+- If the code is behind a feature flag, coordinate flag retirement with the flag owner.

--- a/.claude/references/security-checklist.md
+++ b/.claude/references/security-checklist.md
@@ -1,0 +1,43 @@
+# Security Checklist
+
+## Command & Path Injection
+
+- [ ] Are shell calls using argument arrays, not interpolated strings with user input?
+- [ ] Are user-supplied file paths resolved and checked against an allowed base directory?
+- [ ] Is `..` stripped or rejected in any file path parameters?
+
+## Secret Leakage
+
+- [ ] Are API keys, credentials, or tokens hardcoded or committed to version control?
+- [ ] Could secrets appear in logs, error messages, or debug output?
+
+## Cryptography
+
+- [ ] Is a strong, modern algorithm used (AES-256, SHA-256+)? No MD5/SHA1 for security purposes.
+- [ ] Are cryptographic nonces/IVs unique per operation?
+- [ ] Are checksums or integrity checks applied to on-disk structures (superblock, bitmap)?
+
+## Race Conditions (primary concern for this codebase)
+
+- [ ] Is shared mutable state protected by a mutex or atomics?
+- [ ] Are check-then-act sequences (TOCTOU) atomic or otherwise safe?
+- [ ] Are lock ordering conventions consistent across the codebase to prevent deadlock?
+- [ ] Are signal handlers async-signal-safe?
+- [ ] Are memory-mapped or shared memory regions properly synchronized?
+- [ ] Can the IDLE→STOPPING or similar state machine transitions race? Are they guarded by atomic status counters?
+- [ ] Are coroutine/async I/O completions properly sequenced — no access to freed state after `co_await`?
+
+## Reliability / Resource Safety
+
+- [ ] Are resource allocations bounded (max I/O size, max queue depth, max allocation)?
+- [ ] Are unbounded loops or recursion possible from external input?
+- [ ] Are file descriptors, memory maps, and allocated buffers released on all error paths (RAII)?
+- [ ] Are retries capped to avoid infinite retry storms on persistent device errors?
+- [ ] Is device error propagation correct — does a failed write reach the caller's `io_result`?
+
+## Memory Safety
+
+- [ ] Are raw pointer lifetimes clear and bounded by RAII or explicit ownership?
+- [ ] Are there use-after-free or use-after-move risks (especially across `co_await` suspension points)?
+- [ ] Are buffer sizes validated before memcpy/read/write to avoid overflow?
+- [ ] Are integer conversions between signed and unsigned safe (no UB wrap-around affecting sizes)?

--- a/.claude/references/solid-checklist.md
+++ b/.claude/references/solid-checklist.md
@@ -1,0 +1,66 @@
+# SOLID Checklist
+
+## Single Responsibility Principle (SRP)
+
+**Smell prompts:**
+- Does this class/module do more than one thing? Can you describe it without using "and"?
+- Would changes to two unrelated features both require editing this file?
+- Does this class have more than ~200 lines (excluding tests)? What are all the reasons it might change?
+- Are there multiple levels of abstraction in one file (e.g., HTTP parsing + business logic + DB access)?
+
+**Refactor heuristic:** Extract cohesive groups of methods into a new class. Pass the extracted class via constructor injection. Ensure the original class delegates rather than duplicates.
+
+---
+
+## Open/Closed Principle (OCP)
+
+**Smell prompts:**
+- Are new behaviors added by modifying existing switch/if-else chains rather than adding new types?
+- Does adding a new variant require touching the core class, not just adding a subclass/strategy?
+- Is there a long switch on a type tag or enum that grows with each feature?
+
+**Refactor heuristic:** Introduce a strategy interface or abstract base. Move each branch into its own implementation. Register implementations via a factory or map rather than inline dispatch.
+
+---
+
+## Liskov Substitution Principle (LSP)
+
+**Smell prompts:**
+- Does a subclass override a method to throw `NotImplemented` or do nothing?
+- Are there `instanceof` / `dynamic_cast` checks that dispatch on the concrete type?
+- Does using a subclass where the base is expected change observable behavior (preconditions, postconditions)?
+- Does the subclass narrow an argument type or widen a return type relative to the base?
+
+**Refactor heuristic:** If a subclass can't honor the base contract, the inheritance is wrong. Consider composition over inheritance, or split the base interface.
+
+---
+
+## Interface Segregation Principle (ISP)
+
+**Smell prompts:**
+- Do clients implement methods they don't use (stub or `throw NotImplemented`)?
+- Is a single interface used across very different contexts, each needing only a subset?
+- Does a mock in tests need to stub many unrelated methods just to satisfy the interface?
+
+**Refactor heuristic:** Split the wide interface along client usage boundaries. Each client should depend only on the narrowest interface it needs.
+
+---
+
+## Dependency Inversion Principle (DIP)
+
+**Smell prompts:**
+- Does high-level business logic `new` a concrete low-level class directly?
+- Are there hard-coded references to concrete implementations (file paths, DB drivers) inside domain logic?
+- Is it impossible to unit-test the high-level module without spinning up real infrastructure?
+
+**Refactor heuristic:** Extract an abstract interface for the low-level dependency. Inject the concrete implementation via constructor. The high-level module should own and define the interface, not the low-level module.
+
+---
+
+## General Architecture Smells
+
+- **God object**: One class that knows everything and does everything. Split by responsibility.
+- **Feature envy**: A method that uses another class's data more than its own. Move it there.
+- **Shotgun surgery**: A single change requires editing many unrelated files. Consolidate the concept.
+- **Inappropriate intimacy**: Two classes that reach deeply into each other's internals. Introduce an API boundary.
+- **Data clump**: The same group of fields/parameters always appear together. Extract them into a value object.


### PR DESCRIPTION
## Summary

- Adds three project-level Claude Code skills under `.claude/commands/`:
  - `/code-review` — structured diff review covering SOLID analysis, security, code quality, removal candidates, and commit message review; tuned for this codebase (C++ race conditions, `std::expected`, SISL logging, naming conventions)
  - `/explain-code` — explains code via analogy → ASCII diagram → step-by-step walkthrough → gotcha, grounded in ublkpp-specific context (RAID types, coroutines, public vs internal API)
- Adds supporting reference files for `/code-review` under `.claude/references/`: SOLID checklist, security checklist (C++/RAID focused, no web/DB), code quality checklist, and a removal plan template
- Collapses the verbose "Code Review" section in `CLAUDE.md` to a single pointer to `/code-review`

## Test plan

- [ ] Open a new Claude Code session in this repo and verify `/code-review` and `/explain-code` appear in the available skills list
- [ ] Run `/code-review` on a recent diff and confirm the structured output format (P0–P3 findings, legacy section, next steps prompt)
- [ ] Run `/explain-code` on a RAID1 or coroutine code path and confirm analogy + diagram + walkthrough + gotcha structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)