### PR TITLE
fix(raid1): ban resync_level=0 at construction time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.32.2] - 2026-05-24
+
+### Changed
+- **Ban `resync_level=0`**: construction now throws `std::runtime_error` if `resync_level` is set
+  to 0. A zero level silently produced zero `copies_left`, causing the resync loop to stall with
+  no forward progress. Valid range is 1–32.
+
 ## [0.32.1] - 2026-05-24
 - Some fixes for gcc-16 compilation
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -10,7 +10,7 @@ required_conan_version = ">=2.0"
 
 class UBlkPPConan(ConanFile):
     name = "ublkpp"
-    version = "0.32.1"
+    version = "0.32.2"
 
     homepage = "https://github.com/szmyd/ublkpp"
     description = "A UBlk library for CPP application"

--- a/src/raid/raid1/raid1.cpp
+++ b/src/raid/raid1/raid1.cpp
@@ -44,9 +44,9 @@ MirrorDevice::MirrorDevice(boost::uuids::uuid const& uuid, std::shared_ptr< ublk
         throw std::runtime_error("Invalid Chunk Size");
     } // LCOV_EXCL_STOP
     if (0 == SISL_OPTIONS["resync_level"].as< uint32_t >()) {
-        RLOGE("Invalid resync_level: 0 [min:1] — use 1-32") // LCOV_EXCL_START
+        RLOGE("Invalid resync_level: 0 [min:1] — use 1-32")
         throw std::runtime_error("resync_level must be at least 1");
-    } // LCOV_EXCL_STOP
+    }
 
     // It is not a failure to be able to load the superblock from a missing-leg placeholder
     if (disk->is_missing()) return;

