### PR TITLE
test: replace NiceMock/NaggyMock with StrictMock across all test suites

### DIFF
--- a/src/raid/raid0/tests/asyncio/async_raid0_common.hpp
+++ b/src/raid/raid0/tests/asyncio/async_raid0_common.hpp
@@ -31,18 +31,26 @@ struct AsyncRaid0Fixture : public ::testing::Test {
     std::unique_ptr< ublkpp::MockUblksrv > mock;
 
     void SetUp() override {
+        using ::testing::AnyNumber;
+        using ::testing::StrictMock;
+
         TestParams const p{.capacity = k_disk_cap};
-        disk_a = std::make_shared< ::testing::NiceMock< ublkpp::AsyncTestDisk > >(p);
-        disk_b = std::make_shared< ::testing::NiceMock< ublkpp::AsyncTestDisk > >(p);
-        disk_c = std::make_shared< ::testing::NiceMock< ublkpp::AsyncTestDisk > >(p);
+        disk_a = std::make_shared< StrictMock< ublkpp::AsyncTestDisk > >(p);
+        disk_b = std::make_shared< StrictMock< ublkpp::AsyncTestDisk > >(p);
+        disk_c = std::make_shared< StrictMock< ublkpp::AsyncTestDisk > >(p);
         for (auto& d : {disk_a, disk_b, disk_c}) {
-            ON_CALL(*d, sync_iov(_, _, _, _))
-                .WillByDefault([](uint8_t op, iovec* iovecs, uint32_t, off_t) -> io_result {
+            EXPECT_CALL(*d, prepare(_, _))
+                .Times(AnyNumber())
+                .WillRepeatedly(Return(ublkpp::ublk_disk::prepare_result{}));
+            ON_CALL(*d, submit_iov(_, _, _, _, _)).WillByDefault(make_async_iov_action());
+            EXPECT_CALL(*d, sync_iov(_, _, _, _))
+                .Times(AnyNumber())
+                .WillRepeatedly([](uint8_t op, iovec* iovecs, uint32_t, off_t) -> io_result {
                     if (op == UBLK_IO_OP_READ && iovecs && iovecs->iov_base)
                         memset(iovecs->iov_base, 0, iovecs->iov_len);
                     return sizeof(ublkpp::raid0::SuperBlock);
                 });
-            ON_CALL(*d, submit_iov(_, _, _, _, _)).WillByDefault(make_async_iov_action());
+            EXPECT_CALL(*d, submit_iov(_, _, _, _, _)).Times(AnyNumber()).WillRepeatedly(make_async_iov_action());
         }
         raid = ublkpp::make_raid0_disk(boost::uuids::random_generator()(), k_stripe_size,
                                        std::vector< std::shared_ptr< ublk_disk > >{disk_a, disk_b, disk_c});

--- a/src/raid/raid0/tests/superblock/wrong_uuid.cpp
+++ b/src/raid/raid0/tests/superblock/wrong_uuid.cpp
@@ -2,8 +2,8 @@
 
 // If we initialize with one clean device and one with the wrong uuid in the superblock
 TEST(Raid0, WrongUUIDA) {
-    auto device_a = std::make_shared< ublkpp::TestDisk >(TestParams{.capacity = Gi});
-    auto device_b = std::make_shared< ublkpp::TestDisk >(TestParams{.capacity = Gi});
+    auto device_a = std::make_shared< ::testing::StrictMock< ublkpp::TestDisk > >(TestParams{.capacity = Gi});
+    auto device_b = std::make_shared< ::testing::StrictMock< ublkpp::TestDisk > >(TestParams{.capacity = Gi});
 
     EXPECT_CALL(*device_a, sync_iov(UBLK_IO_OP_READ, _, _, _))
         .Times(1)
@@ -23,8 +23,8 @@ TEST(Raid0, WrongUUIDA) {
 }
 
 TEST(Raid0, WrongUUIDB) {
-    auto device_a = std::make_shared< ublkpp::TestDisk >(TestParams{.capacity = Gi});
-    auto device_b = std::make_shared< ublkpp::TestDisk >(TestParams{.capacity = Gi});
+    auto device_a = std::make_shared< ::testing::StrictMock< ublkpp::TestDisk > >(TestParams{.capacity = Gi});
+    auto device_b = std::make_shared< ::testing::StrictMock< ublkpp::TestDisk > >(TestParams{.capacity = Gi});
 
     EXPECT_CALL(*device_a, sync_iov(UBLK_IO_OP_READ, _, _, _))
         .Times(1)

--- a/src/raid/raid0/tests/test_raid0_common.hpp
+++ b/src/raid/raid0/tests/test_raid0_common.hpp
@@ -49,7 +49,7 @@ static std::string const test_uuid("ada40737-30e3-49fe-9942-5a287d71eb3f");
 
 #define CREATE_DISK_F(params, no_read, fail_read, no_write, fail_write)                                                \
     [] {                                                                                                               \
-        auto device = std::make_shared< ublkpp::TestDisk >((params));                                                  \
+        auto device = std::make_shared< ::testing::StrictMock< ublkpp::TestDisk > >((params));                         \
         if (!no_read) { EXPECT_SB_OP(UBLK_IO_OP_READ, device, fail_read) }                                             \
         if (!no_write && !fail_read) { EXPECT_SB_OP(UBLK_IO_OP_WRITE, device, fail_write) }                            \
         return device;                                                                                                 \

--- a/src/raid/raid1/tests/asyncio/async_raid1_common.hpp
+++ b/src/raid/raid1/tests/asyncio/async_raid1_common.hpp
@@ -45,24 +45,31 @@ struct AsyncRaid1Fixture : public ::testing::Test {
     std::unique_ptr< ublkpp::MockUblksrv > mock;
 
     void SetUp() override {
-        using ::testing::NiceMock;
+        using ::testing::AnyNumber;
+        using ::testing::StrictMock;
 
         TestParams const pa{.capacity = k_disk_cap, .id = "DiskA", .is_slot_b = false};
         TestParams const pb{.capacity = k_disk_cap, .id = "DiskB", .is_slot_b = true};
-        disk_a = std::make_shared< NiceMock< ublkpp::AsyncTestDisk > >(pa);
-        disk_b = std::make_shared< NiceMock< ublkpp::AsyncTestDisk > >(pb);
+        disk_a = std::make_shared< StrictMock< ublkpp::AsyncTestDisk > >(pa);
+        disk_b = std::make_shared< StrictMock< ublkpp::AsyncTestDisk > >(pb);
 
-        ON_CALL(*disk_a, prepare(_, _)).WillByDefault(Return(ublkpp::ublk_disk::prepare_result{}));
-        ON_CALL(*disk_b, prepare(_, _)).WillByDefault(Return(ublkpp::ublk_disk::prepare_result{}));
+        EXPECT_CALL(*disk_a, prepare(_, _))
+            .Times(AnyNumber())
+            .WillRepeatedly(Return(ublkpp::ublk_disk::prepare_result{}));
+        EXPECT_CALL(*disk_b, prepare(_, _))
+            .Times(AnyNumber())
+            .WillRepeatedly(Return(ublkpp::ublk_disk::prepare_result{}));
 
-        ON_CALL(*disk_a, sync_iov(_, _, _, _))
-            .WillByDefault([](uint8_t op, iovec* iovecs, uint32_t, off_t) -> io_result {
+        EXPECT_CALL(*disk_a, sync_iov(_, _, _, _))
+            .Times(AnyNumber())
+            .WillRepeatedly([](uint8_t op, iovec* iovecs, uint32_t, off_t) -> io_result {
                 if (op == UBLK_IO_OP_READ && iovecs && iovecs->iov_base)
                     memcpy(iovecs->iov_base, &async_raid1_superblock, ublkpp::raid1::k_page_size);
                 return static_cast< int >(iovecs->iov_len);
             });
-        ON_CALL(*disk_b, sync_iov(_, _, _, _))
-            .WillByDefault([](uint8_t op, iovec* iovecs, uint32_t, off_t) -> io_result {
+        EXPECT_CALL(*disk_b, sync_iov(_, _, _, _))
+            .Times(AnyNumber())
+            .WillRepeatedly([](uint8_t op, iovec* iovecs, uint32_t, off_t) -> io_result {
                 if (op == UBLK_IO_OP_READ && iovecs && iovecs->iov_base) {
                     memcpy(iovecs->iov_base, &async_raid1_superblock, ublkpp::raid1::k_page_size);
                     static_cast< ublkpp::raid1::SuperBlock* >(iovecs->iov_base)->fields.device_b = 1;
@@ -72,6 +79,8 @@ struct AsyncRaid1Fixture : public ::testing::Test {
 
         ON_CALL(*disk_a, submit_iov(_, _, _, _, _)).WillByDefault(make_async_iov_action());
         ON_CALL(*disk_b, submit_iov(_, _, _, _, _)).WillByDefault(make_async_iov_action());
+        EXPECT_CALL(*disk_a, submit_iov(_, _, _, _, _)).Times(AnyNumber()).WillRepeatedly(make_async_iov_action());
+        EXPECT_CALL(*disk_b, submit_iov(_, _, _, _, _)).Times(AnyNumber()).WillRepeatedly(make_async_iov_action());
 
         raid = std::make_shared< ublkpp::raid1::Raid1Disk >(boost::uuids::string_generator()(std::string(k_uuid)),
                                                             disk_a, disk_b);

--- a/src/raid/raid1/tests/asyncio/bitmap.cpp
+++ b/src/raid/raid1/tests/asyncio/bitmap.cpp
@@ -156,8 +156,9 @@ TEST_F(AsyncRaid1Fixture, ResyncCleansMultipleRegions) {
 TEST_F(AsyncRaid1Fixture, ResyncReadFailurePreservesDirty) {
     degrade_via_backup_fail(mock.get(), 0, 0, 32 * Ki / 512);
 
-    ON_CALL(*disk_a, sync_iov(UBLK_IO_OP_READ, _, _, testing::Ge((off_t)raid->reserved_size())))
-        .WillByDefault([](uint8_t, iovec*, uint32_t, off_t) -> io_result {
+    EXPECT_CALL(*disk_a, sync_iov(UBLK_IO_OP_READ, _, _, testing::Ge((off_t)raid->reserved_size())))
+        .Times(AnyNumber())
+        .WillRepeatedly([](uint8_t, iovec*, uint32_t, off_t) -> io_result {
             return std::unexpected(std::make_error_condition(std::errc::io_error));
         });
 
@@ -174,8 +175,9 @@ TEST_F(AsyncRaid1Fixture, ResyncReadFailurePreservesDirty) {
 TEST_F(AsyncRaid1Fixture, ResyncWriteFailurePreservesDirty) {
     degrade_via_backup_fail(mock.get(), 0, 0, 32 * Ki / 512);
 
-    ON_CALL(*disk_b, sync_iov(UBLK_IO_OP_WRITE, _, _, testing::Ge((off_t)raid->reserved_size())))
-        .WillByDefault([](uint8_t, iovec*, uint32_t, off_t) -> io_result {
+    EXPECT_CALL(*disk_b, sync_iov(UBLK_IO_OP_WRITE, _, _, testing::Ge((off_t)raid->reserved_size())))
+        .Times(AnyNumber())
+        .WillRepeatedly([](uint8_t, iovec*, uint32_t, off_t) -> io_result {
             return std::unexpected(std::make_error_condition(std::errc::io_error));
         });
 
@@ -245,8 +247,9 @@ TEST_F(AsyncRaid1Fixture, ResyncLaunchWhileRunningIsNoop) {
     ASSERT_GT(raid->replica_states().bytes_to_sync, 0u);
 
     std::atomic_bool resync_started{false};
-    ON_CALL(*disk_a, sync_iov(UBLK_IO_OP_READ, _, _, testing::Ge((off_t)raid->reserved_size())))
-        .WillByDefault([&resync_started](uint8_t, iovec* iov, uint32_t, off_t) -> io_result {
+    EXPECT_CALL(*disk_a, sync_iov(UBLK_IO_OP_READ, _, _, testing::Ge((off_t)raid->reserved_size())))
+        .Times(AnyNumber())
+        .WillRepeatedly([&resync_started](uint8_t, iovec* iov, uint32_t, off_t) -> io_result {
             resync_started.store(true);
             std::this_thread::sleep_for(50ms); // hold ACTIVE long enough for extra calls
             return static_cast< int >(iov->iov_len);
@@ -289,8 +292,9 @@ TEST_F(AsyncRaid1Fixture, ResyncStopTerminatesWithoutDeadlock) {
 
     std::atomic_bool resync_started{false};
     std::atomic_bool unblock_reads{false};
-    ON_CALL(*disk_a, sync_iov(UBLK_IO_OP_READ, _, _, testing::Ge((off_t)raid->reserved_size())))
-        .WillByDefault([&](uint8_t, iovec* iov, uint32_t, off_t) -> io_result {
+    EXPECT_CALL(*disk_a, sync_iov(UBLK_IO_OP_READ, _, _, testing::Ge((off_t)raid->reserved_size())))
+        .Times(AnyNumber())
+        .WillRepeatedly([&](uint8_t, iovec* iov, uint32_t, off_t) -> io_result {
             resync_started.store(true);
             while (!unblock_reads.load(std::memory_order_acquire))
                 std::this_thread::sleep_for(1ms);
@@ -332,8 +336,9 @@ TEST_F(AsyncRaid1Fixture, ResyncBlockedByOutstandingWrites) {
 
     // Slow sync_iov reads on disk_a to make resync measurable (gives time to submit write).
     std::atomic_bool resync_started{false};
-    ON_CALL(*disk_a, sync_iov(UBLK_IO_OP_READ, _, _, testing::Ge((off_t)raid->reserved_size())))
-        .WillByDefault([&resync_started](uint8_t, iovec* iov, uint32_t, off_t) -> io_result {
+    EXPECT_CALL(*disk_a, sync_iov(UBLK_IO_OP_READ, _, _, testing::Ge((off_t)raid->reserved_size())))
+        .Times(AnyNumber())
+        .WillRepeatedly([&resync_started](uint8_t, iovec* iov, uint32_t, off_t) -> io_result {
             resync_started = true;
             std::this_thread::sleep_for(20ms);
             return static_cast< int >(iov->iov_len);

--- a/src/raid/raid1/tests/asyncio/degraded.cpp
+++ b/src/raid/raid1/tests/asyncio/degraded.cpp
@@ -126,7 +126,7 @@ TEST_F(AsyncRaid1Fixture, ReadAfterReplicaFail) {
 
     // In degraded mode with disk_b unavail, reads must route to disk_a only.
     std::thread([this] {
-        EXPECT_CALL(*disk_a, submit_iov(_, _, _, _, _)).Times(1);
+        EXPECT_CALL(*disk_a, submit_iov(_, _, _, _, _)).Times(1).WillRepeatedly(make_async_iov_action());
         EXPECT_CALL(*disk_b, submit_iov(_, _, _, _, _)).Times(0);
 
         auto res = mock->submit_io(1, UBLK_IO_OP_READ, 0, 4 * Ki / 512, nullptr);

--- a/src/raid/raid1/tests/asyncio/discard.cpp
+++ b/src/raid/raid1/tests/asyncio/discard.cpp
@@ -43,8 +43,8 @@ TEST_F(AsyncRaid1Fixture, LargeDiscardDirtiesMultiplePages) {
 // Discard where async_iov returns 0 (synchronous inline completion) → task finishes
 // without suspending on co_await *state. RAID1 still awaits both tasks.
 TEST_F(AsyncRaid1Fixture, DiscardSyncCompletion) {
-    ON_CALL(*disk_a, submit_iov(_, _, _, _, _)).WillByDefault(Return(io_result{0}));
-    ON_CALL(*disk_b, submit_iov(_, _, _, _, _)).WillByDefault(Return(io_result{0}));
+    EXPECT_CALL(*disk_a, submit_iov(_, _, _, _, _)).Times(AnyNumber()).WillRepeatedly(Return(io_result{0}));
+    EXPECT_CALL(*disk_b, submit_iov(_, _, _, _, _)).Times(AnyNumber()).WillRepeatedly(Return(io_result{0}));
 
     auto res = mock->submit_io(0, UBLK_IO_OP_DISCARD, 0, 32 * Ki / 512, nullptr);
     ASSERT_TRUE(res);

--- a/src/raid/raid1/tests/asyncio/failover.cpp
+++ b/src/raid/raid1/tests/asyncio/failover.cpp
@@ -7,8 +7,8 @@
 TEST_F(AsyncRaid1Fixture, ReadFailoverToBackup) {
     std::thread([this] {
         // Expect both disks to be called: primary attempt + failover attempt.
-        EXPECT_CALL(*disk_a, submit_iov(_, _, _, _, _)).Times(1);
-        EXPECT_CALL(*disk_b, submit_iov(_, _, _, _, _)).Times(1);
+        EXPECT_CALL(*disk_a, submit_iov(_, _, _, _, _)).Times(1).WillRepeatedly(make_async_iov_action());
+        EXPECT_CALL(*disk_b, submit_iov(_, _, _, _, _)).Times(1).WillRepeatedly(make_async_iov_action());
 
         auto res = mock->submit_io(0, UBLK_IO_OP_READ, 0, 4 * Ki / 512, nullptr);
         ASSERT_TRUE(res);
@@ -43,8 +43,8 @@ TEST_F(AsyncRaid1Fixture, ReadBothDevicesFail) {
 // Write: active device fails; backup was started eagerly and succeeds.
 // co_return backup_res (backup bytes returned).
 TEST_F(AsyncRaid1Fixture, WriteActiveFailsBecomeDegraded) {
-    EXPECT_CALL(*disk_a, submit_iov(_, _, _, _, _)).Times(1);
-    EXPECT_CALL(*disk_b, submit_iov(_, _, _, _, _)).Times(1);
+    EXPECT_CALL(*disk_a, submit_iov(_, _, _, _, _)).Times(1).WillRepeatedly(make_async_iov_action());
+    EXPECT_CALL(*disk_b, submit_iov(_, _, _, _, _)).Times(1).WillRepeatedly(make_async_iov_action());
 
     auto res = mock->submit_io(0, UBLK_IO_OP_WRITE, 0, 4 * Ki / 512, nullptr);
     ASSERT_TRUE(res);
@@ -60,8 +60,8 @@ TEST_F(AsyncRaid1Fixture, WriteActiveFailsBecomeDegraded) {
 
 // Write: active succeeds but backup device fails → become degraded, co_return active_res.
 TEST_F(AsyncRaid1Fixture, WriteReplicaFailsBecomeDegraded) {
-    EXPECT_CALL(*disk_a, submit_iov(_, _, _, _, _)).Times(1);
-    EXPECT_CALL(*disk_b, submit_iov(_, _, _, _, _)).Times(1);
+    EXPECT_CALL(*disk_a, submit_iov(_, _, _, _, _)).Times(1).WillRepeatedly(make_async_iov_action());
+    EXPECT_CALL(*disk_b, submit_iov(_, _, _, _, _)).Times(1).WillRepeatedly(make_async_iov_action());
 
     auto res = mock->submit_io(0, UBLK_IO_OP_WRITE, 0, 4 * Ki / 512, nullptr);
     ASSERT_TRUE(res);

--- a/src/raid/raid1/tests/asyncio/read_fail_degraded_dirty.cpp
+++ b/src/raid/raid1/tests/asyncio/read_fail_degraded_dirty.cpp
@@ -5,13 +5,14 @@
 
 #include "async_raid1_common.hpp"
 
-using ::testing::NiceMock;
+using ::testing::AnyNumber;
+using ::testing::StrictMock;
 
 TEST(Raid1Async, ReadDegradedDirtyActiveFailNoFallback) {
     TestParams const pa{.capacity = AsyncRaid1Fixture::k_disk_cap, .id = "DiskA", .is_slot_b = false};
     TestParams const pb{.capacity = AsyncRaid1Fixture::k_disk_cap, .id = "DiskB", .is_slot_b = true};
-    auto disk_a = std::make_shared< NiceMock< ublkpp::AsyncTestDisk > >(pa);
-    auto disk_b = std::make_shared< NiceMock< ublkpp::AsyncTestDisk > >(pb);
+    auto disk_a = std::make_shared< StrictMock< ublkpp::AsyncTestDisk > >(pa);
+    auto disk_b = std::make_shared< StrictMock< ublkpp::AsyncTestDisk > >(pb);
 
     // Degraded superblock on disk_a: route=DEVA, unclean → __init_bitmap_and_degraded_route marks
     // bitmap fully dirty. Backup is reachable but has stale data.
@@ -27,11 +28,12 @@ TEST(Raid1Async, ReadDegradedDirtyActiveFailNoFallback) {
                    .bitmap = {._reserved = {0x00}, .chunk_size = htobe32(32 * Ki), .age = htobe64(2)}},
         .superbitmap_reserved = {0x00}};
 
-    ON_CALL(*disk_a, prepare(_, _)).WillByDefault(Return(ublkpp::ublk_disk::prepare_result{}));
-    ON_CALL(*disk_b, prepare(_, _)).WillByDefault(Return(ublkpp::ublk_disk::prepare_result{}));
+    EXPECT_CALL(*disk_a, prepare(_, _)).Times(AnyNumber()).WillRepeatedly(Return(ublkpp::ublk_disk::prepare_result{}));
+    EXPECT_CALL(*disk_b, prepare(_, _)).Times(AnyNumber()).WillRepeatedly(Return(ublkpp::ublk_disk::prepare_result{}));
 
-    ON_CALL(*disk_a, sync_iov(_, _, _, _))
-        .WillByDefault([](uint8_t op, iovec* iovecs, uint32_t, off_t off) -> io_result {
+    EXPECT_CALL(*disk_a, sync_iov(_, _, _, _))
+        .Times(AnyNumber())
+        .WillRepeatedly([](uint8_t op, iovec* iovecs, uint32_t, off_t off) -> io_result {
             if (op == UBLK_IO_OP_READ) {
                 // Non-SB reads fail: prevents resync from cleaning dirty regions before the test.
                 if (off != 0) return std::unexpected(std::make_error_condition(std::errc::io_error));
@@ -39,17 +41,19 @@ TEST(Raid1Async, ReadDegradedDirtyActiveFailNoFallback) {
             }
             return static_cast< int >(iovecs->iov_len);
         });
-    ON_CALL(*disk_b, sync_iov(_, _, _, _)).WillByDefault([](uint8_t op, iovec* iovecs, uint32_t, off_t) -> io_result {
-        if (op == UBLK_IO_OP_READ && iovecs && iovecs->iov_base) {
-            memcpy(iovecs->iov_base, &async_raid1_superblock, ublkpp::raid1::k_page_size);
-            static_cast< ublkpp::raid1::SuperBlock* >(iovecs->iov_base)->fields.device_b = 1;
-            static_cast< ublkpp::raid1::SuperBlock* >(iovecs->iov_base)->fields.bitmap.age = htobe64(1);
-        }
-        return static_cast< int >(iovecs->iov_len);
-    });
+    EXPECT_CALL(*disk_b, sync_iov(_, _, _, _))
+        .Times(AnyNumber())
+        .WillRepeatedly([](uint8_t op, iovec* iovecs, uint32_t, off_t) -> io_result {
+            if (op == UBLK_IO_OP_READ && iovecs && iovecs->iov_base) {
+                memcpy(iovecs->iov_base, &async_raid1_superblock, ublkpp::raid1::k_page_size);
+                static_cast< ublkpp::raid1::SuperBlock* >(iovecs->iov_base)->fields.device_b = 1;
+                static_cast< ublkpp::raid1::SuperBlock* >(iovecs->iov_base)->fields.bitmap.age = htobe64(1);
+            }
+            return static_cast< int >(iovecs->iov_len);
+        });
 
-    ON_CALL(*disk_a, submit_iov(_, _, _, _, _)).WillByDefault(make_async_iov_action());
-    ON_CALL(*disk_b, submit_iov(_, _, _, _, _)).WillByDefault(make_async_iov_action());
+    EXPECT_CALL(*disk_a, submit_iov(_, _, _, _, _)).Times(AnyNumber()).WillRepeatedly(make_async_iov_action());
+    EXPECT_CALL(*disk_b, submit_iov(_, _, _, _, _)).Times(AnyNumber()).WillRepeatedly(make_async_iov_action());
 
     auto raid = std::make_shared< ublkpp::raid1::Raid1Disk >(
         boost::uuids::string_generator()(std::string(AsyncRaid1Fixture::k_uuid)), disk_a, disk_b);
@@ -62,7 +66,7 @@ TEST(Raid1Async, ReadDegradedDirtyActiveFailNoFallback) {
     // Run in a fresh thread to isolate the thread_local read-route cursor from other tests.
     std::thread([&] {
         // Active device is called once; backup must not be touched (it has stale data).
-        EXPECT_CALL(*disk_a, submit_iov(_, _, _, _, _)).Times(1);
+        EXPECT_CALL(*disk_a, submit_iov(_, _, _, _, _)).Times(1).WillRepeatedly(make_async_iov_action());
         EXPECT_CALL(*disk_b, submit_iov(_, _, _, _, _)).Times(0);
 
         auto res = mock->submit_io(0, UBLK_IO_OP_READ, 0, 4 * Ki / 512, nullptr);

--- a/src/raid/raid1/tests/asyncio/read_write.cpp
+++ b/src/raid/raid1/tests/asyncio/read_write.cpp
@@ -18,8 +18,8 @@ TEST_F(AsyncRaid1Fixture, ReadSingleDevice) {
 // Healthy write: replicates to both devices.
 // inject active CQE first (task suspends on backup), then inject backup CQE (task done).
 TEST_F(AsyncRaid1Fixture, WriteBothDevices) {
-    EXPECT_CALL(*disk_a, submit_iov(_, _, _, _, _)).Times(1);
-    EXPECT_CALL(*disk_b, submit_iov(_, _, _, _, _)).Times(1);
+    EXPECT_CALL(*disk_a, submit_iov(_, _, _, _, _)).Times(1).WillRepeatedly(make_async_iov_action());
+    EXPECT_CALL(*disk_b, submit_iov(_, _, _, _, _)).Times(1).WillRepeatedly(make_async_iov_action());
 
     auto res = mock->submit_io(0, UBLK_IO_OP_WRITE, 0, 4 * Ki / 512, nullptr);
     ASSERT_TRUE(res);
@@ -39,8 +39,8 @@ TEST_F(AsyncRaid1Fixture, WriteBothDevices) {
 // second routes to DEVB (disk_b).
 TEST_F(AsyncRaid1Fixture, ReadRoundRobin) {
     std::thread([this] {
-        EXPECT_CALL(*disk_a, submit_iov(_, _, _, _, _)).Times(1);
-        EXPECT_CALL(*disk_b, submit_iov(_, _, _, _, _)).Times(1);
+        EXPECT_CALL(*disk_a, submit_iov(_, _, _, _, _)).Times(1).WillRepeatedly(make_async_iov_action());
+        EXPECT_CALL(*disk_b, submit_iov(_, _, _, _, _)).Times(1).WillRepeatedly(make_async_iov_action());
 
         auto res0 = mock->submit_io(0, UBLK_IO_OP_READ, 0, 4 * Ki / 512, nullptr);
         ASSERT_TRUE(res0);
@@ -77,7 +77,7 @@ TEST_F(AsyncRaid1Fixture, WriteDegradedSkipsReplica) {
 
     // Second write: only disk_b (now the active surviving device) should be called.
     EXPECT_CALL(*disk_a, submit_iov(_, _, _, _, _)).Times(0);
-    EXPECT_CALL(*disk_b, submit_iov(_, _, _, _, _)).Times(1);
+    EXPECT_CALL(*disk_b, submit_iov(_, _, _, _, _)).Times(1).WillRepeatedly(make_async_iov_action());
 
     auto res2 = mock->submit_io(1, UBLK_IO_OP_WRITE, 0, 4 * Ki / 512, nullptr);
     ASSERT_TRUE(res2);

--- a/src/raid/raid1/tests/asyncio/retry.cpp
+++ b/src/raid/raid1/tests/asyncio/retry.cpp
@@ -82,7 +82,7 @@ TEST_F(AsyncRaid1Fixture, UnavailReadReroutes) {
         // Read 1: last_read=DEVA → next = DEVB. disk_b succeeds normally.
         {
             EXPECT_CALL(*disk_a, submit_iov(_, _, _, _, _)).Times(0);
-            EXPECT_CALL(*disk_b, submit_iov(_, _, _, _, _)).Times(1);
+            EXPECT_CALL(*disk_b, submit_iov(_, _, _, _, _)).Times(1).WillRepeatedly(make_async_iov_action());
             auto res = mock->submit_io(1, UBLK_IO_OP_READ, 0, 4 * Ki / 512, nullptr);
             ASSERT_TRUE(res);
             auto c = mock->inject_cqe(1, 4 * Ki);
@@ -92,7 +92,7 @@ TEST_F(AsyncRaid1Fixture, UnavailReadReroutes) {
         // Read 2: last_read=DEVB → round-robin gives DEVA, but UNAVAIL → reroutes to DEVB.
         {
             EXPECT_CALL(*disk_a, submit_iov(_, _, _, _, _)).Times(0);
-            EXPECT_CALL(*disk_b, submit_iov(_, _, _, _, _)).Times(1);
+            EXPECT_CALL(*disk_b, submit_iov(_, _, _, _, _)).Times(1).WillRepeatedly(make_async_iov_action());
             auto res = mock->submit_io(2, UBLK_IO_OP_READ, 0, 4 * Ki / 512, nullptr);
             ASSERT_TRUE(res);
             auto c = mock->inject_cqe(2, 4 * Ki);

--- a/src/raid/raid1/tests/bitmap/sync_to_batching.cpp
+++ b/src/raid/raid1/tests/bitmap/sync_to_batching.cpp
@@ -12,7 +12,7 @@ using ::testing::Return;
 
 // Test that sync_to batches consecutive pages into single write operations
 TEST(Raid1Bitmap, SyncToBatchesConsecutivePages) {
-    auto device = std::make_shared< ublkpp::TestDisk >(TestParams{.capacity = 8 * ublkpp::Gi});
+    auto device = std::make_shared< ::testing::StrictMock< ublkpp::TestDisk > >(TestParams{.capacity = 8 * ublkpp::Gi});
     auto superbitmap_buf = make_test_superbitmap();
     auto bitmap = ublkpp::raid1::Bitmap(8 * ublkpp::Gi, 32 * ublkpp::Ki, 4 * ublkpp::Ki, superbitmap_buf.get());
 
@@ -35,7 +35,7 @@ TEST(Raid1Bitmap, SyncToBatchesConsecutivePages) {
 
 // Test that sync_to creates separate writes for non-consecutive pages
 TEST(Raid1Bitmap, SyncToSeparatesNonConsecutivePages) {
-    auto device = std::make_shared< ublkpp::TestDisk >(TestParams{.capacity = 8 * ublkpp::Gi});
+    auto device = std::make_shared< ::testing::StrictMock< ublkpp::TestDisk > >(TestParams{.capacity = 8 * ublkpp::Gi});
     auto superbitmap_buf = make_test_superbitmap();
     auto bitmap = ublkpp::raid1::Bitmap(8 * ublkpp::Gi, 32 * ublkpp::Ki, 4 * ublkpp::Ki, superbitmap_buf.get());
 
@@ -65,7 +65,7 @@ TEST(Raid1Bitmap, SyncToSeparatesNonConsecutivePages) {
 // Test that sync_to respects max_pages_per_tx batch limit
 TEST(Raid1Bitmap, SyncToRespectsMaxBatchSize) {
     // Create device with small max_io to force batching limits
-    auto device = std::make_shared< ublkpp::TestDisk >(TestParams{
+    auto device = std::make_shared< ::testing::StrictMock< ublkpp::TestDisk > >(TestParams{
         .capacity = 16 * ublkpp::Gi,
         .max_io = 4 * ublkpp::Ki // 4 KiB = 1 page, so max_batch = 1
     });
@@ -89,7 +89,7 @@ TEST(Raid1Bitmap, SyncToRespectsMaxBatchSize) {
 
 // Test that sync_to skips pages loaded from disk (not modified)
 TEST(Raid1Bitmap, SyncToSkipsUnmodifiedLoadedPages) {
-    auto device = std::make_shared< ublkpp::TestDisk >(TestParams{.capacity = 8 * ublkpp::Gi});
+    auto device = std::make_shared< ::testing::StrictMock< ublkpp::TestDisk > >(TestParams{.capacity = 8 * ublkpp::Gi});
     auto superbitmap_buf = make_test_superbitmap();
 
     // Mark all 8 pages as dirty in the SuperBitmap so load_from will load them
@@ -119,7 +119,7 @@ TEST(Raid1Bitmap, SyncToSkipsUnmodifiedLoadedPages) {
 
 // Test that sync_to writes pages that were loaded then modified
 TEST(Raid1Bitmap, SyncToWritesModifiedLoadedPages) {
-    auto device = std::make_shared< ublkpp::TestDisk >(TestParams{.capacity = 8 * ublkpp::Gi});
+    auto device = std::make_shared< ::testing::StrictMock< ublkpp::TestDisk > >(TestParams{.capacity = 8 * ublkpp::Gi});
     auto superbitmap_buf = make_test_superbitmap();
 
     // Mark all 8 pages as dirty in the SuperBitmap so load_from will load them
@@ -157,7 +157,7 @@ TEST(Raid1Bitmap, SyncToWritesModifiedLoadedPages) {
 
 // Test that sync_to handles write failures correctly
 TEST(Raid1Bitmap, SyncToHandlesWriteFailure) {
-    auto device = std::make_shared< ublkpp::TestDisk >(TestParams{.capacity = 8 * ublkpp::Gi});
+    auto device = std::make_shared< ::testing::StrictMock< ublkpp::TestDisk > >(TestParams{.capacity = 8 * ublkpp::Gi});
     auto superbitmap_buf = make_test_superbitmap();
     auto bitmap = ublkpp::raid1::Bitmap(8 * ublkpp::Gi, 32 * ublkpp::Ki, 4 * ublkpp::Ki, superbitmap_buf.get());
 
@@ -178,7 +178,8 @@ TEST(Raid1Bitmap, SyncToHandlesWriteFailure) {
 
 // Test batching with mixed consecutive and non-consecutive pages
 TEST(Raid1Bitmap, SyncToBatchesMixedPages) {
-    auto device = std::make_shared< ublkpp::TestDisk >(TestParams{.capacity = 16 * ublkpp::Gi});
+    auto device =
+        std::make_shared< ::testing::StrictMock< ublkpp::TestDisk > >(TestParams{.capacity = 16 * ublkpp::Gi});
     auto superbitmap_buf = make_test_superbitmap();
     auto bitmap = ublkpp::raid1::Bitmap(16 * ublkpp::Gi, 32 * ublkpp::Ki, 4 * ublkpp::Ki, superbitmap_buf.get());
 
@@ -214,7 +215,7 @@ TEST(Raid1Bitmap, SyncToBatchesMixedPages) {
 
 // Test empty bitmap sync_to (no dirty pages)
 TEST(Raid1Bitmap, SyncToEmptyBitmap) {
-    auto device = std::make_shared< ublkpp::TestDisk >(TestParams{.capacity = 8 * ublkpp::Gi});
+    auto device = std::make_shared< ::testing::StrictMock< ublkpp::TestDisk > >(TestParams{.capacity = 8 * ublkpp::Gi});
     auto superbitmap_buf = make_test_superbitmap();
     auto bitmap = ublkpp::raid1::Bitmap(8 * ublkpp::Gi, 32 * ublkpp::Ki, 4 * ublkpp::Ki, superbitmap_buf.get());
 
@@ -229,7 +230,7 @@ TEST(Raid1Bitmap, SyncToEmptyBitmap) {
 
 // Test that sync_to skips zero pages (cleaned pages)
 TEST(Raid1Bitmap, SyncToSkipsZeroPages) {
-    auto device = std::make_shared< ublkpp::TestDisk >(TestParams{.capacity = 8 * ublkpp::Gi});
+    auto device = std::make_shared< ::testing::StrictMock< ublkpp::TestDisk > >(TestParams{.capacity = 8 * ublkpp::Gi});
     auto superbitmap_buf = make_test_superbitmap();
     auto bitmap = ublkpp::raid1::Bitmap(8 * ublkpp::Gi, 32 * ublkpp::Ki, 4 * ublkpp::Ki, superbitmap_buf.get());
 

--- a/src/raid/raid1/tests/bitmap/sync_to_crash_scenarios.cpp
+++ b/src/raid/raid1/tests/bitmap/sync_to_crash_scenarios.cpp
@@ -12,8 +12,8 @@ using ::testing::Return;
 // Test crash during multi-page batch write
 TEST(Raid1BitmapCrash, CrashDuringBatchWrite) {
     // Limit max_io to 8 KiB = 2 pages max per batch
-    auto device =
-        std::make_shared< ublkpp::TestDisk >(TestParams{.capacity = 16 * ublkpp::Gi, .max_io = 8 * ublkpp::Ki});
+    auto device = std::make_shared< ::testing::StrictMock< ublkpp::TestDisk > >(
+        TestParams{.capacity = 16 * ublkpp::Gi, .max_io = 8 * ublkpp::Ki});
     auto superbitmap_buf = make_test_superbitmap();
     auto bitmap = ublkpp::raid1::Bitmap(16 * ublkpp::Gi, 32 * ublkpp::Ki, 4 * ublkpp::Ki, superbitmap_buf.get());
 
@@ -43,7 +43,8 @@ TEST(Raid1BitmapCrash, CrashDuringBatchWrite) {
 
 // Test partial write in the middle of batching
 TEST(Raid1BitmapCrash, PartialBatchWrite) {
-    auto device = std::make_shared< ublkpp::TestDisk >(TestParams{.capacity = 16 * ublkpp::Gi});
+    auto device =
+        std::make_shared< ::testing::StrictMock< ublkpp::TestDisk > >(TestParams{.capacity = 16 * ublkpp::Gi});
     auto superbitmap_buf = make_test_superbitmap();
     auto bitmap = ublkpp::raid1::Bitmap(16 * ublkpp::Gi, 32 * ublkpp::Ki, 4 * ublkpp::Ki, superbitmap_buf.get());
 
@@ -77,7 +78,7 @@ TEST(Raid1BitmapCrash, RecoveryAfterFailedSync) {
     // This simulates the full shutdown/reboot cycle
 
     // Setup: Device with initial bitmap
-    auto device = std::make_shared< ublkpp::TestDisk >(TestParams{.capacity = 8 * ublkpp::Gi});
+    auto device = std::make_shared< ::testing::StrictMock< ublkpp::TestDisk > >(TestParams{.capacity = 8 * ublkpp::Gi});
     auto superbitmap_buf1 = make_test_superbitmap();
     auto bitmap1 = ublkpp::raid1::Bitmap(8 * ublkpp::Gi, 32 * ublkpp::Ki, 4 * ublkpp::Ki, superbitmap_buf1.get());
 
@@ -104,7 +105,7 @@ TEST(Raid1BitmapCrash, RecoveryAfterFailedSync) {
 // Test that batch size respects device limits
 TEST(Raid1BitmapCrash, BatchSizeWithDeviceLimits) {
     // Device with very small max_io
-    auto device = std::make_shared< ublkpp::TestDisk >(TestParams{
+    auto device = std::make_shared< ::testing::StrictMock< ublkpp::TestDisk > >(TestParams{
         .capacity = 16 * ublkpp::Gi,
         .max_io = 8 * ublkpp::Ki // 8 KiB = 2 pages max
     });
@@ -129,7 +130,7 @@ TEST(Raid1BitmapCrash, BatchSizeWithDeviceLimits) {
 
 // Test failure in the middle batch (first succeeds, middle fails, last not attempted)
 TEST(Raid1BitmapCrash, FailureInMiddleBatch) {
-    auto device = std::make_shared< ublkpp::TestDisk >(TestParams{
+    auto device = std::make_shared< ::testing::StrictMock< ublkpp::TestDisk > >(TestParams{
         .capacity = 32 * ublkpp::Gi,
         .max_io = 8 * ublkpp::Ki // Max 2 pages per batch
     });
@@ -163,7 +164,7 @@ TEST(Raid1BitmapCrash, FailureInMiddleBatch) {
 
 // Test sync_to with offset parameter (for SuperBlock)
 TEST(Raid1BitmapCrash, SyncToWithOffset) {
-    auto device = std::make_shared< ublkpp::TestDisk >(TestParams{.capacity = 8 * ublkpp::Gi});
+    auto device = std::make_shared< ::testing::StrictMock< ublkpp::TestDisk > >(TestParams{.capacity = 8 * ublkpp::Gi});
     auto superbitmap_buf = make_test_superbitmap();
     auto bitmap = ublkpp::raid1::Bitmap(8 * ublkpp::Gi, 32 * ublkpp::Ki, 4 * ublkpp::Ki, superbitmap_buf.get());
 
@@ -187,7 +188,8 @@ TEST(Raid1BitmapCrash, SyncToWithOffset) {
 
 // Test that consecutive page detection works correctly
 TEST(Raid1BitmapCrash, ConsecutivePageDetection) {
-    auto device = std::make_shared< ublkpp::TestDisk >(TestParams{.capacity = 16 * ublkpp::Gi});
+    auto device =
+        std::make_shared< ::testing::StrictMock< ublkpp::TestDisk > >(TestParams{.capacity = 16 * ublkpp::Gi});
     auto superbitmap_buf = make_test_superbitmap();
     auto bitmap = ublkpp::raid1::Bitmap(16 * ublkpp::Gi, 32 * ublkpp::Ki, 4 * ublkpp::Ki, superbitmap_buf.get());
 

--- a/src/raid/raid1/tests/misc/replica_states.cpp
+++ b/src/raid/raid1/tests/misc/replica_states.cpp
@@ -73,9 +73,8 @@ TEST(Raid1, IdMethod) {
 // Helper: set up new_device mock expectations for a successful swap of device A.
 // After this swap: route=DEVB, new_device is in A slot (backup, unavail=false), device_b is active.
 // Caller must register the device_b staying-write and unmount expectations separately.
-static void expect_swap_a_success(std::shared_ptr< ublkpp::TestDisk >& new_device,
-                                  std::shared_ptr< ublkpp::TestDisk >& device_b,
-                                  ublkpp::raid1::Raid1Disk& raid_device) {
+static void expect_swap_a_success(std::shared_ptr< ublkpp::TestDisk > new_device,
+                                  std::shared_ptr< ublkpp::TestDisk > device_b, ublkpp::raid1::Raid1Disk& raid_device) {
     // new device read returns all-zeros → new_device=true → init_to is called
     EXPECT_CALL(*new_device, sync_iov(UBLK_IO_OP_READ, _, _, _))
         .Times(1)
@@ -127,7 +126,8 @@ TEST(Raid1, ReplicaStatesSyncingDEVB) {
     auto raid_device = ublkpp::raid1::Raid1Disk(boost::uuids::string_generator()(test_uuid), device_a, device_b);
     raid_device.toggle_resync(false);
 
-    auto new_device = std::make_shared< ublkpp::TestDisk >(TestParams{.capacity = Gi, .id = "DiskC"});
+    auto new_device =
+        std::make_shared< ::testing::StrictMock< ublkpp::TestDisk > >(TestParams{.capacity = Gi, .id = "DiskC"});
     expect_swap_a_success(new_device, device_b, raid_device);
 
     // Swap succeeds; returns outgoing device_a
@@ -159,7 +159,8 @@ TEST(Raid1, ReplicasAccessDEVB) {
     auto raid_device = ublkpp::raid1::Raid1Disk(boost::uuids::string_generator()(test_uuid), device_a, device_b);
     raid_device.toggle_resync(false);
 
-    auto new_device = std::make_shared< ublkpp::TestDisk >(TestParams{.capacity = Gi, .id = "DiskC"});
+    auto new_device =
+        std::make_shared< ::testing::StrictMock< ublkpp::TestDisk > >(TestParams{.capacity = Gi, .id = "DiskC"});
     expect_swap_a_success(new_device, device_b, raid_device);
 
     // Swap succeeds; returns outgoing device_a

--- a/src/raid/raid1/tests/misc/swap_device.cpp
+++ b/src/raid/raid1/tests/misc/swap_device.cpp
@@ -23,7 +23,8 @@ TEST(Raid1, SwapDeviceB) {
             return ublkpp::raid1::k_page_size;
         });
 
-    auto new_device = std::make_shared< ublkpp::TestDisk >(TestParams{.capacity = Gi, .id = "DiskC"});
+    auto new_device =
+        std::make_shared< ::testing::StrictMock< ublkpp::TestDisk > >(TestParams{.capacity = Gi, .id = "DiskC"});
     EXPECT_CALL(*new_device, sync_iov(UBLK_IO_OP_READ, _, _, _))
         .Times(1)
         .WillOnce([](uint8_t, iovec* iovecs, uint32_t nr_vecs, off_t addr) -> io_result {
@@ -90,11 +91,13 @@ TEST(Raid1, SwapDeviceA) {
             return ublkpp::raid1::k_page_size;
         });
 
-    auto small_device = std::make_shared< ublkpp::TestDisk >(TestParams{.capacity = Mi, .id = "DiskD"});
+    auto small_device =
+        std::make_shared< ::testing::StrictMock< ublkpp::TestDisk > >(TestParams{.capacity = Mi, .id = "DiskD"});
     auto old_device = raid_device.swap_device("DiskA", small_device);
     EXPECT_EQ(old_device, small_device);
 
-    auto new_device = std::make_shared< ublkpp::TestDisk >(TestParams{.capacity = Gi, .id = "DiskC"});
+    auto new_device =
+        std::make_shared< ::testing::StrictMock< ublkpp::TestDisk > >(TestParams{.capacity = Gi, .id = "DiskC"});
     EXPECT_CALL(*new_device, sync_iov(UBLK_IO_OP_READ, _, _, _))
         .Times(1)
         .WillOnce([](uint8_t, iovec* iovecs, uint32_t nr_vecs, off_t addr) -> io_result {
@@ -146,7 +149,8 @@ TEST(Raid1, SwapStayingWriteFail) {
     auto raid_device = ublkpp::raid1::Raid1Disk(boost::uuids::string_generator()(test_uuid), device_a, device_b);
     raid_device.toggle_resync(false);
 
-    auto new_device = std::make_shared< ublkpp::TestDisk >(TestParams{.capacity = Gi, .id = "DiskC"});
+    auto new_device =
+        std::make_shared< ::testing::StrictMock< ublkpp::TestDisk > >(TestParams{.capacity = Gi, .id = "DiskC"});
     // New device read returns a valid superblock with matching age → not a new device → no bitmap write
     EXPECT_CALL(*new_device, sync_iov(UBLK_IO_OP_READ, _, _, _))
         .Times(1)
@@ -199,7 +203,8 @@ TEST(Raid1, SwapDeviceWhileIdle) {
             return ublkpp::raid1::k_page_size;
         });
 
-    auto new_device = std::make_shared< ublkpp::TestDisk >(TestParams{.capacity = Gi, .id = "DiskC"});
+    auto new_device =
+        std::make_shared< ::testing::StrictMock< ublkpp::TestDisk > >(TestParams{.capacity = Gi, .id = "DiskC"});
     EXPECT_CALL(*new_device, sync_iov(UBLK_IO_OP_READ, _, _, _))
         .Times(1)
         .WillOnce([](uint8_t, iovec* iovecs, uint32_t, off_t addr) -> io_result {
@@ -241,7 +246,8 @@ TEST(Raid1, SwapFail) {
     auto raid_device = ublkpp::raid1::Raid1Disk(boost::uuids::string_generator()(test_uuid), device_a, device_b);
     raid_device.toggle_resync(false);
 
-    auto new_device = std::make_shared< ublkpp::TestDisk >(TestParams{.capacity = Gi, .id = "DiskC"});
+    auto new_device =
+        std::make_shared< ::testing::StrictMock< ublkpp::TestDisk > >(TestParams{.capacity = Gi, .id = "DiskC"});
     EXPECT_CALL(*new_device, sync_iov(UBLK_IO_OP_READ, _, _, _))
         .Times(1)
         .WillOnce([](uint8_t, iovec* iovecs, uint32_t nr_vecs, off_t addr) -> io_result {

--- a/src/raid/raid1/tests/syncio/read_fail_degraded_dirty.cpp
+++ b/src/raid/raid1/tests/syncio/read_fail_degraded_dirty.cpp
@@ -6,11 +6,12 @@
 #include "test_raid1_common.hpp"
 
 using ::testing::_;
-using ::testing::NiceMock;
+using ::testing::AnyNumber;
+using ::testing::StrictMock;
 
 TEST(Raid1, SyncIoReadDegradedDirtyActiveFailNoFallback) {
-    auto raw_a = std::make_shared< NiceMock< ublkpp::TestDisk > >(TestParams{.capacity = Gi});
-    auto raw_b = std::make_shared< NiceMock< ublkpp::TestDisk > >(TestParams{.capacity = Gi, .is_slot_b = true});
+    auto raw_a = std::make_shared< StrictMock< ublkpp::TestDisk > >(TestParams{.capacity = Gi});
+    auto raw_b = std::make_shared< StrictMock< ublkpp::TestDisk > >(TestParams{.capacity = Gi, .is_slot_b = true});
 
     // Degraded superblock: route=DEVA, unclean shutdown → __init_bitmap_and_degraded_route
     // calls dirty_region(0, capacity()) without going through __become_degraded, so
@@ -20,15 +21,18 @@ TEST(Raid1, SyncIoReadDegradedDirtyActiveFailNoFallback) {
     degraded_sb.fields.clean_unmount = 0;
     degraded_sb.fields.bitmap.age = htobe64(2);
 
-    ON_CALL(*raw_a, sync_iov(UBLK_IO_OP_READ, _, _, _))
-        .WillByDefault([degraded_sb](uint8_t, iovec* iov, uint32_t, off_t) -> io_result {
+    EXPECT_CALL(*raw_a, sync_iov(UBLK_IO_OP_READ, _, _, _))
+        .Times(AnyNumber())
+        .WillRepeatedly([degraded_sb](uint8_t, iovec* iov, uint32_t, off_t) -> io_result {
             if (iov->iov_base) memcpy(iov->iov_base, &degraded_sb, ublkpp::raid1::k_page_size);
             return ublkpp::raid1::k_page_size;
         });
-    ON_CALL(*raw_a, sync_iov(UBLK_IO_OP_WRITE, _, _, _))
-        .WillByDefault([](uint8_t, iovec* iov, uint32_t, off_t) -> io_result { return iov->iov_len; });
-    ON_CALL(*raw_b, sync_iov(UBLK_IO_OP_READ, _, _, _))
-        .WillByDefault([](uint8_t, iovec* iov, uint32_t, off_t) -> io_result {
+    EXPECT_CALL(*raw_a, sync_iov(UBLK_IO_OP_WRITE, _, _, _))
+        .Times(AnyNumber())
+        .WillRepeatedly([](uint8_t, iovec* iov, uint32_t, off_t) -> io_result { return iov->iov_len; });
+    EXPECT_CALL(*raw_b, sync_iov(UBLK_IO_OP_READ, _, _, _))
+        .Times(AnyNumber())
+        .WillRepeatedly([](uint8_t, iovec* iov, uint32_t, off_t) -> io_result {
             if (iov->iov_base) {
                 memcpy(iov->iov_base, &normal_superblock, ublkpp::raid1::k_page_size);
                 auto* sb = static_cast< ublkpp::raid1::SuperBlock* >(iov->iov_base);
@@ -37,6 +41,9 @@ TEST(Raid1, SyncIoReadDegradedDirtyActiveFailNoFallback) {
             }
             return ublkpp::raid1::k_page_size;
         });
+    EXPECT_CALL(*raw_b, sync_iov(UBLK_IO_OP_WRITE, _, _, _))
+        .Times(AnyNumber())
+        .WillRepeatedly([](uint8_t, iovec* iov, uint32_t, off_t) -> io_result { return iov->iov_len; });
 
     auto raid_device = ublkpp::raid1::Raid1Disk(boost::uuids::string_generator()(test_uuid), raw_a, raw_b);
 

--- a/src/raid/raid1/tests/syncio/write_backup_fail_degrade_fail.cpp
+++ b/src/raid/raid1/tests/syncio/write_backup_fail_degrade_fail.cpp
@@ -5,30 +5,35 @@
 #include "test_raid1_common.hpp"
 
 using ::testing::_;
-using ::testing::NiceMock;
+using ::testing::AnyNumber;
+using ::testing::StrictMock;
 
 TEST(Raid1, SyncIoWriteBackupFailDegradeFail) {
-    auto raw_a = std::make_shared< NiceMock< ublkpp::TestDisk > >(TestParams{.capacity = Gi});
-    auto raw_b = std::make_shared< NiceMock< ublkpp::TestDisk > >(TestParams{.capacity = Gi, .is_slot_b = true});
+    auto raw_a = std::make_shared< StrictMock< ublkpp::TestDisk > >(TestParams{.capacity = Gi});
+    auto raw_b = std::make_shared< StrictMock< ublkpp::TestDisk > >(TestParams{.capacity = Gi, .is_slot_b = true});
 
     // Normal healthy superblock on both sides for init.
-    ON_CALL(*raw_a, sync_iov(UBLK_IO_OP_READ, _, _, _))
-        .WillByDefault([](uint8_t, iovec* iov, uint32_t, off_t) -> io_result {
+    EXPECT_CALL(*raw_a, sync_iov(UBLK_IO_OP_READ, _, _, _))
+        .Times(AnyNumber())
+        .WillRepeatedly([](uint8_t, iovec* iov, uint32_t, off_t) -> io_result {
             if (iov->iov_base) memcpy(iov->iov_base, &normal_superblock, ublkpp::raid1::k_page_size);
             return ublkpp::raid1::k_page_size;
         });
-    ON_CALL(*raw_b, sync_iov(UBLK_IO_OP_READ, _, _, _))
-        .WillByDefault([](uint8_t, iovec* iov, uint32_t, off_t) -> io_result {
+    EXPECT_CALL(*raw_b, sync_iov(UBLK_IO_OP_READ, _, _, _))
+        .Times(AnyNumber())
+        .WillRepeatedly([](uint8_t, iovec* iov, uint32_t, off_t) -> io_result {
             if (iov->iov_base) {
                 memcpy(iov->iov_base, &normal_superblock, ublkpp::raid1::k_page_size);
                 static_cast< ublkpp::raid1::SuperBlock* >(iov->iov_base)->fields.device_b = 1;
             }
             return ublkpp::raid1::k_page_size;
         });
-    ON_CALL(*raw_a, sync_iov(UBLK_IO_OP_WRITE, _, _, _))
-        .WillByDefault([](uint8_t, iovec* iov, uint32_t, off_t) -> io_result { return iov->iov_len; });
-    ON_CALL(*raw_b, sync_iov(UBLK_IO_OP_WRITE, _, _, _))
-        .WillByDefault([](uint8_t, iovec* iov, uint32_t, off_t) -> io_result { return iov->iov_len; });
+    EXPECT_CALL(*raw_a, sync_iov(UBLK_IO_OP_WRITE, _, _, _))
+        .Times(AnyNumber())
+        .WillRepeatedly([](uint8_t, iovec* iov, uint32_t, off_t) -> io_result { return iov->iov_len; });
+    EXPECT_CALL(*raw_b, sync_iov(UBLK_IO_OP_WRITE, _, _, _))
+        .Times(AnyNumber())
+        .WillRepeatedly([](uint8_t, iovec* iov, uint32_t, off_t) -> io_result { return iov->iov_len; });
 
     auto raid_device = ublkpp::raid1::Raid1Disk(boost::uuids::string_generator()(test_uuid), raw_a, raw_b);
     raid_device.toggle_resync(false);

--- a/src/raid/raid1/tests/syncio/write_optimistic.cpp
+++ b/src/raid/raid1/tests/syncio/write_optimistic.cpp
@@ -12,11 +12,12 @@
 #include "test_raid1_common.hpp"
 
 using ::testing::_;
-using ::testing::NiceMock;
+using ::testing::AnyNumber;
+using ::testing::StrictMock;
 
 TEST(Raid1, SyncIoOptimisticWriteCleansBitmap) {
-    auto raw_a = std::make_shared< NiceMock< ublkpp::TestDisk > >(TestParams{.capacity = Gi});
-    auto raw_b = std::make_shared< NiceMock< ublkpp::TestDisk > >(TestParams{.capacity = Gi, .is_slot_b = true});
+    auto raw_a = std::make_shared< StrictMock< ublkpp::TestDisk > >(TestParams{.capacity = Gi});
+    auto raw_b = std::make_shared< StrictMock< ublkpp::TestDisk > >(TestParams{.capacity = Gi, .is_slot_b = true});
 
     // raw_a SB: route=DEVA, clean_unmount=0, age=2.
     // pick_superblock prefers raw_a (age 2 > 1) and sets read_route=DEVA.
@@ -27,28 +28,32 @@ TEST(Raid1, SyncIoOptimisticWriteCleansBitmap) {
     degraded_sb.fields.clean_unmount = 0;
     degraded_sb.fields.bitmap.age = htobe64(2);
 
-    ON_CALL(*raw_a, sync_iov(UBLK_IO_OP_READ, _, _, _))
-        .WillByDefault([degraded_sb](uint8_t, iovec* iov, uint32_t, off_t) -> io_result {
+    EXPECT_CALL(*raw_a, sync_iov(UBLK_IO_OP_READ, _, _, _))
+        .Times(AnyNumber())
+        .WillRepeatedly([degraded_sb](uint8_t, iovec* iov, uint32_t, off_t) -> io_result {
             if (iov->iov_base) memcpy(iov->iov_base, &degraded_sb, ublkpp::raid1::k_page_size);
             return ublkpp::raid1::k_page_size;
         });
 
-    ON_CALL(*raw_b, sync_iov(UBLK_IO_OP_READ, _, _, _))
-        .WillByDefault([](uint8_t, iovec* iov, uint32_t, off_t) -> io_result {
+    EXPECT_CALL(*raw_b, sync_iov(UBLK_IO_OP_READ, _, _, _))
+        .Times(AnyNumber())
+        .WillRepeatedly([](uint8_t, iovec* iov, uint32_t, off_t) -> io_result {
             if (iov->iov_base) {
                 memcpy(iov->iov_base, &normal_superblock, ublkpp::raid1::k_page_size);
                 auto* sb = static_cast< ublkpp::raid1::SuperBlock* >(iov->iov_base);
                 sb->fields.device_b = 1;
-                sb->fields.bitmap.age = htobe64(1); // older than raw_a → raw_a wins
+                sb->fields.bitmap.age = htobe64(1); // older than raw_a -> raw_a wins
             }
             return ublkpp::raid1::k_page_size;
         });
 
-    ON_CALL(*raw_a, sync_iov(UBLK_IO_OP_WRITE, _, _, _))
-        .WillByDefault([](uint8_t, iovec* iov, uint32_t, off_t) -> io_result { return iov->iov_len; });
+    EXPECT_CALL(*raw_a, sync_iov(UBLK_IO_OP_WRITE, _, _, _))
+        .Times(AnyNumber())
+        .WillRepeatedly([](uint8_t, iovec* iov, uint32_t, off_t) -> io_result { return iov->iov_len; });
 
-    ON_CALL(*raw_b, sync_iov(UBLK_IO_OP_WRITE, _, _, _))
-        .WillByDefault([](uint8_t, iovec* iov, uint32_t, off_t) -> io_result { return iov->iov_len; });
+    EXPECT_CALL(*raw_b, sync_iov(UBLK_IO_OP_WRITE, _, _, _))
+        .Times(AnyNumber())
+        .WillRepeatedly([](uint8_t, iovec* iov, uint32_t, off_t) -> io_result { return iov->iov_len; });
 
     auto raid_device = ublkpp::raid1::Raid1Disk(boost::uuids::string_generator()(test_uuid), raw_a, raw_b);
 

--- a/src/raid/raid1/tests/test_raid1_common.hpp
+++ b/src/raid/raid1/tests/test_raid1_common.hpp
@@ -96,7 +96,7 @@ inline std::unique_ptr< uint8_t[] > make_test_superbitmap() {
     [] {                                                                                                               \
         auto p = (params);                                                                                             \
         p.is_slot_b = (dev_b);                                                                                         \
-        auto device = std::make_shared< ublkpp::TestDisk >(p);                                                         \
+        auto device = std::make_shared< ::testing::StrictMock< ublkpp::TestDisk > >(p);                                \
         /* Expect to load and write clean_unmount bit */                                                               \
         if (!no_read) { EXPECT_TO_READ_SB_F(device, (dev_b), fail_read) }                                              \
         if (!no_write && !fail_read) { EXPECT_TO_WRITE_SB_F(device, fail_write) }                                      \


### PR DESCRIPTION
Replace every mock instantiation (NiceMock<>, bare TestDisk, bare AsyncTestDisk) with StrictMock<> so that any mock call without a matching EXPECT_CALL immediately fails the test rather than silently succeeding or emitting a suppressed warning.

- CREATE_DISK_F macros (raid0 + raid1) now produce StrictMock<TestDisk>
- Async fixtures (async_raid0/1_common.hpp) replace NiceMock with StrictMock and convert ON_CALL to EXPECT_CALL(...).Times(AnyNumber()) so init/destructor I/O is covered by a catchall fallback while test-body EXPECT_CALLs retain higher LIFO priority for assertions
- Four standalone NiceMock tests receive the same treatment; the syncio read_fail_degraded_dirty test gains an explicit raw_b WRITE fallback that NiceMock was silently providing before
- Direct make_shared<TestDisk> sites (bitmap, misc, raid0 superblock) converted to StrictMock; all had existing EXPECT_CALLs covering every operation, so behaviour is unchanged