### PR TITLE
refactor(raid1): eliminate _sb_fields_lock via local-copy in write_superblock

### DIFF
--- a/src/raid/raid1/raid1.cpp
+++ b/src/raid/raid1/raid1.cpp
@@ -333,7 +333,8 @@ bool Raid1Disk::__swap_device(std::string const& outgoing_device_id, std::shared
     _sb->fields.bitmap.age = htobe64(new_age);
 
     // Write superblock to staying device first (critical path).
-    // Lock guards the bitfield byte shared by clean_unmount/read_route/device_b.
+    // write_superblock works on a stack-local copy, so the shared SB bitfield byte
+    // (clean_unmount/read_route/device_b) is never mutated in-place here.
     auto& staying_dev = swapping_device_a ? _device_b : _device_a;
     if (auto sync_res = write_superblock(*staying_dev->disk, _sb.get(), swapping_device_a, new_read_route); !sync_res) {
         RLOGE("Could not advance Age [uuid:{}]: {}", _str_uuid, sync_res.error().message())

--- a/src/raid/raid1/raid1.cpp
+++ b/src/raid/raid1/raid1.cpp
@@ -255,8 +255,12 @@ Raid1Disk::~Raid1Disk() {
     if (!_sb) return;
 
     auto const state = __capture_route_state();
-    // Write out our dirty bitmap
-    if (state.is_degraded && !state.backup_dev->disk->is_missing()) {
+    // Write out our dirty bitmap.
+    // Flush even when the backup is a missing placeholder: the active device always holds the
+    // authoritative bitmap, and persisting it avoids a full resync when the missing disk is
+    // swapped in later. Skipping the flush when backup is missing was the old behaviour and
+    // caused incremental resync to fall back to a full resync unnecessarily (M11).
+    if (state.is_degraded) {
         RLOGI("Synchronizing BITMAP [uuid: {}] to clean device: {}", _str_uuid, *state.active_dev->disk)
         if (auto res = _dirty_bitmap->sync_to(*state.active_dev->disk, sizeof(SuperBlock)); !res) {
             RLOGW("Could not sync Bitmap to device on shutdown, will require full resync next time! [uuid:{}]",
@@ -265,16 +269,24 @@ Raid1Disk::~Raid1Disk() {
         }
         RLOGI("Synchronized: [uuid: {}]", _str_uuid)
     }
-    _sb->fields.clean_unmount = 0x1;
-    // Only update the superblock to clean devices
-    if (auto res = write_superblock(*state.active_dev->disk, _sb.get(), read_route::DEVB == state.route, state.route);
-        !res) {
-        if (state.is_degraded) {
-            RLOGE("Failed to clear clean bit...full sync required upon next assembly [uuid:{}]", _str_uuid)
+    // _sb->fields.{clean_unmount,read_route,device_b} share one byte; hold the lock across
+    // both the direct bitfield write and the write_superblock calls that write the same byte,
+    // eliminating the UB that would arise if an IO/resync thread calls write_superblock
+    // concurrently (even though thread joins ensure this cannot happen in practice).
+    {
+        auto lk = std::scoped_lock< std::mutex >(_sb_fields_lock);
+        _sb->fields.clean_unmount = 0x1;
+        // Only update the superblock to clean devices
+        if (auto res =
+                write_superblock(*state.active_dev->disk, _sb.get(), read_route::DEVB == state.route, state.route);
+            !res) {
+            if (state.is_degraded) {
+                RLOGE("Failed to clear clean bit...full sync required upon next assembly [uuid:{}]", _str_uuid)
+            }
         }
+        if (!state.is_degraded)
+            write_superblock(*state.backup_dev->disk, _sb.get(), read_route::DEVB != state.route, state.route);
     }
-    if (!state.is_degraded)
-        write_superblock(*state.backup_dev->disk, _sb.get(), read_route::DEVB != state.route, state.route);
 }
 
 Raid1Disk::prepare_result Raid1Disk::prepare(ublksrv_queue const* q, int const iouring_device_start) {
@@ -328,20 +340,25 @@ bool Raid1Disk::__swap_device(std::string const& outgoing_device_id, std::shared
     outgoing_dev.swap(incoming_mirror);
     _sb->fields.bitmap.age = htobe64(new_age);
 
-    // Write superblock to staying device first (critical path)
+    // Write superblock to staying device first (critical path).
+    // Lock guards the bitfield byte shared by clean_unmount/read_route/device_b.
     auto& staying_dev = swapping_device_a ? _device_b : _device_a;
-    if (auto sync_res = write_superblock(*staying_dev->disk, _sb.get(), swapping_device_a, new_read_route); !sync_res) {
-        RLOGE("Could not advance Age [uuid:{}]: {}", _str_uuid, sync_res.error().message())
-        // Rollback
-        _sb->fields.bitmap.age = htobe64(old_age);
-        outgoing_dev.swap(incoming_mirror);
-        _read_route_cache.compare_exchange_strong(new_read_route, cur_route);
-        return false;
+    {
+        auto lk = std::scoped_lock< std::mutex >(_sb_fields_lock);
+        if (auto sync_res = write_superblock(*staying_dev->disk, _sb.get(), swapping_device_a, new_read_route);
+            !sync_res) {
+            RLOGE("Could not advance Age [uuid:{}]: {}", _str_uuid, sync_res.error().message())
+            // Rollback
+            _sb->fields.bitmap.age = htobe64(old_age);
+            outgoing_dev.swap(incoming_mirror);
+            _read_route_cache.compare_exchange_strong(new_read_route, cur_route);
+            return false;
+        }
+        // Commit SuperBlock to new device; if this fails it's not fatal per say...could work
+        // later when we become clean; so let's be optimistic!
+        write_superblock(*outgoing_dev->disk, _sb.get(), !swapping_device_a,
+                         _read_route_cache.load(std::memory_order_acquire));
     }
-    // Commit SuperBlock to new device; if this fails it's not fatal per say...could work
-    // later when we become clean; so let's be optimistic!
-    write_superblock(*outgoing_dev->disk, _sb.get(), !swapping_device_a,
-                     _read_route_cache.load(std::memory_order_acquire));
 
     // Dirty entire bitmap if this is a new device
     if (outgoing_dev->new_device) _dirty_bitmap->dirty_region(0, capacity());
@@ -573,13 +590,18 @@ io_result Raid1Disk::__become_clean() {
     // - When route == DEVB: active_dev is B (is_device_b=true), backup_dev is A (is_device_b=false)
     bool const active_is_device_b = (state.route == read_route::DEVB);
 
-    if (auto sync_res = write_superblock(*state.active_dev->disk, _sb.get(), active_is_device_b, read_route::EITHER);
-        !sync_res) {
-        RLOGW("Could not become clean [uuid:{}]: {}", _str_uuid, sync_res.error().message())
-    }
-    if (auto sync_res = write_superblock(*state.backup_dev->disk, _sb.get(), !active_is_device_b, read_route::EITHER);
-        !sync_res) {
-        RLOGW("Could not become clean [uuid:{}]: {}", _str_uuid, sync_res.error().message())
+    {
+        auto lk = std::scoped_lock< std::mutex >(_sb_fields_lock);
+        if (auto sync_res =
+                write_superblock(*state.active_dev->disk, _sb.get(), active_is_device_b, read_route::EITHER);
+            !sync_res) {
+            RLOGW("Could not become clean [uuid:{}]: {}", _str_uuid, sync_res.error().message())
+        }
+        if (auto sync_res =
+                write_superblock(*state.backup_dev->disk, _sb.get(), !active_is_device_b, read_route::EITHER);
+            !sync_res) {
+            RLOGW("Could not become clean [uuid:{}]: {}", _str_uuid, sync_res.error().message())
+        }
     }
 
     // Avoid checking DirtyBitmap going forward on reads/writes
@@ -607,7 +629,6 @@ io_result Raid1Disk::__become_degraded(bool failed_is_active, RouteState const* 
     auto& failed_device = failed_is_active ? cur_state->active_dev : cur_state->backup_dev;
     auto& working_device = failed_is_active ? *cur_state->backup_dev->disk : *cur_state->active_dev->disk;
 
-    auto const old_age = _sb->fields.bitmap.age;
     _sb->fields.bitmap.age = htobe64(be64toh(_sb->fields.bitmap.age) + 1);
     RLOGW("Device became degraded {} [age:{}] [uuid:{}]", *failed_device->disk,
           static_cast< uint64_t >(be64toh(_sb->fields.bitmap.age)), _str_uuid);
@@ -621,13 +642,21 @@ io_result Raid1Disk::__become_degraded(bool failed_is_active, RouteState const* 
     } // LCOV_EXCL_STOP
 
     // Must update age first; we do this synchronously to gate pending retry results
-    if (auto sync_res = write_superblock(working_device, _sb.get(), backup_clean, new_route); !sync_res) {
+    auto sync_res = [&]() {
+        auto lk = std::scoped_lock< std::mutex >(_sb_fields_lock);
+        return write_superblock(working_device, _sb.get(), backup_clean, new_route);
+    }();
+    if (!sync_res) {
         // SB write failed -- we cannot persist the degradation, but rolling back to EITHER would
         // allow round-robin reads to the failed device, serving inconsistent data (the backup may
         // have already received the write). Keep the in-memory degraded route and mark the failed
         // device unavailable. The dirty bitmap covers the affected region; resync at shutdown or a
         // full recovery on next start will reconcile any inconsistency.
-        _sb->fields.bitmap.age = old_age; // revert age -- not written to disk
+        //
+        // Do NOT revert _sb->fields.bitmap.age here: the in-memory route is already degraded
+        // (the CAS above succeeded), so a later successful SB write must persist the incremented
+        // age. Reverting age while keeping new_route active would make on-disk state appear
+        // pre-degradation, corrupting device selection on restart.
         failed_device->unavail.test_and_set(std::memory_order_acquire);
         RLOGE("Could not persist degradation [uuid:{}]: {}", _str_uuid, sync_res.error().message())
         return sync_res;

--- a/src/raid/raid1/raid1.cpp
+++ b/src/raid/raid1/raid1.cpp
@@ -269,24 +269,16 @@ Raid1Disk::~Raid1Disk() {
         }
         RLOGI("Synchronized: [uuid: {}]", _str_uuid)
     }
-    // _sb->fields.{clean_unmount,read_route,device_b} share one byte; hold the lock across
-    // both the direct bitfield write and the write_superblock calls that write the same byte,
-    // eliminating the UB that would arise if an IO/resync thread calls write_superblock
-    // concurrently (even though thread joins ensure this cannot happen in practice).
-    {
-        auto lk = std::scoped_lock< std::mutex >(_sb_fields_lock);
-        _sb->fields.clean_unmount = 0x1;
-        // Only update the superblock to clean devices
-        if (auto res =
-                write_superblock(*state.active_dev->disk, _sb.get(), read_route::DEVB == state.route, state.route);
-            !res) {
-            if (state.is_degraded) {
-                RLOGE("Failed to clear clean bit...full sync required upon next assembly [uuid:{}]", _str_uuid)
-            }
+    _sb->fields.clean_unmount = 0x1;
+    // Only update the superblock to clean devices
+    if (auto res = write_superblock(*state.active_dev->disk, _sb.get(), read_route::DEVB == state.route, state.route);
+        !res) {
+        if (state.is_degraded) {
+            RLOGE("Failed to clear clean bit...full sync required upon next assembly [uuid:{}]", _str_uuid)
         }
-        if (!state.is_degraded)
-            write_superblock(*state.backup_dev->disk, _sb.get(), read_route::DEVB != state.route, state.route);
     }
+    if (!state.is_degraded)
+        write_superblock(*state.backup_dev->disk, _sb.get(), read_route::DEVB != state.route, state.route);
 }
 
 Raid1Disk::prepare_result Raid1Disk::prepare(ublksrv_queue const* q, int const iouring_device_start) {
@@ -343,22 +335,18 @@ bool Raid1Disk::__swap_device(std::string const& outgoing_device_id, std::shared
     // Write superblock to staying device first (critical path).
     // Lock guards the bitfield byte shared by clean_unmount/read_route/device_b.
     auto& staying_dev = swapping_device_a ? _device_b : _device_a;
-    {
-        auto lk = std::scoped_lock< std::mutex >(_sb_fields_lock);
-        if (auto sync_res = write_superblock(*staying_dev->disk, _sb.get(), swapping_device_a, new_read_route);
-            !sync_res) {
-            RLOGE("Could not advance Age [uuid:{}]: {}", _str_uuid, sync_res.error().message())
-            // Rollback
-            _sb->fields.bitmap.age = htobe64(old_age);
-            outgoing_dev.swap(incoming_mirror);
-            _read_route_cache.compare_exchange_strong(new_read_route, cur_route);
-            return false;
-        }
-        // Commit SuperBlock to new device; if this fails it's not fatal per say...could work
-        // later when we become clean; so let's be optimistic!
-        write_superblock(*outgoing_dev->disk, _sb.get(), !swapping_device_a,
-                         _read_route_cache.load(std::memory_order_acquire));
+    if (auto sync_res = write_superblock(*staying_dev->disk, _sb.get(), swapping_device_a, new_read_route); !sync_res) {
+        RLOGE("Could not advance Age [uuid:{}]: {}", _str_uuid, sync_res.error().message())
+        // Rollback
+        _sb->fields.bitmap.age = htobe64(old_age);
+        outgoing_dev.swap(incoming_mirror);
+        _read_route_cache.compare_exchange_strong(new_read_route, cur_route);
+        return false;
     }
+    // Commit SuperBlock to new device; if this fails it's not fatal per say...could work
+    // later when we become clean; so let's be optimistic!
+    write_superblock(*outgoing_dev->disk, _sb.get(), !swapping_device_a,
+                     _read_route_cache.load(std::memory_order_acquire));
 
     // Dirty entire bitmap if this is a new device
     if (outgoing_dev->new_device) _dirty_bitmap->dirty_region(0, capacity());
@@ -590,18 +578,13 @@ io_result Raid1Disk::__become_clean() {
     // - When route == DEVB: active_dev is B (is_device_b=true), backup_dev is A (is_device_b=false)
     bool const active_is_device_b = (state.route == read_route::DEVB);
 
-    {
-        auto lk = std::scoped_lock< std::mutex >(_sb_fields_lock);
-        if (auto sync_res =
-                write_superblock(*state.active_dev->disk, _sb.get(), active_is_device_b, read_route::EITHER);
-            !sync_res) {
-            RLOGW("Could not become clean [uuid:{}]: {}", _str_uuid, sync_res.error().message())
-        }
-        if (auto sync_res =
-                write_superblock(*state.backup_dev->disk, _sb.get(), !active_is_device_b, read_route::EITHER);
-            !sync_res) {
-            RLOGW("Could not become clean [uuid:{}]: {}", _str_uuid, sync_res.error().message())
-        }
+    if (auto sync_res = write_superblock(*state.active_dev->disk, _sb.get(), active_is_device_b, read_route::EITHER);
+        !sync_res) {
+        RLOGW("Could not become clean [uuid:{}]: {}", _str_uuid, sync_res.error().message())
+    }
+    if (auto sync_res = write_superblock(*state.backup_dev->disk, _sb.get(), !active_is_device_b, read_route::EITHER);
+        !sync_res) {
+        RLOGW("Could not become clean [uuid:{}]: {}", _str_uuid, sync_res.error().message())
     }
 
     // Avoid checking DirtyBitmap going forward on reads/writes
@@ -642,10 +625,7 @@ io_result Raid1Disk::__become_degraded(bool failed_is_active, RouteState const* 
     } // LCOV_EXCL_STOP
 
     // Must update age first; we do this synchronously to gate pending retry results
-    auto sync_res = [&]() {
-        auto lk = std::scoped_lock< std::mutex >(_sb_fields_lock);
-        return write_superblock(working_device, _sb.get(), backup_clean, new_route);
-    }();
+    auto sync_res = write_superblock(working_device, _sb.get(), backup_clean, new_route);
     if (!sync_res) {
         // SB write failed -- we cannot persist the degradation, but rolling back to EITHER would
         // allow round-robin reads to the failed device, serving inconsistent data (the backup may

--- a/src/raid/raid1/raid1_impl.hpp
+++ b/src/raid/raid1/raid1_impl.hpp
@@ -50,6 +50,12 @@ class Raid1Disk : public ublk_disk {
     //         (2) _pending_results - serializes prepare() insertions across queue threads.
     std::mutex _ctrl_lock;
 
+    // Guards all writes to _sb->fields bitfields (clean_unmount, read_route, device_b).
+    // Those three bitfields share a single byte in the packed SuperBlock struct; concurrent
+    // writes from different threads (IO/resync paths vs. destructor) are C++ UB even when
+    // execution ordering via join() prevents the actual data race at runtime.
+    mutable std::mutex _sb_fields_lock;
+
     // Counts prepare() calls; used to enable resync on the first queue init.
     std::atomic_uint16_t _nr_hw_queues{0};
 

--- a/src/raid/raid1/raid1_impl.hpp
+++ b/src/raid/raid1/raid1_impl.hpp
@@ -50,12 +50,6 @@ class Raid1Disk : public ublk_disk {
     //         (2) _pending_results - serializes prepare() insertions across queue threads.
     std::mutex _ctrl_lock;
 
-    // Guards all writes to _sb->fields bitfields (clean_unmount, read_route, device_b).
-    // Those three bitfields share a single byte in the packed SuperBlock struct; concurrent
-    // writes from different threads (IO/resync paths vs. destructor) are C++ UB even when
-    // execution ordering via join() prevents the actual data race at runtime.
-    mutable std::mutex _sb_fields_lock;
-
     // Counts prepare() calls; used to enable resync on the first queue init.
     std::atomic_uint16_t _nr_hw_queues{0};
 

--- a/src/raid/raid1/raid1_superblock.cpp
+++ b/src/raid/raid1/raid1_superblock.cpp
@@ -61,9 +61,14 @@ io_result write_superblock(ublk_disk& device, raid1::SuperBlock const* sb, bool 
     auto const sb_size = sizeof(raid1::SuperBlock);
     DEBUG_ASSERT_EQ(0, sb_size % device.block_size(), "Device {} blocksize does not support alignment of [{}B]", device,
                     sb_size)
-    // Work on a stack copy so the shared SB is never mutated — eliminates the data race between
-    // concurrent write_superblock callers (__become_clean vs __become_degraded) on the packed byte
-    // that holds clean_unmount, read_route, and device_b.
+    // Work on a stack copy so the shared SB is never mutated by write_superblock itself.
+    // This eliminates the write-write race between concurrent callers (__become_clean vs
+    // __become_degraded) on the packed bitfield byte shared by clean_unmount, read_route,
+    // and device_b — the most dangerous form because compilers generate non-atomic RMW sequences
+    // for bitfields and can silently corrupt adjacent bits.
+    // Note: the struct copy is still an unsynchronised read of _sb->fields.bitmap.age if
+    // __become_degraded is concurrently incrementing it; that is a pre-existing race not
+    // introduced here (it existed when write_superblock mutated the shared struct in-place).
     auto local = *sb;
     local.fields.read_route = static_cast< uint8_t >(read_route);
     local.fields.device_b = device_b ? 1 : 0;

--- a/src/raid/raid1/raid1_superblock.cpp
+++ b/src/raid/raid1/raid1_superblock.cpp
@@ -56,16 +56,20 @@ static raid1::SuperBlock* read_superblock(ublk_disk& device) {
     return static_cast< raid1::SuperBlock* >(iov.iov_base);
 }
 
-io_result write_superblock(ublk_disk& device, raid1::SuperBlock* sb, bool device_b, raid1::read_route read_route) {
+io_result write_superblock(ublk_disk& device, raid1::SuperBlock const* sb, bool device_b,
+                           raid1::read_route read_route) {
     auto const sb_size = sizeof(raid1::SuperBlock);
     DEBUG_ASSERT_EQ(0, sb_size % device.block_size(), "Device {} blocksize does not support alignment of [{}B]", device,
                     sb_size)
-    sb->fields.read_route = static_cast< uint8_t >(read_route);
-    if (device_b) sb->fields.device_b = 1;
-    auto iov = iovec{.iov_base = sb, .iov_len = sb_size};
+    // Work on a stack copy so the shared SB is never mutated — eliminates the data race between
+    // concurrent write_superblock callers (__become_clean vs __become_degraded) on the packed byte
+    // that holds clean_unmount, read_route, and device_b.
+    auto local = *sb;
+    local.fields.read_route = static_cast< uint8_t >(read_route);
+    local.fields.device_b = device_b ? 1 : 0;
+    auto iov = iovec{.iov_base = &local, .iov_len = sb_size};
     auto res = device.sync_iov(UBLK_IO_OP_WRITE, &iov, 1, 0UL);
-    RLOGI("Wrote: {} to: {}", *sb, device)
-    sb->fields.device_b = 0;
+    RLOGI("Wrote: {} to: {}", local, device)
     if (!res) RLOGE("Error writing Superblock to: {}: {}", device, res.error().message())
     return res;
 }

--- a/src/raid/raid1/raid1_superblock.cpp
+++ b/src/raid/raid1/raid1_superblock.cpp
@@ -61,15 +61,20 @@ io_result write_superblock(ublk_disk& device, raid1::SuperBlock const* sb, bool 
     auto const sb_size = sizeof(raid1::SuperBlock);
     DEBUG_ASSERT_EQ(0, sb_size % device.block_size(), "Device {} blocksize does not support alignment of [{}B]", device,
                     sb_size)
-    // Work on a stack copy so the shared SB is never mutated by write_superblock itself.
-    // This eliminates the write-write race between concurrent callers (__become_clean vs
-    // __become_degraded) on the packed bitfield byte shared by clean_unmount, read_route,
-    // and device_b — the most dangerous form because compilers generate non-atomic RMW sequences
+    // Build a local write buffer with the per-call bitfield values.
+    // Only header + fields (first 74 bytes) are copied from the shared SB.
+    // superbitmap_reserved is left zero in this write because SuperBitmap::set_bit modifies
+    // that region concurrently via atomic ops, and copying it non-atomically is a data race
+    // (TSan: non-atomic 8-byte load at offset 72 overlaps atomic fetch_or at offset 74).
+    // Zero superbitmap_reserved is the safe fallback: on next startup the bitmap layer does
+    // a full page scan to rebuild the super-index — correct, no data-loss risk.
+    // The live in-memory _sb->superbitmap_reserved is unaffected.
+    // This also eliminates the write-write race between concurrent write_superblock callers
+    // (__become_clean vs __become_degraded) on the packed bitfield byte shared by
+    // clean_unmount, read_route, and device_b — compilers generate non-atomic RMW sequences
     // for bitfields and can silently corrupt adjacent bits.
-    // Note: the struct copy is still an unsynchronised read of _sb->fields.bitmap.age if
-    // __become_degraded is concurrently incrementing it; that is a pre-existing race not
-    // introduced here (it existed when write_superblock mutated the shared struct in-place).
-    auto local = *sb;
+    alignas(4096) SuperBlock local{};
+    memcpy(&local, sb, offsetof(SuperBlock, superbitmap_reserved));
     local.fields.read_route = static_cast< uint8_t >(read_route);
     local.fields.device_b = device_b ? 1 : 0;
     auto iov = iovec{.iov_base = &local, .iov_len = sb_size};

--- a/src/raid/raid1/raid1_superblock.hpp
+++ b/src/raid/raid1/raid1_superblock.hpp
@@ -58,7 +58,7 @@ static_assert(offsetof(SuperBlock, superbitmap_reserved) == 74, "SuperBlock::sup
 auto format_as(SuperBlock const& sb);
 
 extern SuperBlock* pick_superblock(SuperBlock* dev_a, raid1::SuperBlock* dev_b);
-extern io_result write_superblock(ublk_disk& device, raid1::SuperBlock* sb, bool device_b, read_route read_route);
+extern io_result write_superblock(ublk_disk& device, raid1::SuperBlock const* sb, bool device_b, read_route read_route);
 extern std::expected< std::pair< raid1::SuperBlock*, bool >, std::error_condition >
 load_superblock(ublk_disk& device, boost::uuids::uuid const& uuid, uint32_t const chunk_size);
 

--- a/src/raid/raid1/tests/superblock/missing_disk.cpp
+++ b/src/raid/raid1/tests/superblock/missing_disk.cpp
@@ -117,8 +117,7 @@ TEST(Raid1, DegradedMissingBackupSyncsBitmapAtShutdown) {
     // SB writes at offset 0: __become_active (clean_unmount=0) + destructor (clean_unmount=1).
     EXPECT_CALL(*device_a, sync_iov(UBLK_IO_OP_WRITE, _, _, (off_t)0))
         .Times(2)
-        .WillRepeatedly(
-            [](uint8_t, iovec* iovecs, uint32_t, off_t) -> io_result { return ublkpp::raid1::k_page_size; });
+        .WillRepeatedly([](uint8_t, iovec*, uint32_t, off_t) -> io_result { return ublkpp::raid1::k_page_size; });
 
     // Writes at offset > 0: data write (via sync_iov) + bitmap page write (via sync_to in destructor).
     // The bitmap write is the M11 regression check: it only happens if sync_to() is called even

--- a/src/raid/raid1/tests/superblock/missing_disk.cpp
+++ b/src/raid/raid1/tests/superblock/missing_disk.cpp
@@ -97,3 +97,47 @@ TEST(Raid1, MissingDisks) {
     EXPECT_THROW(ublkpp::raid1::Raid1Disk(boost::uuids::string_generator()(test_uuid), device_a, device_b),
                  std::runtime_error);
 }
+
+// M11 regression: when the array is degraded because the backup is a missing-leg placeholder,
+// the destructor must still call sync_to() to persist the dirty bitmap to the active device.
+// The old condition was (is_degraded && !backup->is_missing()), which skipped the sync when
+// backup was a missing placeholder — causing the next swap-in to fall back to a full resync.
+TEST(Raid1, DegradedMissingBackupSyncsBitmapAtShutdown) {
+    auto device_a = std::make_shared< ublkpp::TestDisk >(TestParams{.capacity = Gi});
+    auto device_b = ublkpp::make_missing_disk();
+
+    // SB read during construction (normal_superblock: clean, route=EITHER).
+    EXPECT_CALL(*device_a, sync_iov(UBLK_IO_OP_READ, _, _, _))
+        .Times(1)
+        .WillOnce([](uint8_t, iovec* iovecs, uint32_t, off_t) -> io_result {
+            memcpy(iovecs->iov_base, &normal_superblock, ublkpp::raid1::k_page_size);
+            return ublkpp::raid1::k_page_size;
+        });
+
+    // SB writes at offset 0: __become_active (clean_unmount=0) + destructor (clean_unmount=1).
+    EXPECT_CALL(*device_a, sync_iov(UBLK_IO_OP_WRITE, _, _, (off_t)0))
+        .Times(2)
+        .WillRepeatedly(
+            [](uint8_t, iovec* iovecs, uint32_t, off_t) -> io_result { return ublkpp::raid1::k_page_size; });
+
+    // Writes at offset > 0: data write (via sync_iov) + bitmap page write (via sync_to in destructor).
+    // The bitmap write is the M11 regression check: it only happens if sync_to() is called even
+    // though the backup device is a missing placeholder.
+    EXPECT_CALL(*device_a, sync_iov(UBLK_IO_OP_WRITE, _, _, testing::Gt((off_t)0)))
+        .Times(2)
+        .WillRepeatedly([](uint8_t, iovec* iovecs, uint32_t nr_vecs, off_t) -> io_result {
+            return ublkpp::iovec_len(iovecs, iovecs + nr_vecs);
+        });
+
+    {
+        auto raid_device = ublkpp::raid1::Raid1Disk(boost::uuids::string_generator()(test_uuid), device_a, device_b);
+
+        // Write marks a bitmap page dirty; the failed write to missing_device is silently absorbed
+        // (we're already degraded) and dirty_region() is called for the affected LBA range.
+        auto iov = iovec{.iov_base = nullptr, .iov_len = 4 * Ki};
+        ASSERT_TRUE(raid_device.sync_iov(UBLK_IO_OP_WRITE, &iov, 1, 0));
+
+        // Destructor: sync_to() writes the dirty bitmap page to device_a (Times(2) above),
+        // then the clean-unmount SB write (counted in the offset-0 Times(2) above).
+    }
+}


### PR DESCRIPTION
## Summary

Replaces the `_sb_fields_lock` mutex from #273 with a lock-free approach: `write_superblock` now takes `const SuperBlock*` and works on a stack-local copy, setting `read_route` and `device_b` on the copy before the disk write. The shared `_sb` is never mutated inside `write_superblock`, so concurrent callers cannot race on the bitfield byte and no lock is needed.

**TSan fix**: a naive `auto local = *sb` full-struct copy generates a non-atomic 8-byte load at offset 72 that spans into `superbitmap_reserved` (offset 74), which `SuperBitmap::set_bit` writes concurrently via `atomic_ref::fetch_or`. TSan flags this correctly. Fix: `memcpy` only `header` + `fields` (first 74 bytes = `offsetof(SuperBlock, superbitmap_reserved)`); `superbitmap_reserved` is left zero in the write buffer. Zero on-disk superbitmap is safe — startup does a full bitmap page scan to rebuild the super-index, which is the correct fallback with no data-loss risk. The live in-memory `_sb->superbitmap_reserved` is unaffected.

Stacks on top of #273.

## Test plan

- [ ] `GccThreadSanitize` CI job passes (previously failed with WriteDuringSwap TSan report on `superbitmap_reserved`)
- [ ] All existing raid1 unit tests pass (`GccCoverage`, `GccAddressSanitize`, `ClangRelease`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)