### PR TITLE
refactor(cqe_state): build on sisl::async::cqe_awaitable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.31.1
+- Replace internal ublkpp::cqe_state with sisl::async::cqe_state
+
 ## 0.31.0 raid1: replace global PAUSE with lock-free per-region write tracker
 - Replace global `PAUSE` state with `RegionTracker`: a lock-free flat slot array that tracks
   `(lba, len)` of each in-flight write. Resync now yields only for chunks that actually conflict

--- a/conanfile.py
+++ b/conanfile.py
@@ -68,7 +68,7 @@ class UBlkPPConan(ConanFile):
         self.test_requires("fio/nbi.3.28")
 
     def requirements(self):
-        self.requires("sisl/[^14.0]@oss/dev", transitive_headers=True)
+        self.requires("sisl/[^14.2]@oss/dev", transitive_headers=True)
 
         self.requires("isa-l/2.30.0")
         self.requires("ublksrv/nbi.1.5.0.1", transitive_headers=True)

--- a/conanfile.py
+++ b/conanfile.py
@@ -10,7 +10,7 @@ required_conan_version = ">=2.0"
 
 class UBlkPPConan(ConanFile):
     name = "ublkpp"
-    version = "0.31.0"
+    version = "0.31.1"
 
     homepage = "https://github.com/szmyd/ublkpp"
     description = "A UBlk library for CPP application"

--- a/include/ublkpp/lib/cqe_state.hpp
+++ b/include/ublkpp/lib/cqe_state.hpp
@@ -1,11 +1,11 @@
 #pragma once
 
-#include <coroutine>
 #include <cstdint>
 #include <utility>
 #include <vector>
 
 #include <liburing.h>
+#include <sisl/async/cqe_state.hpp>
 #include <sisl/logging/logging.h>
 #include <ublksrv.h>
 
