### PR TITLE
third

### DIFF
--- a/include/ublkpp/lib/ublk_disk.hpp
+++ b/include/ublkpp/lib/ublk_disk.hpp
@@ -11,6 +11,7 @@
 #include "disk_task.hpp"
 #include <ublkpp/lib/ublk_params.hpp>
 
+struct io_uring;
 struct iovec;
 struct ublk_io_data;
 struct ublksrv_queue;
@@ -90,6 +91,18 @@ public:
     virtual io_result sync_iov(uint8_t /*op*/, iovec* /*iovecs*/, uint32_t /*nr_vecs*/, off_t /*addr*/) noexcept {
         RELEASE_ASSERT(_is_missing, "sync_iov() called on a non-missing ublk_disk that did not override");
         return std::unexpected(std::make_error_condition(std::errc::io_error));
+    }
+
+    // Prepares a scatter-gather read or write SQE on the caller's io_uring ring.
+    // op:        UBLK_IO_OP_READ or UBLK_IO_OP_WRITE
+    // user_data: stored in sqe->user_data for CQE routing by the caller.
+    // Returns true if a SQE was successfully prepared; false if this disk does not
+    // support io_uring submission (e.g. composite disks, test doubles) or no SQE
+    // slot was available in the ring. The caller must fall back to sync_iov when false.
+    // Default: returns false (safe no-op for missing-disk and non-leaf implementations).
+    virtual bool prep_iov_sqe(io_uring* /*ring*/, uint8_t /*op*/, iovec const* /*iovs*/, uint32_t /*nr*/,
+                              uint64_t /*addr*/, uint64_t /*user_data*/) noexcept {
+        return false;
     }
 
     // Returned by prepare(). Carries the file descriptors to register in the queue's io_uring

