### PR TITLE
fix(raid1): snapshot iovecs in __failover_read_async to prevent stale-iovec corruption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.32.4] - 2026-05-25
+### Fixed
+- raid1: Make stable copy of iovecs in __failover_read
+
 ## [0.32.3] - 2026-05-25
 ### Fixed
 - raid1: Remove Optimistic write path which can now race with region tracked resync.

--- a/conanfile.py
+++ b/conanfile.py
@@ -10,7 +10,7 @@ required_conan_version = ">=2.0"
 
 class UBlkPPConan(ConanFile):
     name = "ublkpp"
-    version = "0.32.3"
+    version = "0.32.4"
 
     homepage = "https://github.com/szmyd/ublkpp"
     description = "A UBlk library for CPP application"

--- a/src/raid/raid1/raid1.cpp
+++ b/src/raid/raid1/raid1.cpp
@@ -661,7 +661,11 @@ disk_task< int > Raid1Disk::__failover_read_async(ublksrv_queue const* q, ublk_i
     // Snapshot before first co_await: in RAID10, iovecs points into RAID0's thread_local
     // sub_cmds. Once we suspend, concurrent I/Os on the same queue thread can overwrite
     // sub_cmds, making iovecs stale when the failover SQE is submitted.
-    auto iov_snap = std::vector< iovec >(iovecs, iovecs + nr_vecs);
+    // nr_vecs is bounded by StripeAccum::io_array (16 entries) or 1 from ublkpp_tgt.
+    // std::array avoids an additional heap allocation; the coroutine frame is already heap-allocated.
+    DEBUG_ASSERT_LE(nr_vecs, 16u)
+    std::array< iovec, 16 > iov_snap{};
+    std::copy_n(iovecs, nr_vecs, iov_snap.begin());
     iovecs = iov_snap.data();
 
     auto const state = __capture_route_state();

--- a/src/raid/raid1/raid1.cpp
+++ b/src/raid/raid1/raid1.cpp
@@ -658,6 +658,12 @@ io_result Raid1Disk::__become_degraded(bool failed_is_active, RouteState const* 
 
 disk_task< int > Raid1Disk::__failover_read_async(ublksrv_queue const* q, ublk_io_data const* data, iovec* iovecs,
                                                   uint32_t nr_vecs, uint64_t addr, uint32_t len) {
+    // Snapshot before first co_await: in RAID10, iovecs points into RAID0's thread_local
+    // sub_cmds. Once we suspend, concurrent I/Os on the same queue thread can overwrite
+    // sub_cmds, making iovecs stale when the failover SQE is submitted.
+    auto iov_snap = std::vector< iovec >(iovecs, iovecs + nr_vecs);
+    iovecs = iov_snap.data();
+
     auto const state = __capture_route_state();
     auto devices = __select_read_devices(state, addr, len);
     auto& primary_dev = devices.first;

--- a/src/raid/raid1/tests/asyncio/CMakeLists.txt
+++ b/src/raid/raid1/tests/asyncio/CMakeLists.txt
@@ -5,6 +5,7 @@ list(APPEND RAID1_TEST_SRCS
   asyncio/degraded.cpp
   asyncio/discard.cpp
   asyncio/failover.cpp
+  asyncio/failover_stale_iov.cpp
   asyncio/flush.cpp
   asyncio/idle.cpp
   asyncio/read_fail_degraded_dirty.cpp

--- a/src/raid/raid1/tests/asyncio/failover_stale_iov.cpp
+++ b/src/raid/raid1/tests/asyncio/failover_stale_iov.cpp
@@ -4,41 +4,46 @@
 //
 // In RAID10, RAID0::__distribute populates thread_local sub_cmds and passes iovecs pointing
 // into it to RAID1::async_iov. While __failover_read_async is suspended at co_await
-// primary_task, a concurrent I/O on the same queue thread can overwrite sub_cmds, leaving
-// iovecs stale when the failover SQE is submitted.
+// primary_task, a concurrent I/O on the same queue thread can overwrite sub_cmds. The fix
+// snapshots iovecs into a frame-local array before the first co_await.
 //
-// The fix snapshots iovecs into a coroutine-frame-local copy before the first co_await so
-// the failover always uses the original values. This test simulates the race by mutating the
-// caller-side iov after the primary is in-flight and verifying the failover still sees the
-// original iov_len.
+// This test simulates the race by mutating the caller-side iov (MockUblksrv's TagState::iov,
+// analogous to sub_cmds) after the primary is in-flight. The failover must see the original
+// iov_base and iov_len, not the stale values.
 TEST_F(AsyncRaid1Fixture, FailoverUsesSnapshotIovecNotStaleCopy) {
+    // Thread is required: __select_read_devices uses thread_local last_read for round-robin
+    // routing. Running in a fresh thread prevents this test from mutating that state and
+    // causing routing surprises in other tests that share the main gtest thread.
     std::thread([this] {
         constexpr size_t k_req_len = 4 * Ki;
-        constexpr size_t k_stale_len = 128 * Ki;
 
-        // Capture the iov_len that disk_b's submit_iov receives during the failover.
-        size_t failover_iov_len = 0;
+        auto* const buf = mock->io_buf(0);
+        iovec captured_failover_iov{};
+
         EXPECT_CALL(*disk_b, submit_iov(_, _, _, _, _))
-            .WillOnce([&failover_iov_len](ublksrv_queue const*, ublk_io_data const*, iovec* iov, uint32_t,
-                                          uint64_t) -> io_result {
-                failover_iov_len = iov->iov_len;
+            .WillOnce([&captured_failover_iov](ublksrv_queue const*, ublk_io_data const*, iovec* iov, uint32_t,
+                                               uint64_t) -> io_result {
+                captured_failover_iov = *iov;
                 return 1;
             });
 
-        auto res = mock->submit_io(0, UBLK_IO_OP_READ, 0, k_req_len / 512, nullptr);
+        auto res = mock->submit_io(0, UBLK_IO_OP_READ, 0, k_req_len / 512, buf);
         ASSERT_TRUE(res);
         EXPECT_EQ(res.value(), 1u);
 
-        // Simulate concurrent I/O overwriting thread_local sub_cmds: mutate the
-        // caller-side iov_len after the primary is in-flight. Without the snapshot fix,
-        // the failover would use this stale value; with the fix it sees the original 4 KiB.
-        mock->iov_ref(0).iov_len = k_stale_len;
+        // Simulate sub_cmds overwrite: stomp both iov_base and iov_len on the caller-side iov
+        // after the primary is in-flight. Without the snapshot fix, the failover would use these
+        // stale values and read into the wrong buffer with the wrong length.
+        auto& orig_iov = mock->iov_ref(0);
+        orig_iov.iov_base = reinterpret_cast< void* >(static_cast< uintptr_t >(0xdeadbeef));
+        orig_iov.iov_len = 128 * Ki;
 
         // Primary fails (simulating SIGKILL'd AM) -> failover starts synchronously.
         EXPECT_TRUE(mock->inject_cqe(0, -EIO).empty());
 
-        // Failover must have used the snapshotted iov_len (4 KiB), not the stale 128 KiB.
-        EXPECT_EQ(failover_iov_len, k_req_len);
+        // Failover must have used the snapshotted iov_base/iov_len, not the stale values.
+        EXPECT_EQ(captured_failover_iov.iov_base, buf);
+        EXPECT_EQ(captured_failover_iov.iov_len, k_req_len);
 
         auto completions = mock->inject_cqe(0, static_cast< int >(k_req_len));
         ASSERT_EQ(completions.size(), 1u);

--- a/src/raid/raid1/tests/asyncio/failover_stale_iov.cpp
+++ b/src/raid/raid1/tests/asyncio/failover_stale_iov.cpp
@@ -1,0 +1,47 @@
+#include "async_raid1_common.hpp"
+
+// Regression test for stale iovec in the RAID1 failover read path.
+//
+// In RAID10, RAID0::__distribute populates thread_local sub_cmds and passes iovecs pointing
+// into it to RAID1::async_iov. While __failover_read_async is suspended at co_await
+// primary_task, a concurrent I/O on the same queue thread can overwrite sub_cmds, leaving
+// iovecs stale when the failover SQE is submitted.
+//
+// The fix snapshots iovecs into a coroutine-frame-local copy before the first co_await so
+// the failover always uses the original values. This test simulates the race by mutating the
+// caller-side iov after the primary is in-flight and verifying the failover still sees the
+// original iov_len.
+TEST_F(AsyncRaid1Fixture, FailoverUsesSnapshotIovecNotStaleCopy) {
+    std::thread([this] {
+        constexpr size_t k_req_len = 4 * Ki;
+        constexpr size_t k_stale_len = 128 * Ki;
+
+        // Capture the iov_len that disk_b's submit_iov receives during the failover.
+        size_t failover_iov_len = 0;
+        EXPECT_CALL(*disk_b, submit_iov(_, _, _, _, _))
+            .WillOnce([&failover_iov_len](ublksrv_queue const*, ublk_io_data const*, iovec* iov, uint32_t,
+                                          uint64_t) -> io_result {
+                failover_iov_len = iov->iov_len;
+                return 1;
+            });
+
+        auto res = mock->submit_io(0, UBLK_IO_OP_READ, 0, k_req_len / 512, nullptr);
+        ASSERT_TRUE(res);
+        EXPECT_EQ(res.value(), 1u);
+
+        // Simulate concurrent I/O overwriting thread_local sub_cmds: mutate the
+        // caller-side iov_len after the primary is in-flight. Without the snapshot fix,
+        // the failover would use this stale value; with the fix it sees the original 4 KiB.
+        mock->iov_ref(0).iov_len = k_stale_len;
+
+        // Primary fails (simulating SIGKILL'd AM) -> failover starts synchronously.
+        EXPECT_TRUE(mock->inject_cqe(0, -EIO).empty());
+
+        // Failover must have used the snapshotted iov_len (4 KiB), not the stale 128 KiB.
+        EXPECT_EQ(failover_iov_len, k_req_len);
+
+        auto completions = mock->inject_cqe(0, static_cast< int >(k_req_len));
+        ASSERT_EQ(completions.size(), 1u);
+        EXPECT_EQ(completions[0].result, static_cast< int >(k_req_len));
+    }).join();
+}

--- a/src/tests/mock_ublksrv/mock_ublksrv.hpp
+++ b/src/tests/mock_ublksrv/mock_ublksrv.hpp
@@ -55,7 +55,8 @@ public:
     void* io_buf(int tag);
 
     // Direct reference to the iovec passed to async_iov for the given tag slot.
-    // Used by tests that simulate sub_cmds overwrite (e.g. RAID10 stale-iovec regression).
+    // Allows tests to mutate the caller-side iov after submission to verify that the
+    // disk under test has snapshotted the values rather than holding a raw pointer.
     iovec& iov_ref(int tag) noexcept { return _tags[tag].iov; }
 
     int q_depth() const noexcept { return _q_depth; }

--- a/src/tests/mock_ublksrv/mock_ublksrv.hpp
+++ b/src/tests/mock_ublksrv/mock_ublksrv.hpp
@@ -54,6 +54,10 @@ public:
     // Per-tag sector-aligned I/O buffer (max_io_size = DEF_BUF_SIZE bytes).
     void* io_buf(int tag);
 
+    // Direct reference to the iovec passed to async_iov for the given tag slot.
+    // Used by tests that simulate sub_cmds overwrite (e.g. RAID10 stale-iovec regression).
+    iovec& iov_ref(int tag) noexcept { return _tags[tag].iov; }
+
     int q_depth() const noexcept { return _q_depth; }
     int nr_queues() const noexcept { return static_cast< int >(_queues.size()); }
     ublksrv_queue const* queue(int q_id = 0) const noexcept { return &_queues[q_id]; }


### PR DESCRIPTION
## Summary

- Snapshots \`iovecs\` into a coroutine-frame-local \`std::array<iovec, 16>\` at the top of \`__failover_read_async\`, before any \`co_await\`, to prevent use of stale RAID0 \`thread_local sub_cmds\` data in the failover read path
- Adds \`MockUblksrv::iov_ref()\` accessor to expose the caller-side iovec for test mutation
- Adds regression test \`FailoverUsesSnapshotIovecNotStaleCopy\` that simulates the race and verifies the failover uses the original \`iov_base\` and \`iov_len\`

## Root Cause

In RAID10, \`RAID0::__distribute\` populates \`thread_local sub_cmds\` and passes \`iovecs\` pointing into it when calling \`RAID1::async_iov\`. Once \`__failover_read_async\` suspends at \`co_await primary_task\`, concurrent I/Os on the same queue thread can overwrite \`sub_cmds\`, leaving the \`iovecs\` pointer stale by the time the failover SQE is submitted. The failover then reads the wrong number of bytes into the wrong buffer.

Confirmed via raw-block fio logs showing \`r > len\` on failover reads (e.g. \`len:4096\` but \`r=131072\`) immediately after a SIGKILL'd AM caused multiple simultaneous in-flight read failures.

The existing \`io_uring_submit\` guard in \`RAID0::async_iov\` only protects the initial SQEs - the failover SQE is submitted much later, after the primary fails and \`sub_cmds\` has been overwritten.

## Why SIGTERM doesn't reproduce

With SIGTERM (30s grace), AMs flush and close iSCSI connections gracefully. No reads are in-flight when the failure is detected, so the failover path is never exercised while \`sub_cmds\` is in a stale window.

## Implementation notes

- \`std::array<iovec, 16>\` is used (not \`std::vector\`) to avoid an extra heap allocation; the coroutine frame is already heap-allocated. The bound of 16 matches \`StripeAccum::io_array\` in RAID0.
- \`DEBUG_ASSERT_LE(nr_vecs, 16u)\` guards the copy in debug builds.
- The regression test runs in a \`std::thread\` to isolate \`thread_local last_read\` state from other tests on the main gtest thread (same pattern used by other \`AsyncRaid1Fixture\` tests).

## Test plan

- [x] CI passes (GccAddressSanitize, GccThreadSanitize, GccCoverage, ClangRelease)
- [x] \`ctest -R Raid1.*FailoverStale\` passes
- [x] \`am_resync\` resiliency test passes with SIGKILL pod restarts