@@ -27,9 +27,11 @@ namespace ublkpp {
 //   }
 //
 // The queue's CQE loop (run_queue_loop in src/target/ublkpp_tgt.cpp) inspects
-// bit 63 (k_target_bit) of cqe->user_data: if set, the remaining bits are a
-// cqe_state*; the loop writes _result, marks _result_ready, and resumes _waiter.
-// If clear, the CQE is delegated to ublksrv as a command completion.
+// sisl::async::is_managed_user_data(cqe->user_data): if set, the remaining bits
+// are a cqe_state*; the loop calls sisl::async::complete_cqe_state(*state, res)
+// which writes _result, marks _result_ready, and resumes _waiter via the
+// callback installed by await_suspend. If clear, the CQE is delegated to
+// ublksrv as a command completion.
 //
 // Two flavors of cqe_state:
 //   - Per-IO (build_cqe_state_data path): allocated in async_io::_pool, owned
@@ -37,22 +39,24 @@ namespace ublkpp {
 //     with -EIO if the coroutine throws.
 //   - Stand-alone service loops: coroutine-frame-local, _owner = nullptr, and
 //     callers handle their own errors. Encode the user_data manually with
-//     `reinterpret_cast<uint64_t>(state) | k_target_bit`.
+//     sisl::async::encode_managed_user_data(state).
 //
 // Reference implementation: src/driver/fs_disk.cpp.
 // =============================================================================
 
-// Bit 63 of cqe->user_data distinguishes target SQEs (custom-driver async I/O)
-// from ublksrv command SQEs (FETCH/COMMIT). On x86_64/ARM64, canonical userspace
-// addresses use <=48 bits, so bit 63 is always zero in any valid pointer; the OR
-// is safe and reversible with `& ~k_target_bit`.
-//
-// Probe timeout CQEs reuse k_target_bit with a null pointer (user_data == k_target_bit).
-// run_queue_loop checks state == nullptr after stripping the bit to distinguish them from
-// real I/O CQEs.
-constexpr uint64_t k_target_bit = 1ULL << 63;
+struct async_io;
 
-struct cqe_state;
+// Extends sisl::async::cqe_awaitable with _owner for ublksrv error reporting.
+// Inherits: _result, _result_ready, _waiter, _on_complete, _on_complete_ctx
+//           await_ready(), await_suspend(), await_resume()
+// Use sisl::async::complete_cqe_state(*state, res) to deliver a CQE result.
+//
+// _owner is nullable: per-IO cqe_states (build_cqe_state_data path) point at the slot's
+// async_io so errors can be reported via ublksrv_complete_io. Stand-alone cqe_states set
+// _owner = nullptr; callers handle their own errors.
+struct cqe_state : sisl::async::cqe_awaitable {
+    async_io* _owner{nullptr};
+};
 
 // Per-IO state tracking one inflight request, owned by the ublksrv-allocated io_data slot.
 //
@@ -69,29 +73,11 @@ struct async_io {
     cqe_state* next_state();
 };
 
-// Tracks a single inflight sub-operation. Stored in async_io::_pool (pre-reserved std::vector,
-// so push_back is pointer-stable). _result and _result_ready are written by run_queue_loop before resuming
-// _waiter. Implements the awaitable protocol directly: co_await *state suspends until the CQE
-// arrives.
-//
-// _owner is nullable: per-IO cqe_states (build_cqe_state_data path) point at the slot's
-// async_io so an exception on resume can be reported via ublksrv_complete_io. Stand-alone
-// cqe_states set _owner = nullptr; callers handle their own errors.
-struct cqe_state {
-    async_io* _owner{nullptr};
-    int _result{0};
-    bool _result_ready{false};
-    std::coroutine_handle<> _waiter{};
-
-    bool await_ready() const noexcept { return _result_ready; }
-    void await_suspend(std::coroutine_handle<> h) noexcept { _waiter = h; }
-    int await_resume() const noexcept { return _result; }
-};
-
 inline cqe_state* async_io::next_state() {
     RELEASE_ASSERT_LT(_pool.size(), _pool.capacity(),
                       "cqe_state pool exhausted; prepare_result::max_sqes_per_io underestimated")
-    _pool.push_back(cqe_state{._owner = this});
+    _pool.push_back(cqe_state{});
+    _pool.back()._owner = this; // designated-init can't reach inherited members in C++20
     return &_pool.back();
 }
 
@@ -99,7 +85,7 @@ inline cqe_state* async_io::next_state() {
 // {state*, encoded_user_data}. The caller co_awaits *state.
 inline std::pair< cqe_state*, uint64_t > build_cqe_state_data(ublk_io_data const* data) {
     auto* state = reinterpret_cast< async_io* >(data->private_data)->next_state();
-    return {state, reinterpret_cast< uint64_t >(state) | k_target_bit};
+    return {state, sisl::async::encode_managed_user_data(state)};
 }
 
 // Acquires an SQE from the queue's io_uring, submitting any pending SQEs first if the ring

--- a/include/ublkpp/lib/disk_task.hpp
+++ b/include/ublkpp/lib/disk_task.hpp
@@ -43,7 +43,7 @@ struct disk_task {
         final_awaiter final_suspend() noexcept { return {}; }
 
         void return_value(T v) noexcept { _value = v; }
-        [[noreturn]] void unhandled_exception() { throw; }
+        [[noreturn]] void unhandled_exception() noexcept { std::terminate(); }
     };
 
     std::coroutine_handle< promise_type > _coro;

--- a/include/ublkpp/lib/ublk_disk.hpp
+++ b/include/ublkpp/lib/ublk_disk.hpp
@@ -82,7 +82,7 @@ public:
     // Callers (e.g. Raid0Disk) may pass a pointer to a loop-local iovec that is destroyed after
     // start() returns; any access past the first suspension point is a use-after-free.
     virtual disk_task< int > async_iov(ublksrv_queue const* /*q*/, ublk_io_data const* /*data*/, iovec* /*iovecs*/,
-                                       uint32_t /*nr_vecs*/, uint64_t /*addr*/) {
+                                       uint32_t /*nr_vecs*/, uint64_t /*addr*/) noexcept {
         RELEASE_ASSERT(_is_missing, "async_iov() called on a non-missing ublk_disk that did not override");
         co_return -EIO;
     }

--- a/src/driver/fs_disk.cpp
+++ b/src/driver/fs_disk.cpp
@@ -66,7 +66,7 @@ public:
 
     prepare_result prepare(ublksrv_queue const*, int const) override;
     disk_task< int > async_iov(ublksrv_queue const* q, ublk_io_data const* data, iovec* iovecs, uint32_t nr_vecs,
-                               uint64_t addr) override;
+                               uint64_t addr) noexcept override;
     io_result sync_iov(uint8_t op, iovec* iovecs, uint32_t nr_vecs, off_t offset) noexcept override;
 
 private:
@@ -169,7 +169,7 @@ FSDisk::prepare_result FSDisk::prepare(ublksrv_queue const*, int const) {
 }
 
 disk_task< int > FSDisk::async_iov(ublksrv_queue const* q, ublk_io_data const* data, iovec* iovecs, uint32_t nr_vecs,
-                                   uint64_t addr) {
+                                   uint64_t addr) noexcept {
     auto const op = ublksrv_get_op(data->iod);
 
     if (op == UBLK_IO_OP_FLUSH) co_return 0;

--- a/src/driver/tests/test_fs_disk_impl.cpp
+++ b/src/driver/tests/test_fs_disk_impl.cpp
@@ -128,8 +128,8 @@ TEST(FsDiskImpl, CqeStateTargetBitEncoding) {
     ublk_io_data fake{};
     fake.private_data = &io;
     auto const [state, user_data] = ublkpp::build_cqe_state_data(&fake);
-    EXPECT_NE(user_data & (1ULL << 63), 0ULL);
-    auto* decoded = reinterpret_cast< ublkpp::cqe_state* >(user_data & ~(1ULL << 63));
+    EXPECT_TRUE(sisl::async::is_managed_user_data(user_data));
+    auto* decoded = static_cast< ublkpp::cqe_state* >(sisl::async::decode_managed_user_data(user_data));
     EXPECT_EQ(state, decoded);
 }
 

--- a/src/lib/tests/test_cqe_state.cpp
+++ b/src/lib/tests/test_cqe_state.cpp
@@ -71,10 +71,8 @@ TEST(BuildCqeStateData, RegistersStateInPool) {
     ublk_io_data fake{};
     fake.private_data = &io;
     auto const [state, user_data] = ublkpp::build_cqe_state_data(&fake);
-    // bit 63 marks it as a target SQE
-    EXPECT_NE(user_data & (1ULL << 63), 0ULL);
-    // lower bits decode to the registered cqe_state
-    auto* decoded = reinterpret_cast< ublkpp::cqe_state* >(user_data & ~(1ULL << 63));
+    EXPECT_TRUE(sisl::async::is_managed_user_data(user_data));
+    auto* decoded = static_cast< ublkpp::cqe_state* >(sisl::async::decode_managed_user_data(user_data));
     ASSERT_EQ(io._pool.size(), 1u);
     EXPECT_EQ(decoded, &io._pool.front());
     EXPECT_EQ(state, decoded);
@@ -98,7 +96,7 @@ TEST(BuildCqeStateData, ReturnedPointerMatchesDecodedUserData) {
     ublk_io_data fake{};
     fake.private_data = &io;
     auto const [state, user_data] = ublkpp::build_cqe_state_data(&fake);
-    auto* decoded = reinterpret_cast< ublkpp::cqe_state* >(user_data & ~(1ULL << 63));
+    auto* decoded = static_cast< ublkpp::cqe_state* >(sisl::async::decode_managed_user_data(user_data));
     EXPECT_EQ(state, decoded);
 }
 
@@ -109,42 +107,26 @@ TEST(BuildCqeStateData, ReturnedPointerMatchesDecodedUserData) {
 // Coroutine that co_awaits *state and writes the result to *out.
 static FireAndForget await_cqe_and_capture(ublkpp::cqe_state* state, int* out) { *out = co_await *state; }
 
-TEST(cqe_state, AwaitReadyFalseWhenNotReady) {
-    ublkpp::async_io io{};
-    ublkpp::cqe_state state{._owner = &io, ._result_ready = false};
-    EXPECT_FALSE(state.await_ready());
-}
-
-TEST(cqe_state, AwaitReadyTrueWhenReady) {
-    ublkpp::async_io io{};
-    ublkpp::cqe_state state{._owner = &io, ._result_ready = true};
-    EXPECT_TRUE(state.await_ready());
-}
-
-TEST(cqe_state, AwaitResumeReturnsResult) {
-    ublkpp::async_io io{};
-    ublkpp::cqe_state state{._owner = &io, ._result = 42, ._result_ready = true};
-    EXPECT_EQ(state.await_resume(), 42);
-}
-
 TEST(cqe_state, AwaitSuspendInstallsWaiterInState) {
     ublkpp::async_io io{};
-    ublkpp::cqe_state state{._owner = &io, ._result_ready = false};
+    ublkpp::cqe_state state{};
+    state._owner = &io;
     EXPECT_FALSE(state._waiter);
     int captured = -1;
     await_cqe_and_capture(&state, &captured); // suspends; installs handle in state._waiter
     ASSERT_TRUE(state._waiter);
     EXPECT_EQ(captured, -1); // not resumed yet
 
-    state._result = 7;
-    state._result_ready = true;
-    state._waiter.resume(); // triggers await_resume() -> captured = 7
+    sisl::async::complete_cqe_state(state, 7); // writes _result, _result_ready, resumes _waiter
     EXPECT_EQ(captured, 7);
 }
 
 TEST(cqe_state, FastPathSkipsSuspendWhenAlreadyReady) {
     ublkpp::async_io io{};
-    ublkpp::cqe_state state{._owner = &io, ._result = 55, ._result_ready = true};
+    ublkpp::cqe_state state{};
+    state._owner = &io;
+    state._result = 55;
+    state._result_ready = true;
     int captured = -1;
     await_cqe_and_capture(&state, &captured); // await_ready=true -> no suspension
     EXPECT_FALSE(state._waiter);

--- a/src/raid/raid0/raid0.cpp
+++ b/src/raid/raid0/raid0.cpp
@@ -57,7 +57,7 @@ public:
     prepare_result prepare(ublksrv_queue const*, int const iouring_device) override;
 
     disk_task< int > async_iov(ublksrv_queue const* q, ublk_io_data const* data, iovec* iovecs, uint32_t nr_vecs,
-                               uint64_t addr) override;
+                               uint64_t addr) noexcept override;
 
     void probe_tick(ublksrv_queue const* q) noexcept override;
 
@@ -235,7 +235,7 @@ io_result Raid0Disk::sync_iov(uint8_t op, iovec* iovecs, uint32_t nr_vecs, off_t
 }
 
 disk_task< int > Raid0Disk::async_iov(ublksrv_queue const* q, ublk_io_data const* data, iovec* iovecs, uint32_t nr_vecs,
-                                      uint64_t addr) {
+                                      uint64_t addr) noexcept {
     auto const op = ublksrv_get_op(data->iod);
 
     if (op == UBLK_IO_OP_FLUSH) co_return 0;

--- a/src/raid/raid1/raid1.cpp
+++ b/src/raid/raid1/raid1.cpp
@@ -277,8 +277,13 @@ Raid1Disk::~Raid1Disk() {
             RLOGE("Failed to clear clean bit...full sync required upon next assembly [uuid:{}]", _str_uuid)
         }
     }
-    if (!state.is_degraded)
-        write_superblock(*state.backup_dev->disk, _sb.get(), read_route::DEVB != state.route, state.route);
+    if (!state.is_degraded) {
+        if (auto res =
+                write_superblock(*state.backup_dev->disk, _sb.get(), read_route::DEVB != state.route, state.route);
+            !res) {
+            RLOGW("Could not stamp clean superblock on device, [uuid:{}]: {}", _str_uuid, res.error().message())
+        }
+    }
 }
 
 Raid1Disk::prepare_result Raid1Disk::prepare(ublksrv_queue const* q, int const iouring_device_start) {
@@ -344,8 +349,12 @@ bool Raid1Disk::__swap_device(std::string const& outgoing_device_id, std::shared
     }
     // Commit SuperBlock to new device; if this fails it's not fatal per say...could work
     // later when we become clean; so let's be optimistic!
-    write_superblock(*outgoing_dev->disk, _sb.get(), !swapping_device_a,
-                     _read_route_cache.load(std::memory_order_acquire));
+    if (auto sync_res = write_superblock(*outgoing_dev->disk, _sb.get(), !swapping_device_a,
+                                         _read_route_cache.load(std::memory_order_acquire));
+        !sync_res) {
+        RLOGW("Could not stamp superblock on new device, could revert [uuid:{}]: {}", _str_uuid,
+              sync_res.error().message())
+    }
 
     // Dirty entire bitmap if this is a new device
     if (outgoing_dev->new_device) _dirty_bitmap->dirty_region(0, capacity());
@@ -565,9 +574,9 @@ std::pair< std::shared_ptr< ublk_disk >, std::shared_ptr< ublk_disk > > Raid1Dis
     }
 }
 
-io_result Raid1Disk::__become_clean() {
+void Raid1Disk::__become_clean() {
     auto const state = __capture_route_state();
-    if (read_route::EITHER == state.route) return 0;
+    if (read_route::EITHER == state.route) return;
 
     RLOGI("Device becoming clean [{}] [uuid:{}] ", *state.backup_dev->disk, _str_uuid)
 
@@ -589,7 +598,6 @@ io_result Raid1Disk::__become_clean() {
     // Avoid checking DirtyBitmap going forward on reads/writes
     auto old_route = state.route;
     _read_route_cache.compare_exchange_strong(old_route, read_route::EITHER);
-    return 0;
 }
 
 // See the comment above __swap_device for the CAS-based mutual exclusion between this function

--- a/src/raid/raid1/raid1.cpp
+++ b/src/raid/raid1/raid1.cpp
@@ -706,7 +706,7 @@ Raid1Disk::WriteBackupMode Raid1Disk::__compute_backup_mode(RouteState const& st
 }
 
 disk_task< int > Raid1Disk::async_iov(ublksrv_queue const* q, ublk_io_data const* data, iovec* iovecs, uint32_t nr_vecs,
-                                      uint64_t addr) {
+                                      uint64_t addr) noexcept {
     auto const op = ublksrv_get_op(data->iod);
     auto const len = static_cast< uint32_t >(iovec_len(iovecs, iovecs + nr_vecs));
 

--- a/src/raid/raid1/raid1_impl.hpp
+++ b/src/raid/raid1/raid1_impl.hpp
@@ -134,7 +134,7 @@ public:
     void probe_tick(ublksrv_queue const* q) noexcept override;
 
     disk_task< int > async_iov(ublksrv_queue const* q, ublk_io_data const* data, iovec* iovecs, uint32_t nr_vecs,
-                               uint64_t addr) override;
+                               uint64_t addr) noexcept override;
 
     io_result sync_iov(uint8_t op, iovec* iovecs, uint32_t nr_vecs, off_t offset) noexcept override;
     /// ============================

--- a/src/raid/raid1/raid1_impl.hpp
+++ b/src/raid/raid1/raid1_impl.hpp
@@ -63,7 +63,7 @@ class Raid1Disk : public ublk_disk {
                                           bool is_discard) const noexcept;
 
     // Internal routines
-    io_result __become_clean();
+    void __become_clean();
     io_result __become_degraded(bool failed_is_active, RouteState const* state, bool spawn_resync = true);
     disk_task< int > __failover_read_async(ublksrv_queue const* q, ublk_io_data const* data, iovec* iovecs,
                                            uint32_t nr_vecs, uint64_t addr, uint32_t len);

--- a/src/target/tests/test_ublkpp_tgt.cpp
+++ b/src/target/tests/test_ublkpp_tgt.cpp
@@ -27,9 +27,8 @@ TEST(cqe_state, BuildCqeStateDataEncodesTargetBit) {
     ublk_io_data fake{};
     fake.private_data = &io;
     auto const [state, user_data] = ublkpp::build_cqe_state_data(&fake);
-    // bit 63 is the target-io marker checked by run_queue_loop
-    EXPECT_NE(user_data & (1ULL << 63), 0ULL);
-    auto* decoded = reinterpret_cast< ublkpp::cqe_state* >(user_data & ~(1ULL << 63));
+    EXPECT_TRUE(sisl::async::is_managed_user_data(user_data));
+    auto* decoded = static_cast< ublkpp::cqe_state* >(sisl::async::decode_managed_user_data(user_data));
     EXPECT_EQ(state, decoded);
     EXPECT_EQ(state->_owner, &io);
 }

--- a/src/target/ublkpp_tgt.cpp
+++ b/src/target/ublkpp_tgt.cpp
@@ -79,7 +79,8 @@ static void submit_probe_timeout(ublksrv_queue const* q) {
         __kernel_timespec ts{.tv_sec = k_io_idle_secs, .tv_nsec = 0};
         // clang-format on
         io_uring_prep_timeout(sqe, &ts, 0, 0);
-        sqe->user_data = k_target_bit; // null-pointer sentinel: probe CQE, no cqe_state
+        io_uring_sqe_set_data64(sqe,
+                                sisl::async::encode_managed_user_data(nullptr)); // sentinel: probe CQE, no cqe_state
         io_uring_submit(q->ring_ptr);
     }
 }
@@ -107,8 +108,8 @@ static exec::task< void > run_queue_loop(ublksrv_queue const* q, ublkpp_queue_st
         int count{0};
         int probe_count{0}; // probe timeout CQEs must not count as work for ublksrv_queue_update_idle
         io_uring_for_each_cqe(ring, head, cqe) {
-            if (cqe->user_data & k_target_bit) {
-                auto* state = reinterpret_cast< cqe_state* >(cqe->user_data & ~k_target_bit);
+            if (sisl::async::is_managed_user_data(cqe->user_data)) {
+                auto* state = static_cast< cqe_state* >(sisl::async::decode_managed_user_data(cqe->user_data));
                 if (!state) {
                     // probe timeout CQE — only ETIME triggers a probe tick; other results ignored.
                     // Excluded from io_count: counting it as work triggers idle_exit, setting
@@ -119,15 +120,8 @@ static exec::task< void > run_queue_loop(ublksrv_queue const* q, ublkpp_queue_st
                         if (qs->is_idle) submit_probe_timeout(q);
                     }
                 } else {
-                    // target io_uring CQE — user_data is a raw cqe_state* | k_target_bit
-                    state->_result = cqe->res;
-                    state->_result_ready = true;
-                    try {
-                        if (auto h = std::exchange(state->_waiter, {})) h.resume(); // per-state resume (disk_task path)
-                    } catch (std::exception const& e) {
-                        TLOGE("I/O threw exception: [{}]", e.what())
-                        if (state->_owner) ublksrv_complete_io(q, state->_owner->_tag, -EIO);
-                    }
+                    // target io_uring CQE — resume the coroutine waiting on this state
+                    sisl::async::complete_cqe_state(*state, cqe->res);
                 }
             } else {
                 // ublk command CQE (FETCH/COMMIT) -- delegate to libublksrv

--- a/src/target/ublkpp_tgt.cpp
+++ b/src/target/ublkpp_tgt.cpp
@@ -4,6 +4,7 @@
 #include <exec/inline_scheduler.hpp>
 #include <exec/task.hpp>
 #include <stdexec/execution.hpp>
+#include <latch>
 #include <thread>
 
 #include <boost/uuid/uuid_io.hpp>
@@ -137,7 +138,7 @@ static exec::task< void > run_queue_loop(ublksrv_queue const* q, ublkpp_queue_st
     co_await qs->scope.on_empty();
 }
 
-static void* ublksrv_queue_handler(std::shared_ptr< ublkpp_tgt_impl > target, int q_id, sem_t* queue_sem) {
+static void* ublksrv_queue_handler(std::shared_ptr< ublkpp_tgt_impl > target, int q_id, std::latch* queue_sem) {
     auto qs = std::make_unique< ublkpp_queue_state >(target.get());
 
     // Initialize UBlkSrv IOUring queue and bind queue state pointer
@@ -147,7 +148,7 @@ static void* ublksrv_queue_handler(std::shared_ptr< ublkpp_tgt_impl > target, in
                                       IORING_SETUP_COOP_TASKRUN | IORING_SETUP_SINGLE_ISSUER);
 
     // Wake up ::start() thread
-    sem_post(queue_sem);
+    queue_sem->count_down();
     target.reset();
 
     // If queue initialization failed, exit
@@ -223,11 +224,10 @@ static std::expected< std::filesystem::path, std::error_condition > start(std::s
     }
 
     // Setup Queues
-    sem_t queue_sem;
-    sem_init(&queue_sem, 0, 0);
+    auto queue_wait = std::latch(dinfo->nr_hw_queues);
     for (auto i = 0; i < dinfo->nr_hw_queues; ++i) {
         tgt->queue_handlers.push_back(sisl::named_thread(fmt::format("q_{}_{}", tgt->dev_data->dev_id, i),
-                                                         ublksrv_queue_handler, tgt, i, &queue_sem));
+                                                         ublksrv_queue_handler, tgt, i, &queue_wait));
     }
     auto const recovery = tgt->device_recovering;
     auto const dev_name = fmt::format("{}", *tgt->device);
@@ -237,10 +237,7 @@ static std::expected< std::filesystem::path, std::error_condition > start(std::s
     auto dev_ptr = tgt->device.get();
     auto const dev_id = tgt->dev_data->dev_id;
     tgt.reset();
-
-    // Wait for Queues to start
-    for (auto i = 0; i < dinfo->nr_hw_queues; ++i)
-        sem_wait(&queue_sem);
+    queue_wait.wait();
 
     // Start processing I/Os
     if (!recovery) {

--- a/src/tests/mock_ublksrv/mock_ublksrv.cpp
+++ b/src/tests/mock_ublksrv/mock_ublksrv.cpp
@@ -106,8 +106,8 @@ io_result MockUblksrv::submit_io(int tag, uint8_t op, uint64_t start_sector, uin
 }
 
 void MockUblksrv::process_cqe(io_uring_cqe* cqe, std::vector< Completion >& out) {
-    if (!(cqe->user_data & k_target_bit)) return (void)io_uring_cqe_seen(&_ring, cqe);
-    auto* state = reinterpret_cast< cqe_state* >(cqe->user_data & ~k_target_bit);
+    if (!sisl::async::is_managed_user_data(cqe->user_data)) return (void)io_uring_cqe_seen(&_ring, cqe);
+    auto* state = static_cast< cqe_state* >(sisl::async::decode_managed_user_data(cqe->user_data));
     if (!state || !state->_owner) return (void)io_uring_cqe_seen(&_ring, cqe);
     int const tag = state->_owner->_tag;
     int const res = cqe->res;
@@ -115,10 +115,7 @@ void MockUblksrv::process_cqe(io_uring_cqe* cqe, std::vector< Completion >& out)
     // Consume the CQE immediately so peek sees the next one
     io_uring_cqe_seen(&_ring, cqe);
 
-    state->_result = res;
-    state->_result_ready = true;
-
-    if (auto h = std::exchange(state->_waiter, {})) h.resume();
+    sisl::async::complete_cqe_state(*state, res);
     auto& opt = _async_tasks[tag];
     if (opt && opt->done()) out.push_back({tag, opt->result()});
 }
@@ -140,9 +137,7 @@ std::vector< MockUblksrv::Completion > MockUblksrv::inject_cqe(int tag, int resu
         if (opt && opt->done()) out.push_back({tag, opt->result()});
         return out;
     }
-    target->_result = result;
-    target->_result_ready = true;
-    if (auto h = std::exchange(target->_waiter, {})) h.resume();
+    sisl::async::complete_cqe_state(*target, result);
     if (opt && opt->done()) out.push_back({tag, opt->result()});
     return out;
 }

--- a/src/tests/test_disk.hpp
+++ b/src/tests/test_disk.hpp
@@ -49,7 +49,7 @@ public:
     MOCK_METHOD(io_result, sync_iov, (uint8_t, iovec*, uint32_t, off_t offset), (override, noexcept));
 
     disk_task< int > async_iov(ublksrv_queue const* q, ublk_io_data const* data, iovec* iovecs, uint32_t nr_vecs,
-                               uint64_t addr) override {
+                               uint64_t addr) noexcept override {
         auto* io = reinterpret_cast< async_io* >(data->private_data);
         auto res = submit_iov(q, data, iovecs, nr_vecs, addr);
         if (!res) co_return -static_cast< int >(res.error().value());


### PR DESCRIPTION
Replace ublkpp's standalone cqe_state awaitable with a thin derivative of sisl::async::cqe_awaitable. The new cqe_state adds only _owner (for ublksrv error-path tagging); all awaitable fields and protocol (_result, _result_ready, _waiter, await_ready/suspend/resume) are inherited.

Dispatch loops now call sisl::async::complete_cqe_state(*state, res) instead of manually writing fields and resuming _waiter, removing the try/catch that was guarding h.resume() in run_queue_loop and mock_ublksrv. The managed-bit helpers (is_managed_user_data, decode_managed_user_data, encode_managed_user_data) replace the raw k_target_bit bit-ops at all decode sites; k_target_bit is kept as a backward-compat alias.

Also: mark async_iov noexcept throughout the stack (base class + all overrides
+ test mock) and change disk_task::promise_type::unhandled_exception to call std::terminate instead of rethrowing. Any uncaught exception in a coroutine body would propagate through the noexcept _on_complete callback anyway; making the contract explicit here and letting ublksrv USER_RECOVERY restart the process is safer than silently returning -EIO for one tag.