--- a/src/driver/fs_disk.cpp
+++ b/src/driver/fs_disk.cpp
@@ -2,6 +2,7 @@
 
 extern "C" {
 #include <fcntl.h>
+#include <liburing.h>
 #include <sys/ioctl.h>
 #include <sys/stat.h>
 #include <sys/statfs.h>
@@ -68,6 +69,8 @@ public:
     disk_task< int > async_iov(ublksrv_queue const* q, ublk_io_data const* data, iovec* iovecs, uint32_t nr_vecs,
                                uint64_t addr) override;
     io_result sync_iov(uint8_t op, iovec* iovecs, uint32_t nr_vecs, off_t offset) noexcept override;
+    bool prep_iov_sqe(io_uring* ring, uint8_t op, iovec const* iovs, uint32_t nr, uint64_t addr,
+                      uint64_t user_data) noexcept override;
 
 private:
     std::pair< io_result, cqe_state* > handle_discard(ublksrv_queue const* q, ublk_io_data const* data, uint32_t len,
@@ -250,6 +253,22 @@ std::pair< io_result, cqe_state* > FSDisk::handle_discard(ublksrv_queue const* q
     }
     DLOGE("ioctl BLKDISCARD on {} returned error: {}", _path.native(), strerror(errno))
     return {std::unexpected(std::make_error_condition(static_cast< std::errc >(errno))), nullptr};
+}
+
+bool FSDisk::prep_iov_sqe(io_uring* ring, uint8_t op, iovec const* iovs, uint32_t nr, uint64_t addr,
+                          uint64_t user_data) noexcept {
+    // Only use io_uring for direct I/O. Buffered io_uring has ordering issues on kernel ≤ 5.4
+    // and is not supported on overlayfs (common in CI Docker environments).
+    if (!_direct_io) return false;
+    auto* sqe = io_uring_get_sqe(ring);
+    if (!sqe) [[unlikely]]
+        return false;
+    if (op == UBLK_IO_OP_READ)
+        io_uring_prep_readv(sqe, _fd, const_cast< iovec* >(iovs), nr, static_cast< off_t >(addr));
+    else
+        io_uring_prep_writev(sqe, _fd, const_cast< iovec* >(iovs), nr, static_cast< off_t >(addr));
+    io_uring_sqe_set_data64(sqe, user_data);
+    return true;
 }
 
 io_result FSDisk::sync_iov(uint8_t op, iovec* iovecs, uint32_t nr_vecs, off_t addr) noexcept {

--- a/src/raid/raid1/raid1_resync_task.cpp
+++ b/src/raid/raid1/raid1_resync_task.cpp
@@ -26,145 +26,419 @@ Raid1ResyncTask::~Raid1ResyncTask() noexcept {
     if (_resync_task.joinable()) _resync_task.join();
 }
 
-template < typename StateHandler >
-[[gnu::noinline]] bool Raid1ResyncTask::__transition_to(resync_state initial, resync_state target,
-                                                        StateHandler&& handler) noexcept {
-    auto cur_state = initial;
-    while (!__cas_state(cur_state, target)) {
-        auto [next_state, action] = handler(cur_state);
-
-        switch (action) {
-        case transition_action::RETRY: // LCOV_EXCL_LINE
-            cur_state = next_state;    // LCOV_EXCL_LINE
-            break;                     // LCOV_EXCL_LINE
-        case transition_action::RETRY_WITH_SLEEP:
-            cur_state = next_state;
-            std::this_thread::sleep_for(k_state_spin_time);
-            break;
-        case transition_action::SUCCESS:
-            return true;
-        case transition_action::EARLY_EXIT:
-            return false;
-        }
-    }
-    return true; // CAS succeeded
-}
-
-void Raid1ResyncTask::_start(std::string str_uuid, std::shared_ptr< MirrorDevice >& clean_mirror,
-                             std::shared_ptr< MirrorDevice >& dirty_mirror, std::function< void() >&& complete) {
-    RLOGD("Resync Task created for [uuid:{}]", str_uuid)
-    // Wait to become Available & IDLE
-    auto cur_state = resync_state::IDLE;
-    while (dirty_mirror->unavail.test(std::memory_order_acquire) || !__cas_state(cur_state, resync_state::ACTIVE)) {
-        // If we're stopped or another we should exit
-        if (resync_state::STOPPING == cur_state) break;
-
-        cur_state = resync_state::IDLE;
-        if (dirty_mirror->unavail.test(std::memory_order_acquire)) {
-            cur_state = __load_state();
-            if (resync_state::STOPPING == cur_state) break;
-            std::this_thread::sleep_for(std::chrono::seconds(SISL_OPTIONS["avail_delay"].as< uint32_t >()));
-            probe_mirror(*dirty_mirror, _offset);
-        } else // LCOV_EXCL_START -- CAS IDLE→ACTIVE race inside _start(); not deterministically triggerable
-            std::this_thread::sleep_for(std::chrono::microseconds(SISL_OPTIONS["resync_delay"].as< uint32_t >()));
-        // LCOV_EXCL_STOP
-    }
-    cur_state = __load_state();
-
-    // We are now guaranteed to be the only active thread performing I/O on the device
-    if (resync_state::STOPPING != cur_state) {
-        auto const initial_resync_size = _dirty_bitmap->dirty_data_est();
-        // Set ourselves up with a buffer to do all the read/write operations from
-        auto iov = iovec{.iov_base = nullptr, .iov_len = 0};
-        if (auto err = ::posix_memalign(&iov.iov_base, _io_size, _max_size); 0 != err || nullptr == iov.iov_base)
-            [[unlikely]] { // LCOV_EXCL_START
-            RLOGE("Could not allocate memory for I/O: {}", strerror(err))
-            if (iov.iov_base) free(iov.iov_base);
-            return;
-        } // LCOV_EXCL_STOP
-
-        auto const resync_start = std::chrono::steady_clock::now();
-        // Record resync start - increment global and per-device counters
-        // Capture the initial size of data to resync
-        if (_metrics) { // GCOVR_EXCL_BR_LINE -- UblkRaidMetrics requires prometheus registry; not constructible in unit
-                        // tests
-            // LCOV_EXCL_START
-            auto const active_count = s_active_resyncs.fetch_add(1, std::memory_order_relaxed) + 1;
-            _metrics->record_resync_start();
-            _metrics->record_active_resyncs(active_count);
-        } // LCOV_EXCL_STOP
-
-        cur_state = __run(clean_mirror, dirty_mirror, &iov);
-        free(iov.iov_base);
-
-        if (_metrics) { // GCOVR_EXCL_BR_LINE
-            // LCOV_EXCL_START -- UblkRaidMetrics requires prometheus registry; not constructible in unit tests
-            auto const final_count = s_active_resyncs.fetch_sub(1, std::memory_order_relaxed) - 1;
-            auto const resync_end = std::chrono::steady_clock::now();
-            auto const duration_seconds =
-                std::chrono::duration_cast< std::chrono::seconds >(resync_end - resync_start).count();
-            if (duration_seconds > 0) { _metrics->record_resync_complete(duration_seconds); }
-            // Record the size of data that was resynced (initial size before resync started)
-            _metrics->record_last_resync_size(initial_resync_size);
-            _metrics->record_active_resyncs(final_count);
-        } // LCOV_EXCL_STOP
-    }
-
-    // If stopped, end now.
-    if (resync_state::STOPPING == cur_state) {
-        RLOGI("Resync Task Stopped for [uuid:{}] to: {}", str_uuid, *dirty_mirror->disk)
-        for (auto stopping = resync_state::STOPPING;
-             !__cas_state(stopping, resync_state::IDLE) && stopping == resync_state::STOPPING;)
-            std::this_thread::yield();
-        return;
-    }
-
-    // Otherwise we _should_ be active (not paused or idle), if the bitmap is clean call complete
-    DEBUG_ASSERT_EQ(resync_state::ACTIVE, cur_state, "Resync stopped in unexpected state");
-    // I/O may have been interrupted, if not check the bitmap and mark us as _clean_
-    if (0 == _dirty_bitmap->dirty_pages()) complete();
-    RLOGD("Resync Task Finished for [uuid:{}] to: {}", str_uuid, *dirty_mirror->disk)
-
-    // Open up I/O Again
-    for (auto active = resync_state::ACTIVE;
-         !__cas_state(active, resync_state::IDLE) && active == resync_state::ACTIVE;)
-        std::this_thread::yield();
-}
+// ── Public API ────────────────────────────────────────────────────────────────────────────────
 
 void Raid1ResyncTask::launch(std::string const& str_uuid, std::shared_ptr< MirrorDevice > clean_mirror,
                              std::shared_ptr< MirrorDevice > dirty_mirror, std::function< void() >&& complete) {
     auto lg = std::scoped_lock< std::mutex >(_launch_lock);
-    // First we must become IDLE
-    auto transitioned =
-        __transition_to(resync_state::IDLE, resync_state::IDLE, [](resync_state state) -> transition_result {
-            switch (state) {
-            case resync_state::IDLE: // LCOV_EXCL_LINE -- CAS(IDLE→IDLE) succeeds if state==IDLE; handler never called
-                                     // with IDLE
-                return {state, transition_action::SUCCESS}; // LCOV_EXCL_LINE
-            case resync_state::ACTIVE:
-            case resync_state::SLEEPING:
-                return {state, transition_action::EARLY_EXIT};
-            case resync_state::STOPPING: // LCOV_EXCL_LINE -- transient; not deterministically catchable
-                return {resync_state::IDLE, transition_action::RETRY_WITH_SLEEP}; // LCOV_EXCL_LINE
-            }
-            std::unreachable();
-        });
 
-    if (!transitioned) {
-        RLOGD("Resync Task aborted for [uuid:{}] - already running", str_uuid)
-        return;
+    if (_resync_task.joinable()) {
+        // Thread exists: if it's winding down after stop(), join and re-launch; if running, skip.
+        if (!_stop.load(std::memory_order_acquire)) {
+            RLOGD("Resync Task aborted for [uuid:{}] - already running", str_uuid)
+            return;
+        }
+        _resync_task.join();
     }
 
-    // The previous resync thread may still be joinable even though state is IDLE — there is a
-    // window between _start() setting state to IDLE and the thread actually returning. Assigning
-    // to a joinable std::thread calls std::terminate(), so join here first.
-    if (_resync_task.joinable()) _resync_task.join();
-
+    RLOGD("Resync Task created for [uuid:{}]", str_uuid)
+    _stop.store(false, std::memory_order_relaxed);
     _resync_task = sisl::named_thread(
         fmt::format("r_{}", str_uuid.substr(0, 13)),
         [this, uuid = str_uuid, clean = std::move(clean_mirror), dirty = std::move(dirty_mirror),
-         compl_cb = std::move(complete)] mutable { _start(uuid, clean, dirty, std::move(compl_cb)); });
+         compl_cb = std::move(complete)] mutable { _run(std::move(clean), std::move(dirty), std::move(compl_cb)); });
 }
+
+void Raid1ResyncTask::stop() noexcept {
+    _stop.store(true, std::memory_order_release);
+    auto lg = std::scoped_lock< std::mutex >(_launch_lock);
+    if (_resync_task.joinable()) _resync_task.join();
+}
+
+// ── Private helpers ───────────────────────────────────────────────────────────────────────────
+
+bool Raid1ResyncTask::_sleep_check_stop(std::chrono::microseconds dur) noexcept {
+    static constexpr auto k_tick = std::chrono::microseconds{500};
+    auto const end = std::chrono::steady_clock::now() + dur;
+    while (std::chrono::steady_clock::now() < end) {
+        if (_stop.load(std::memory_order_acquire)) return false;
+        std::this_thread::sleep_for(k_tick);
+    }
+    return !_stop.load(std::memory_order_acquire);
+}
+
+bool Raid1ResyncTask::_init_ring(ublk_disk& clean_disk, ublk_disk& dirty_disk) noexcept {
+    // Probe both disks with a temporary ring to check prep_iov_sqe() support.
+    // Priming a zero-vector readv/writev SQE is sufficient — nr=0 means no actual I/O;
+    // the SQEs are never submitted (io_uring_queue_exit() discards them).
+    io_uring probe_ring{};
+    if (io_uring_queue_init(k_resync_ring_depth, &probe_ring, IORING_SETUP_SINGLE_ISSUER | IORING_SETUP_COOP_TASKRUN) !=
+        0) [[unlikely]]
+        return false;
+
+    iovec probe_iov{};
+    bool const clean_ok = clean_disk.prep_iov_sqe(&probe_ring, UBLK_IO_OP_READ, &probe_iov, 0, 0, 0);
+    bool const dirty_ok = dirty_disk.prep_iov_sqe(&probe_ring, UBLK_IO_OP_WRITE, &probe_iov, 0, 0, 0);
+    io_uring_queue_exit(&probe_ring);
+
+    if (!clean_ok || !dirty_ok) return false;
+
+    if (io_uring_queue_init(k_resync_ring_depth, &_ring, IORING_SETUP_SINGLE_ISSUER | IORING_SETUP_COOP_TASKRUN) != 0)
+        [[unlikely]]
+        return false;
+
+    for (auto& slot : _slots) {
+        if (auto err = ::posix_memalign(&slot.buf, _io_size, _max_size); err != 0 || !slot.buf) [[unlikely]] {
+            // LCOV_EXCL_START
+            for (auto& s : _slots) {
+                free(s.buf);
+                s.buf = nullptr;
+            }
+            io_uring_queue_exit(&_ring);
+            return false;
+            // LCOV_EXCL_STOP
+        }
+    }
+
+    _ring_initialized = true;
+    return true;
+}
+
+// ── Entry point called by the resync thread ───────────────────────────────────────────────────
+
+void Raid1ResyncTask::_run(std::shared_ptr< MirrorDevice > clean, std::shared_ptr< MirrorDevice > dirty,
+                           std::function< void() > complete) {
+    auto const initial_resync_size = _dirty_bitmap->dirty_data_est();
+    auto const resync_start = std::chrono::steady_clock::now();
+
+    if (_metrics) { // GCOVR_EXCL_BR_LINE
+        // LCOV_EXCL_START
+        auto const active_count = s_active_resyncs.fetch_add(1, std::memory_order_relaxed) + 1;
+        _metrics->record_resync_start();
+        _metrics->record_active_resyncs(active_count);
+    } // LCOV_EXCL_STOP
+
+    bool const use_uring = _init_ring(*clean->disk, *dirty->disk);
+    RLOGD("Resync Task starting [use_uring:{}]", use_uring)
+
+    if (use_uring)
+        _run_uring(*clean, *dirty);
+    else
+        _run_sync(*clean, *dirty);
+
+    if (use_uring) _drain_and_exit();
+
+    if (_metrics) { // GCOVR_EXCL_BR_LINE
+        // LCOV_EXCL_START
+        auto const final_count = s_active_resyncs.fetch_sub(1, std::memory_order_relaxed) - 1;
+        auto const resync_end = std::chrono::steady_clock::now();
+        auto const duration_seconds =
+            std::chrono::duration_cast< std::chrono::seconds >(resync_end - resync_start).count();
+        if (duration_seconds > 0) _metrics->record_resync_complete(duration_seconds);
+        _metrics->record_last_resync_size(initial_resync_size);
+        _metrics->record_active_resyncs(final_count);
+    } // LCOV_EXCL_STOP
+
+    if (_stop.load(std::memory_order_acquire)) {
+        RLOGI("Resync Task Stopped to: {}", *dirty->disk)
+        return;
+    }
+
+    if (0 == _dirty_bitmap->dirty_pages()) complete();
+    RLOGD("Resync Task Finished to: {}", *dirty->disk)
+}
+
+// ── Async (io_uring) path ─────────────────────────────────────────────────────────────────────
+
+// Fills free slots with READ SQEs starting from (cursor_lba, cursor_sz).
+// cursor_lba is a monotonically advancing high-water mark within a single scan pass;
+// it never wraps within _fill_slots — the outer loop resets it for the next pass.
+// This prevents re-submitting READs for ranges already covered by WRITE_PENDING slots.
+void Raid1ResyncTask::_fill_slots(MirrorDevice& clean, uint64_t& cursor_lba, uint32_t& cursor_sz,
+                                  uint64_t& cursor_skip_from) noexcept {
+    for (auto idx = 0u; idx < k_resync_slots && !_stop.load(std::memory_order_relaxed); ++idx) {
+        auto& slot = _slots[idx];
+        if (slot.phase != ResyncSlot::Phase::FREE) continue;
+
+        // Advance cursor to the next dirty chunk without wrapping past the start.
+        if (cursor_sz == 0) {
+            uint64_t const from = cursor_skip_from > 0 ? cursor_skip_from : cursor_lba;
+            cursor_skip_from = 0;
+            auto [lba, sz] = _dirty_bitmap->next_dirty_after(from);
+            if (sz == 0) return; // no dirty data past current position — scan pass complete
+            cursor_lba = lba;
+            cursor_sz = sz;
+        }
+
+        auto const iov_len = std::min(cursor_sz, _max_size);
+        auto const gen_before = _region_tracker.snapshot_gen();
+
+        // Phase 1: skip if a write is in-flight for this range.
+        if (_region_tracker.overlaps(cursor_lba, iov_len)) {
+            cursor_lba += iov_len;
+            cursor_sz -= iov_len;
+            if (cursor_sz == 0) cursor_skip_from = cursor_lba;
+            continue;
+        }
+
+        slot.iov = {.iov_base = slot.buf, .iov_len = iov_len};
+        if (!clean.disk->prep_iov_sqe(&_ring, UBLK_IO_OP_READ, &slot.iov, 1, cursor_lba + _offset, idx)) [[unlikely]]
+            return; // ring full; process existing CQEs first
+
+        slot.phase = ResyncSlot::Phase::READ_PENDING;
+        slot.lba = cursor_lba;
+        slot.len = iov_len;
+        slot.gen_before = gen_before;
+        ++_in_flight;
+
+        cursor_lba += iov_len;
+        cursor_sz -= iov_len;
+    }
+}
+
+void Raid1ResyncTask::_process_cqes(MirrorDevice& clean, MirrorDevice& dirty) noexcept {
+    io_uring_cqe* cqe{};
+    unsigned head{};
+    unsigned seen{0};
+
+    io_uring_for_each_cqe(&_ring, head, cqe) {
+        ++seen;
+        auto const ud = io_uring_cqe_get_data64(cqe);
+        if (ud == k_resync_cancel_tag) continue;
+
+        auto const slot_idx = static_cast< uint32_t >(ud & 0xFFu);
+        bool const is_write = (ud & k_resync_write_tag) != 0;
+        auto& slot = _slots[slot_idx];
+
+        if (!is_write) {
+            // READ CQE
+            if (cqe->res < 0) [[unlikely]] {
+                RLOGE("Resync async READ failed at lba={:#x}: {}", slot.lba, strerror(-cqe->res))
+                dirty.unavail.test_and_set(std::memory_order_acquire);
+                slot.phase = ResyncSlot::Phase::FREE;
+                --_in_flight;
+                continue;
+            }
+
+            // Phase 2: skip the write if a concurrent user write overlaps this range.
+            // Two cases: still in-flight (overlaps()) or completed during our READ (completed_since()).
+            if (_region_tracker.overlaps(slot.lba, slot.len) ||
+                _region_tracker.completed_since(slot.lba, slot.len, slot.gen_before)) {
+                slot.phase = ResyncSlot::Phase::FREE;
+                --_in_flight;
+                continue;
+            }
+
+            if (!dirty.disk->prep_iov_sqe(&_ring, UBLK_IO_OP_WRITE, &slot.iov, 1, slot.lba + _offset,
+                                          slot_idx | k_resync_write_tag)) [[unlikely]] {
+                // LCOV_EXCL_START — ring should never be full here (depth ≥ 2×slots)
+                RLOGW("Resync: WRITE SQE submit failed for lba={:#x} — keeping dirty", slot.lba)
+                slot.phase = ResyncSlot::Phase::FREE;
+                --_in_flight;
+                continue;
+                // LCOV_EXCL_STOP
+            }
+            slot.phase = ResyncSlot::Phase::WRITE_PENDING;
+        } else {
+            // WRITE CQE
+            if (cqe->res < 0) [[unlikely]] {
+                RLOGW("Resync async WRITE failed at lba={:#x}: {}", slot.lba, strerror(-cqe->res))
+                dirty.unavail.test_and_set(std::memory_order_acquire);
+            } else {
+                clean_region(slot.lba, slot.len, clean);
+                if (_metrics) { _metrics->record_resync_progress(slot.len); } // GCOVR_EXCL_BR_LINE
+            }
+            slot.phase = ResyncSlot::Phase::FREE;
+            --_in_flight;
+        }
+    }
+
+    if (seen) io_uring_cq_advance(&_ring, seen);
+}
+
+void Raid1ResyncTask::_drain_and_exit() noexcept {
+    if (_in_flight > 0) {
+        if (auto* sqe = io_uring_get_sqe(&_ring)) {
+            io_uring_prep_cancel(sqe, nullptr, IORING_ASYNC_CANCEL_ANY);
+            io_uring_sqe_set_data64(sqe, k_resync_cancel_tag);
+            io_uring_submit(&_ring);
+        }
+        // Drain all remaining CQEs. Each slot contributes exactly 1 to _in_flight;
+        // the first CQE for it (READ -ECANCELED or WRITE completion/cancel) frees it.
+        while (_in_flight > 0) {
+            io_uring_cqe* cqe{};
+            io_uring_wait_cqe(&_ring, &cqe);
+            auto const ud = io_uring_cqe_get_data64(cqe);
+            if (ud != k_resync_cancel_tag) {
+                auto const slot_idx = static_cast< uint32_t >(ud & 0xFFu);
+                auto& slot = _slots[slot_idx];
+                if (slot.phase != ResyncSlot::Phase::FREE) {
+                    slot.phase = ResyncSlot::Phase::FREE;
+                    --_in_flight;
+                }
+            }
+            io_uring_cqe_seen(&_ring, cqe);
+        }
+    }
+
+    if (_ring_initialized) {
+        io_uring_queue_exit(&_ring);
+        _ring_initialized = false;
+    }
+    for (auto& slot : _slots) {
+        free(slot.buf);
+        slot.buf = nullptr;
+    }
+}
+
+void Raid1ResyncTask::_run_uring(MirrorDevice& clean, MirrorDevice& dirty) {
+    static auto const unavail_delay = std::chrono::seconds(SISL_OPTIONS["avail_delay"].as< uint32_t >());
+    static auto const avail_delay = std::chrono::microseconds(SISL_OPTIONS["resync_delay"].as< uint32_t >());
+
+    uint64_t cursor_lba{0}, cursor_skip_from{0};
+    uint32_t cursor_sz{0};
+    uint32_t consecutive_unavail{0};
+
+    while (!_stop.load(std::memory_order_acquire)) {
+        if (dirty.unavail.test(std::memory_order_acquire)) {
+            if (++consecutive_unavail % 10 == 0)
+                RLOGW("Resync blocked: dirty mirror unreachable for ~{}s [{}]",
+                      consecutive_unavail * SISL_OPTIONS["avail_delay"].as< uint32_t >(), *dirty.disk)
+            if (!_sleep_check_stop(unavail_delay)) break;
+            probe_mirror(dirty, _offset);
+            continue;
+        }
+        consecutive_unavail = 0;
+
+        _fill_slots(clean, cursor_lba, cursor_sz, cursor_skip_from);
+
+        if (_in_flight > 0) {
+            __kernel_timespec ts{0, 500'000}; // 500µs
+            io_uring_cqe* dummy{};
+            io_uring_submit_and_wait_timeout(&_ring, &dummy, 1, &ts, nullptr);
+            _process_cqes(clean, dirty);
+        } else {
+            // No slots in flight: either the scan pass is complete or all dirty ranges are
+            // conflicting with in-flight writes. Reset the cursor for the next pass and yield.
+            auto const nr_pages = _dirty_bitmap->dirty_pages();
+            if (_metrics) { _metrics->record_dirty_pages(nr_pages); } // GCOVR_EXCL_BR_LINE
+            if (0 == nr_pages) break;                                 // bitmap clean — session complete
+
+            cursor_lba = 0;
+            cursor_sz = 0;
+            cursor_skip_from = 0;
+            _yield_count.fetch_add(1, std::memory_order_relaxed);
+            if (!_sleep_check_stop(avail_delay)) break;
+        }
+    }
+}
+
+// ── Synchronous (sync_iov) fallback path ─────────────────────────────────────────────────────
+//
+// Used when prep_iov_sqe() is unavailable (TestDisk, composite disks, overlayfs).
+// Semantics are identical to the old __run() but without the SLEEPING/STOPPING state machine.
+// stop() is detected via _stop.load() checks instead of CAS transitions.
+
+void Raid1ResyncTask::_run_sync(MirrorDevice& clean, MirrorDevice& dirty) {
+    static auto const unavail_delay = std::chrono::seconds(SISL_OPTIONS["avail_delay"].as< uint32_t >());
+    static auto const avail_delay = std::chrono::microseconds(SISL_OPTIONS["resync_delay"].as< uint32_t >());
+
+    auto nr_pages = _dirty_bitmap->dirty_pages();
+    if (_metrics) { _metrics->record_dirty_pages(nr_pages); } // GCOVR_EXCL_BR_LINE
+
+    auto iov = iovec{.iov_base = nullptr, .iov_len = 0};
+    if (auto err = ::posix_memalign(&iov.iov_base, _io_size, _max_size); 0 != err || !iov.iov_base) [[unlikely]] {
+        // LCOV_EXCL_START
+        RLOGE("Could not allocate I/O buffer: {}", strerror(err))
+        if (iov.iov_base) free(iov.iov_base);
+        return;
+        // LCOV_EXCL_STOP
+    }
+
+    uint32_t consecutive_unavail = 0;
+    uint64_t resync_skip_from = 0;
+
+    while (0 < nr_pages && !_stop.load(std::memory_order_acquire)) {
+        if (dirty.unavail.test(std::memory_order_acquire)) {
+            if (++consecutive_unavail % 10 == 0)
+                RLOGW("Resync blocked: dirty mirror unreachable for ~{}s (probe reads failing) [{}]",
+                      consecutive_unavail * SISL_OPTIONS["avail_delay"].as< uint32_t >(), *dirty.disk)
+            if (!_sleep_check_stop(unavail_delay)) break;
+            probe_mirror(dirty, _offset);
+            nr_pages = _dirty_bitmap->dirty_pages();
+            if (_metrics) _metrics->record_dirty_pages(nr_pages); // GCOVR_EXCL_BR_LINE
+            continue;
+        }
+        consecutive_unavail = 0;
+
+        // TODO Change this so it's easier to control with a future QoS algorithm
+        auto copies_left = ((std::min(32U, SISL_OPTIONS["resync_level"].as< uint32_t >()) * 100U) / 32U) * 5U;
+
+        auto [logical_off, sz] =
+            resync_skip_from > 0 ? _dirty_bitmap->next_dirty_after(resync_skip_from) : _dirty_bitmap->next_dirty();
+        if (0 == sz && resync_skip_from > 0) std::tie(logical_off, sz) = _dirty_bitmap->next_dirty();
+        resync_skip_from = 0;
+
+        bool any_copy = false;
+        while (0 < sz && 0U < copies_left && !_stop.load(std::memory_order_acquire)) {
+            auto const iov_len = std::min(sz, _max_size);
+            auto const gen_before = _region_tracker.snapshot_gen();
+
+            // Phase 1: pre-copy conflict check.
+            if (_region_tracker.overlaps(logical_off, iov_len)) {
+                sz -= iov_len;
+                logical_off += iov_len;
+                if (0 == sz) {
+                    if (!any_copy) {
+                        resync_skip_from = logical_off;
+                        break;
+                    }
+                    std::tie(logical_off, sz) = _dirty_bitmap->next_dirty();
+                    any_copy = false;
+                }
+                continue;
+            }
+
+            iov.iov_len = iov_len;
+            auto res = clean.disk->sync_iov(UBLK_IO_OP_READ, &iov, 1, logical_off + _offset);
+            if (res) {
+                res = dirty.disk->sync_iov(UBLK_IO_OP_WRITE, &iov, 1, logical_off + _offset);
+                if (res) {
+                    // Phase 2: post-copy conflict check.
+                    if (!_region_tracker.overlaps(logical_off, iov_len) &&
+                        !_region_tracker.completed_since(logical_off, iov_len, gen_before)) {
+                        clean_region(logical_off, iov_len, clean);
+                        if (_metrics) { _metrics->record_resync_progress(iov.iov_len); } // GCOVR_EXCL_BR_LINE
+                    }
+                    any_copy = true;
+                    --copies_left;
+                    sz -= iov_len;
+                    logical_off += iov_len;
+                    if (0 == sz) {
+                        std::tie(logical_off, sz) = _dirty_bitmap->next_dirty();
+                        any_copy = false;
+                    }
+                } else {
+                    dirty.unavail.test_and_set(std::memory_order_acquire);
+                    break;
+                }
+            } else {
+                RLOGE("Resync: read from clean disk failed at lba={:#x}: {}", logical_off, res.error().message())
+                break;
+            }
+        }
+
+        _yield_count.fetch_add(1, std::memory_order_relaxed);
+        if (!_sleep_check_stop(dirty.unavail.test(std::memory_order_acquire) ? unavail_delay : avail_delay)) break;
+
+        nr_pages = _dirty_bitmap->dirty_pages();
+        if (_metrics) _metrics->record_dirty_pages(nr_pages); // GCOVR_EXCL_BR_LINE
+    }
+
+    free(iov.iov_base);
+}
+
+// ── Static helpers ────────────────────────────────────────────────────────────────────────────
 
 void Raid1ResyncTask::clean_region(uint64_t addr, uint32_t len, MirrorDevice& clean_mirror) {
     auto const pg_size = _dirty_bitmap->page_size();
@@ -188,189 +462,6 @@ void Raid1ResyncTask::clean_region(uint64_t addr, uint32_t len, MirrorDevice& cl
     }
 }
 
-static inline io_result __copy_region(iovec* iovec, int nr_vecs, uint64_t addr, auto& src, auto& dest) {
-    auto res = src.sync_iov(UBLK_IO_OP_READ, iovec, nr_vecs, addr);
-    if (res) {
-        if (res = dest.sync_iov(UBLK_IO_OP_WRITE, iovec, nr_vecs, addr); !res) {
-            RLOGW("Could not write clean chunks of [sz:{}] [res:{}]", iovec_len(iovec, iovec + nr_vecs),
-                  res.error().message())
-        }
-    } else {
-        RLOGE("Could not read Data of [sz:{}] [res:{}]", iovec_len(iovec, iovec + nr_vecs), res.error().message())
-    }
-    return res;
-}
-
-resync_state Raid1ResyncTask::__run(auto& clean_mirror, auto& dirty_mirror, iovec* iov) noexcept {
-    static auto const unavail_delay = std::chrono::seconds(SISL_OPTIONS["avail_delay"].as< uint32_t >());
-    static auto const avail_delay = std::chrono::microseconds(SISL_OPTIONS["resync_delay"].as< uint32_t >());
-
-    auto cur_state = resync_state::ACTIVE;
-    uint32_t consecutive_unavail = 0;
-
-    auto nr_pages = _dirty_bitmap->dirty_pages();
-    if (_metrics) { _metrics->record_dirty_pages(nr_pages); } // GCOVR_EXCL_BR_LINE
-
-    // When a dirty run is entirely blocked by in-flight writes (!any_copy), skip past it on
-    // the next sweep so higher-LBA dirty runs are not starved. Reset after use within each
-    // sweep; set at end of inner loop to advance past a stuck run on the next sweep.
-    uint64_t resync_skip_from = 0;
-
-    while (0 < nr_pages) {
-        // Skip copies entirely if the dirty mirror is known unavailable
-        if (dirty_mirror->unavail.test(std::memory_order_acquire)) {
-            if (++consecutive_unavail % 10 == 0)
-                RLOGW("Resync blocked: dirty mirror unreachable for ~{}s (probe reads failing) [{}]",
-                      consecutive_unavail * SISL_OPTIONS["avail_delay"].as< uint32_t >(), *dirty_mirror->disk)
-            if (cur_state = __yield(unavail_delay, avail_delay); resync_state::STOPPING == cur_state) break;
-            probe_mirror(*dirty_mirror, _offset);
-            nr_pages = _dirty_bitmap->dirty_pages();
-            if (_metrics) _metrics->record_dirty_pages(nr_pages); // GCOVR_EXCL_BR_LINE
-            continue;
-        }
-        consecutive_unavail = 0;
-
-        // TODO Change this so it's easier to control with a future QoS algorithm
-        auto copies_left = ((std::min(32U, SISL_OPTIONS["resync_level"].as< uint32_t >()) * 100U) / 32U) * 5U;
-
-        // Use the skip cursor if a fully-conflicting run was detected last sweep.
-        auto [logical_off, sz] =
-            resync_skip_from > 0 ? _dirty_bitmap->next_dirty_after(resync_skip_from) : _dirty_bitmap->next_dirty();
-        if (0 == sz && resync_skip_from > 0) // nothing after cursor — wrap to beginning
-            std::tie(logical_off, sz) = _dirty_bitmap->next_dirty();
-        resync_skip_from = 0;
-
-        // copies_left counts copy attempts (read+write to replica); only Phase 1 skips are free.
-        // any_copy tracks whether this inner pass produced at least one copy; if a full
-        // dirty run is exhausted via Phase-1 skips alone, we set resync_skip_from and break
-        // to let __yield() fire, advancing past the stuck run on the next sweep.
-        bool any_copy = false;
-        while (0 < sz && 0U < copies_left) {
-            auto const iov_len = std::min(sz, _max_size);
-
-            // Capture generation before Phase 1 so Phase 2 can detect writes that complete
-            // entirely between the two checks (slot freed before Phase 2 runs).
-            auto const gen_before = _region_tracker.snapshot_gen();
-
-            // Phase 1: pre-copy conflict check — skip this chunk if a write is in-flight
-            // for this range. Advance within the dirty run so unrelated chunks still copy.
-            if (_region_tracker.overlaps(logical_off, iov_len)) {
-                sz -= iov_len;
-                logical_off += iov_len;
-                if (0 == sz) {
-                    if (!any_copy) {
-                        resync_skip_from = logical_off; // advance past conflicting run next sweep
-                        break;
-                    }
-                    std::tie(logical_off, sz) = _dirty_bitmap->next_dirty();
-                    any_copy = false;
-                }
-                continue;
-            }
-
-            iov->iov_len = iov_len;
-            // Copy Region from clean to dirty
-            if (auto res = __copy_region(iov, 1, logical_off + _offset, *clean_mirror->disk, *dirty_mirror->disk);
-                res) {
-                // Phase 2: post-copy conflict check. Two cases require skipping clean_region:
-                //   (a) overlaps() — write is still in-flight (single CAS slot still holds
-                //       the packed value; k_free is not visible until untrack() completes).
-                //   (b) completed_since() — write arrived AND fully completed during the READ
-                //       window; slot freed before Phase 2 ran; shadow log catches this.
-                if (!_region_tracker.overlaps(logical_off, iov_len) &&
-                    !_region_tracker.completed_since(logical_off, iov_len, gen_before)) {
-                    clean_region(logical_off, iov->iov_len, *clean_mirror);
-                    if (_metrics) { _metrics->record_resync_progress(iov->iov_len); } // GCOVR_EXCL_BR_LINE
-                }
-                any_copy = true;
-                --copies_left;
-                sz -= iov_len;
-                logical_off += iov_len;
-                if (0 == sz) {
-                    std::tie(logical_off, sz) = _dirty_bitmap->next_dirty();
-                    any_copy = false;
-                }
-            } else {
-                dirty_mirror->unavail.test_and_set(std::memory_order_acquire);
-                break;
-            }
-        }
-
-        // Yield and check for stopped
-        if (cur_state = __yield(dirty_mirror->unavail.test(std::memory_order_acquire) ? unavail_delay : avail_delay,
-                                avail_delay);
-            resync_state::STOPPING == cur_state)
-            break;
-
-        // Sweep and count dirty pages left
-        nr_pages = _dirty_bitmap->dirty_pages();
-        if (_metrics) _metrics->record_dirty_pages(nr_pages); // GCOVR_EXCL_BR_LINE
-    }
-    return cur_state;
-}
-
-// Abort any on-going resync task by moving to STOPPING and rejoin the thread
-void Raid1ResyncTask::stop() noexcept {
-    auto lg = std::scoped_lock< std::mutex >(_launch_lock);
-    // Targets SLEEPING → STOPPING (waits out ACTIVE first via RETRY_WITH_SLEEP).
-    // Never CAS-es ACTIVE→STOPPING directly — this is what makes the ACTIVE→STOPPING
-    // assert in __yield Phase 1 unreachable.
-    __transition_to(resync_state::SLEEPING, resync_state::STOPPING, [this](resync_state state) -> transition_result {
-        switch (state) {
-        case resync_state::IDLE: {
-            if (_resync_task.joinable()) return {state, transition_action::RETRY_WITH_SLEEP};
-            [[fallthrough]];
-        }
-        case resync_state::STOPPING:
-            return {state, transition_action::SUCCESS};
-        case resync_state::ACTIVE:
-            return {resync_state::SLEEPING, transition_action::RETRY_WITH_SLEEP};
-        case resync_state::SLEEPING: // LCOV_EXCL_START -- 0ns window with resync_delay=0
-            return {state, transition_action::RETRY};
-            // LCOV_EXCL_STOP
-        }
-        std::unreachable();
-    });
-    if (_resync_task.joinable()) _resync_task.join();
-    // If the thread finished naturally (ACTIVE→IDLE) before stop() CAS'd IDLE→STOPPING,
-    // it returned without ever seeing STOPPING and never cleared it. _launch_lock is held
-    // so no concurrent caller can observe this window; reset to IDLE so launch() isn't stuck.
-    for (auto stopping = resync_state::STOPPING;
-         !__cas_state(stopping, resync_state::IDLE) && stopping == resync_state::STOPPING;)
-        std::this_thread::yield();
-}
-
-resync_state Raid1ResyncTask::__yield(std::chrono::microseconds const yield_for,
-                                      std::chrono::microseconds const spin_time) noexcept {
-    _yield_count.fetch_add(1, std::memory_order_relaxed);
-    auto cur_state = resync_state::ACTIVE;
-
-    // Phase 1: Transition ACTIVE→SLEEPING (give I/O a chance to interrupt)
-    while (!__cas_state(cur_state, resync_state::SLEEPING)) {
-        // STOPPING here is unreachable: stop() only CAS SLEEPING→STOPPING,
-        // never ACTIVE→STOPPING, so this loop exits on the first successful CAS.
-        DEBUG_ASSERT_NE(cur_state, resync_state::STOPPING, "impossible ACTIVE→STOPPING transition"); // LCOV_EXCL_LINE
-    }
-    cur_state = resync_state::SLEEPING;
-
-    // Phase 2: Sleep for yield_for, checking for STOPPING periodically
-    auto const end_time = std::chrono::steady_clock::now() + yield_for;
-    while (std::chrono::steady_clock::now() < end_time) {
-        std::this_thread::sleep_for(spin_time);
-        if (resync_state::STOPPING == __load_state()) return resync_state::STOPPING;
-    }
-
-    // Phase 3: Transition SLEEPING→ACTIVE (resume resync)
-    while (!__cas_state(cur_state, resync_state::ACTIVE)) {
-        if (resync_state::STOPPING == cur_state) return cur_state;
-        cur_state = resync_state::SLEEPING; // reset after spurious CAS failure
-    }
-    return resync_state::ACTIVE;
-}
-
-// Probes mirror reachability with a single synchronous page read.
-// Returns true  — device is reachable; unavail flag has been cleared.
-// Returns false — device failed the probe; unavail flag has been set.
 bool Raid1ResyncTask::probe_mirror(MirrorDevice& mirror, uint64_t reserved_size) noexcept {
     alignas(k_page_size) uint8_t probe_buf[k_page_size];
     auto iov = iovec{.iov_base = probe_buf, .iov_len = k_page_size};

--- a/src/raid/raid1/raid1_resync_task.hpp
+++ b/src/raid/raid1/raid1_resync_task.hpp
@@ -6,39 +6,34 @@
 #include <sys/uio.h>
 #include <thread>
 
+extern "C" {
+#include <liburing.h>
+}
+
 #include "metrics/ublk_raid_metrics.hpp"
 #include "raid1_superblock.hpp"
 #include "region_tracker.hpp"
+#include "resync_constants.hpp"
 #include "ublkpp/raid.hpp"
 
 namespace ublkpp::raid1 {
 
 using namespace std::chrono_literals;
-constexpr auto k_state_spin_time = 50us;
 constexpr uint32_t k_default_slot_count = 256;
 
 class Bitmap;
 class MirrorDevice;
 
-// State transitions:
-//   IDLE → ACTIVE (launch())
-//   ACTIVE ⟷ SLEEPING (yield for I/O)
-//   any → STOPPING (shutdown requested)
-//   STOPPING → IDLE (shutdown complete)
-ENUM(resync_state, uint32_t, IDLE = 0, ACTIVE = 1, SLEEPING = 2, STOPPING = 3);
-
-// State transition actions for __transition_to helper
-enum class transition_action : uint8_t {
-    RETRY,            // Continue CAS loop immediately
-    RETRY_WITH_SLEEP, // Sleep k_state_spin_time then retry
-    SUCCESS,          // Exit loop (CAS succeeded or found target state)
-    EARLY_EXIT        // Exit caller function immediately
-};
-
-// Result from state transition handler callback
-struct transition_result {
-    resync_state next_state; // State to expect on next retry
-    transition_action action;
+// One async copy operation in flight: READ from clean → WRITE to dirty.
+// Only used when both disks support prep_iov_sqe(); otherwise sync_iov is used directly.
+struct ResyncSlot {
+    enum class Phase : uint8_t { FREE, READ_PENDING, WRITE_PENDING };
+    Phase phase{Phase::FREE};
+    uint64_t lba{0};
+    uint32_t len{0};
+    uint64_t gen_before{0}; // RegionTracker generation snapshot before the READ SQE was submitted
+    void* buf{nullptr};     // posix_memalign'd I/O buffer; owned by the slot
+    iovec iov{};
 };
 
 class Raid1ResyncTask {
@@ -46,50 +41,68 @@ class Raid1ResyncTask {
     // Global counter for active resyncs across all RAID1 devices
     static inline std::atomic_uint32_t s_active_resyncs{0};
 
-    // Number of times __yield() has been called; used by tests to wait for at least one sweep
+    // Number of times a resync sweep has yielded; tests poll this to wait for ≥1 sweep
     // without relying on wall-clock timing.
     std::atomic< uint64_t > _yield_count{0};
 
     std::shared_ptr< raid1::Bitmap > const _dirty_bitmap;
     std::shared_ptr< ublkpp::UblkRaidMetrics > const _metrics;
 
-    // The smallest I/O both devices support (RAID logical block size)
+    // Smallest I/O both devices support (alignment for posix_memalign).
     uint32_t const _io_size;
-    // The largest I/O both devices support
+    // Largest I/O both devices support (max chunk size per copy op).
     uint32_t const _max_size;
-    // This is the offset we should copy the disks @ to avoid writing on the BITMAP itself.
+    // Byte offset added to every logical address before issuing I/O; skips the on-disk bitmap.
     uint64_t const _offset;
 
-    std::atomic< resync_state > _state{resync_state::IDLE};
-    static_assert(std::atomic< resync_state >::is_always_lock_free);
-
-    // Tracks the LBA range of each in-flight write. Resync checks for overlap before
-    // and after each copy so it only skips regions that actually conflict with a write;
-    // unrelated regions proceed without any global pause.
     RegionTracker _region_tracker;
 
+    // Protects _resync_task.joinable() check in launch() against concurrent callers.
     std::mutex _launch_lock;
     std::thread _resync_task;
 
-    // State access helpers
-    resync_state __load_state() const noexcept { return _state.load(std::memory_order_acquire); }
+    // Set to true by stop() to request the resync thread to exit.
+    std::atomic< bool > _stop{false};
 
-    bool __cas_state(resync_state& expected, resync_state desired) noexcept {
-        return _state.compare_exchange_weak(expected, desired, std::memory_order_acq_rel, std::memory_order_acquire);
-    }
+    // io_uring ring used by the async path; owned exclusively by the resync thread.
+    io_uring _ring{};
+    bool _ring_initialized{false};
 
-    resync_state __run(auto& clean_mirror, auto& dirty_mirror, iovec* iov) noexcept;
+    // Fixed-size slot array for the async pipeline.
+    std::array< ResyncSlot, k_resync_slots > _slots{};
+    uint32_t _in_flight{0}; // count of READ_PENDING + WRITE_PENDING slots
 
-    // Generic state transition helper - reduces duplication across launch/stop.
-    // noinline: gcov attributes inlined template instructions to the call-site line numbers
-    // rather than to the template body, making the entire retry loop appear uncovered.
-    template < typename StateHandler >
-    [[gnu::noinline]] bool __transition_to(resync_state initial, resync_state target, StateHandler&& handler) noexcept;
+    // ── Private helpers ───────────────────────────────────────────────────────────────────────
+    void _run(std::shared_ptr< MirrorDevice > clean, std::shared_ptr< MirrorDevice > dirty,
+              std::function< void() > complete);
 
-    void _start(std::string str_uuid, std::shared_ptr< MirrorDevice >& clean_mirror,
-                std::shared_ptr< MirrorDevice >& dirty_mirror, std::function< void() >&& complete);
+    // Initialise the io_uring ring and per-slot buffers.
+    // Returns true if both disks support prep_iov_sqe() and the ring was set up successfully.
+    // On any failure the ring is left uninitialized and the sync fallback is used.
+    bool _init_ring(ublk_disk& clean_disk, ublk_disk& dirty_disk) noexcept;
 
-    resync_state __yield(std::chrono::microseconds const yield_for, std::chrono::microseconds const spin_time) noexcept;
+    // Async (io_uring) copy loop.  Called when _init_ring() returns true.
+    void _run_uring(MirrorDevice& clean, MirrorDevice& dirty);
+
+    // Fills free async slots with READ SQEs for the next dirty chunks starting at cursor.
+    // cursor_{lba,sz,skip_from} are updated in place as slots are filled.
+    void _fill_slots(MirrorDevice& clean, uint64_t& cursor_lba, uint32_t& cursor_sz,
+                     uint64_t& cursor_skip_from) noexcept;
+
+    // Harvests all available CQEs; submits WRITE SQEs for completed READs and calls
+    // clean_region() for completed WRITEs that pass the Phase-2 check.
+    void _process_cqes(MirrorDevice& clean, MirrorDevice& dirty) noexcept;
+
+    // Submits a cancel-all SQE, drains all CQEs to zero, then calls io_uring_queue_exit().
+    void _drain_and_exit() noexcept;
+
+    // Synchronous (sync_iov) copy loop.  Used as fallback when prep_iov_sqe() is unavailable
+    // (e.g. TestDisk, composite disks).  Behaves identically to the old __run() but without
+    // the SLEEPING/STOPPING state machine — stop() is detected via _stop.load() checks.
+    void _run_sync(MirrorDevice& clean, MirrorDevice& dirty);
+
+    // Sleeps for `dur`, checking _stop every 500µs. Returns false if _stop was set.
+    bool _sleep_check_stop(std::chrono::microseconds dur) noexcept;
 
 public:
     Raid1ResyncTask(std::shared_ptr< raid1::Bitmap >& bitmap, uint64_t offset, uint32_t io_size, uint32_t max_io,
@@ -103,18 +116,18 @@ public:
 
     void clean_region(uint64_t addr, uint32_t len, MirrorDevice& clean_device);
 
+    // Spawn a background resync thread if none is running. No-op if one is already active.
     void launch(std::string const& str_uuid, std::shared_ptr< MirrorDevice > clean_mirror,
                 std::shared_ptr< MirrorDevice > dirty_mirror, std::function< void() >&& complete);
 
-    // Generic method to move Resync StateMachine to STOPPING
+    // Signal the resync thread to stop and block until it exits.
     void stop() noexcept;
 
     void enqueue_write(uint64_t lba, uint32_t len) noexcept { _region_tracker.track(lba, len); }
 
     void dequeue_write(uint64_t lba, uint32_t len) noexcept { _region_tracker.untrack(lba, len); }
 
-    // Number of times __yield() has been called. Tests poll this to wait for at least one
-    // resync sweep without relying on wall-clock timing.
+    // Number of completed sweeps. Tests poll this to wait for ≥N sweeps without wall-clock guessing.
     uint64_t yield_count() const noexcept { return _yield_count.load(std::memory_order_acquire); }
 };
 

--- a/src/raid/raid1/resync_constants.hpp
+++ b/src/raid/raid1/resync_constants.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <cstdint>
+
+namespace ublkpp::raid1 {
+
+// Number of concurrent READ+WRITE slots in the io_uring resync pipeline.
+constexpr uint32_t k_resync_slots = 8;
+
+// Ring depth: k_resync_slots READs + k_resync_slots WRITEs + 1 CANCEL SQE.
+constexpr uint32_t k_resync_ring_depth = k_resync_slots * 2 + 1;
+
+// user_data tag that marks a WRITE SQE. Slot index is stored in the lower byte;
+// OR this tag onto it so process_cqes() can distinguish READ CQEs from WRITE CQEs.
+constexpr uint64_t k_resync_write_tag = 0x100ULL;
+
+// user_data sentinel for the cancel-all SQE submitted by drain_and_exit().
+// Never a valid slot index (k_resync_slots is always < 256).
+constexpr uint64_t k_resync_cancel_tag = 0xFFFFFFFFULL;
+
+} // namespace ublkpp::raid1


### PR DESCRIPTION
Replace the synchronous preadv2/pwritev2 resync with a dedicated thread that owns its own io_uring ring (SINGLE_ISSUER). Up to k_resync_slots=8 READ+WRITE pairs can be in-flight simultaneously, saturating the device throughput instead of serializing one chunk at a time.

State machine (IDLE/ACTIVE/SLEEPING/PAUSE/STOPPING atomic CAS) is eliminated: thread joinable() = ACTIVE, _stop flag = exit signal. Phase 1/2 conflict detection is unchanged (RegionTracker from #253).

New virtual ublk_disk::prep_iov_sqe() lets FSDisk submit SQEs onto a caller-provided ring without exposing the fd. Composite disks and TestDisk return false, triggering the sync_iov fallback (_run_sync) which preserves all existing test behaviour without modification.