--- a/src/raid/raid1/raid1.cpp
+++ b/src/raid/raid1/raid1.cpp
@@ -18,7 +18,7 @@
 SISL_OPTION_GROUP(raid1,
                   (chunk_size, "", "chunk_size", "The desired chunk_size for new Raid1 devices",
                    cxxopts::value< std::uint32_t >()->default_value("32768"), "<io_size>"),
-                  (resync_level, "", "resync_level", "Resync prioritization level (0-32)",
+                  (resync_level, "", "resync_level", "Resync prioritization level (1-32)",
                    cxxopts::value< std::uint32_t >()->default_value("4"), "<io_size>"),
                   (resync_delay, "", "resync_delay", "Delay between I/O and Resync context switches",
                    cxxopts::value< std::uint32_t >()->default_value("300"), "<microseconds> (us)"),
@@ -42,6 +42,10 @@ MirrorDevice::MirrorDevice(boost::uuids::uuid const& uuid, std::shared_ptr< ublk
     if (k_min_chunk_size > chunk_size) {
         RLOGE("Invalid chunk_size: {}KiB [min:{}KiB]", chunk_size / Ki, k_min_chunk_size / Ki) // LCOV_EXCL_START
         throw std::runtime_error("Invalid Chunk Size");
+    } // LCOV_EXCL_STOP
+    if (0 == SISL_OPTIONS["resync_level"].as< uint32_t >()) {
+        RLOGE("Invalid resync_level: 0 [min:1] — use 1-32") // LCOV_EXCL_START
+        throw std::runtime_error("resync_level must be at least 1");
     } // LCOV_EXCL_STOP
 
     // It is not a failure to be able to load the superblock from a missing-leg placeholder

--- a/src/raid/raid1/raid1_resync_task.cpp
+++ b/src/raid/raid1/raid1_resync_task.cpp
@@ -268,8 +268,7 @@ resync_state Raid1ResyncTask::__run(auto& clean_mirror, auto& dirty_mirror, iove
                 continue;
             }
 
-            iov->iov_len = iov_len;
-            // Copy Region from clean to dirty
+            iov->iov_len = iov_len; // Copy Region from clean to dirty
             if (auto res = __copy_region(iov, 1, logical_off + _offset, *clean_mirror->disk, *dirty_mirror->disk);
                 res) {
                 // Phase 2: post-copy conflict check. Two cases require skipping clean_region:

--- a/src/raid/raid1/tests/CMakeLists.txt
+++ b/src/raid/raid1/tests/CMakeLists.txt
@@ -37,6 +37,10 @@ target_link_libraries (test_raid1
   $<$<PLATFORM_ID:Linux>:atomic>
 )
 add_test(NAME Raid1Test COMMAND test_raid1 -cv warning)
+# Run ZeroResyncLevelThrows in isolation with resync_level=0 so the global option is set before
+# any MirrorDevice construction; --gtest_filter ensures only this test runs in that invocation.
+add_test(NAME Raid1ZeroResyncLevelThrows
+  COMMAND test_raid1 --resync_level=0 --gtest_filter=Raid1.ZeroResyncLevelThrows -cv warning)
 
 # Set TSAN suppression file for lock-free read path false positives
 if ((DEFINED THREAD_SANITIZER_ON) AND (${THREAD_SANITIZER_ON}))

--- a/src/raid/raid1/tests/misc/edge_cases.cpp
+++ b/src/raid/raid1/tests/misc/edge_cases.cpp
@@ -239,9 +239,11 @@ TEST(Raid1, UncleanShutdownDegraded) {
 }
 
 // Verifies that resync_level=0 is rejected at construction time.
-// This test MUST run in isolation with --resync_level=0; it is not included in the default
-// Raid1Test CTest entry. See CMakeLists.txt: Raid1ZeroResyncLevelThrows target.
+// Only meaningful when the binary is invoked with --resync_level=0; skipped otherwise so
+// the regular Raid1Test CTest entry (resync_level=4) is not affected.
+// See CMakeLists.txt: Raid1ZeroResyncLevelThrows target.
 TEST(Raid1, ZeroResyncLevelThrows) {
+    if (SISL_OPTIONS["resync_level"].as< uint32_t >() != 0) GTEST_SKIP();
     auto device_a = std::make_shared< ublkpp::TestDisk >(TestParams{.capacity = Gi});
     auto device_b = std::make_shared< ublkpp::TestDisk >(TestParams{.capacity = Gi});
     EXPECT_THROW(ublkpp::raid1::Raid1Disk(boost::uuids::string_generator()(test_uuid), device_a, device_b),

--- a/src/raid/raid1/tests/misc/edge_cases.cpp
+++ b/src/raid/raid1/tests/misc/edge_cases.cpp
@@ -237,3 +237,13 @@ TEST(Raid1, UncleanShutdownDegraded) {
     EXPECT_THROW(ublkpp::raid1::Raid1Disk(boost::uuids::string_generator()(test_uuid), device_a, device_b),
                  std::runtime_error);
 }
+
+// Verifies that resync_level=0 is rejected at construction time.
+// This test MUST run in isolation with --resync_level=0; it is not included in the default
+// Raid1Test CTest entry. See CMakeLists.txt: Raid1ZeroResyncLevelThrows target.
+TEST(Raid1, ZeroResyncLevelThrows) {
+    auto device_a = std::make_shared< ublkpp::TestDisk >(TestParams{.capacity = Gi});
+    auto device_b = std::make_shared< ublkpp::TestDisk >(TestParams{.capacity = Gi});
+    EXPECT_THROW(ublkpp::raid1::Raid1Disk(boost::uuids::string_generator()(test_uuid), device_a, device_b),
+                 std::runtime_error);
+}


### PR DESCRIPTION
## Summary

- **Root cause**: with `resync_level=0` the expression `(0 * 100 / 32) * 5 = 0` is assigned to
  `copies_left`; the inner while-loop exits immediately on every sweep with no data copied, so the
  resync task spins indefinitely and the array never recovers from degraded state.
- **Fix**: reject `resync_level=0` eagerly in the `MirrorDevice` constructor (same pattern as
  `chunk_size` validation) — throw `std::runtime_error` at startup rather than silently making no
  progress at runtime. Updated the option description from `(0-32)` to `(1-32)`.
- **Conflict resolution**: rebased onto upstream; upstream's two-phase region-tracker rewrite
  (`#253`) already rewrote `__run`, so the old call-site clamp is dropped in favour of the
  construction-time ban.
- **Version**: bumped to `0.32.2` (behaviour change: previously-silent misconfiguration now throws
  at startup).

## Test plan

- `TEST(Raid1, ZeroResyncLevelThrows)` in `misc/edge_cases.cpp` verifies construction throws with
  `resync_level=0`.
- Dedicated CTest entry `Raid1ZeroResyncLevelThrows` runs `test_raid1 --resync_level=0
  --gtest_filter=Raid1.ZeroResyncLevelThrows` so the global SISL option is set before any
  `MirrorDevice` is constructed; `--gtest_filter` isolates the run from other tests that expect a
  valid level.
- LCOV exclusion annotations removed from the now-covered validation path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)