### PR TITLE
fix(raid1/bitmap): dirty_region TOCTOU and test_and_set memory order

### DIFF
--- a/src/raid/raid1/bitmap.cpp
+++ b/src/raid/raid1/bitmap.cpp
@@ -404,6 +404,14 @@ void Bitmap::dirty_region(uint64_t addr, uint64_t len) {
         auto page_data = __get_or_create_page(page_offset);
         if (!page_data) throw std::runtime_error("Could not insert new page"); // LCOV_EXCL_LINE
 
+        // Clear loaded_from_disk BEFORE writing bits so that a concurrent sync_to cannot
+        // observe loaded_from_disk=true after new dirty bits have already been ORed in.
+        // If sync_to reads loaded_from_disk=false it will include this page in the flush,
+        // which is correct whether or not we have finished setting bits yet (extra flush is safe).
+        // The reverse ordering (bits first, then clear flag) is the TOCTOU bug: sync_to could
+        // read loaded_from_disk=true, skip the page, and a subsequent crash would lose those bits.
+        page_data->loaded_from_disk.store(false, std::memory_order_release);
+
         auto page = page_data->page.load(std::memory_order_acquire);
         auto cur_word = page + word_offset;
         // Handle update crossing multiple words (optimization potential?)
@@ -419,9 +427,6 @@ void Bitmap::dirty_region(uint64_t addr, uint64_t len) {
             ++cur_word;
             shift_offset = bits_in_word - 1; // Word offset back to the beginning
         }
-
-        // Mark as modified AFTER all modifications (release ensures visibility)
-        page_data->loaded_from_disk.store(false, std::memory_order_release);
 
         // Update superbitmap to mark this page as dirty
         _super_bitmap.set_bit(page_offset);

--- a/src/raid/raid1/raid1.cpp
+++ b/src/raid/raid1/raid1.cpp
@@ -499,7 +499,7 @@ std::shared_ptr< ublk_disk > Raid1Disk::swap_device(std::string const& outgoing_
             incoming_mirror->new_device = true;
         }
         // Do not read or write here yet
-        incoming_mirror->unavail.test_and_set(std::memory_order_acquire);
+        incoming_mirror->unavail.test_and_set(std::memory_order_acq_rel);
     } catch (std::runtime_error const& e) { return incoming_device; }
 
     // Stop resync before touching the bitmap so the resync task doesn't race set_bit/clear_bit
@@ -647,11 +647,11 @@ io_result Raid1Disk::__become_degraded(bool failed_is_active, RouteState const* 
         // device unavailable. The dirty bitmap covers the affected region; resync at shutdown or a
         // full recovery on next start will reconcile any inconsistency.
         _sb->fields.bitmap.age = old_age; // revert age -- not written to disk
-        failed_device->unavail.test_and_set(std::memory_order_acquire);
+        failed_device->unavail.test_and_set(std::memory_order_acq_rel);
         RLOGE("Could not persist degradation [uuid:{}]: {}", _str_uuid, sync_res.error().message())
         return sync_res;
     }
-    failed_device->unavail.test_and_set(std::memory_order_acquire);
+    failed_device->unavail.test_and_set(std::memory_order_acq_rel);
     if (spawn_resync && _resync_enabled.load(std::memory_order_relaxed)) toggle_resync(true); // Launch a Resync Task
     return 0;
 }
@@ -680,7 +680,7 @@ disk_task< int > Raid1Disk::__failover_read_async(ublksrv_queue const* q, ublk_i
         primary_dev->unavail.clear(std::memory_order_release);
         co_return r;
     }
-    if (!state.is_degraded && !primary_dev->unavail.test_and_set(std::memory_order_acquire))
+    if (!state.is_degraded && !primary_dev->unavail.test_and_set(std::memory_order_acq_rel))
         RLOGW("Device marked unavailable due to read failure: {}", *primary_dev->disk)
 
     if (!failover_dev) co_return -EAGAIN;
@@ -815,7 +815,7 @@ io_result Raid1Disk::sync_iov(uint8_t op, iovec* iovecs, uint32_t nr_vecs, off_t
             primary_dev->unavail.clear(std::memory_order_release);
             return primary_res;
         }
-        if (!state.is_degraded && !primary_dev->unavail.test_and_set(std::memory_order_acquire))
+        if (!state.is_degraded && !primary_dev->unavail.test_and_set(std::memory_order_acq_rel))
             RLOGW("Device marked unavailable due to read failure: {}", *primary_dev->disk)
 
         if (!failover_dev) return std::unexpected(std::make_error_condition(std::errc::resource_unavailable_try_again));

--- a/src/raid/raid1/raid1_resync_task.cpp
+++ b/src/raid/raid1/raid1_resync_task.cpp
@@ -290,7 +290,7 @@ resync_state Raid1ResyncTask::__run(auto& clean_mirror, auto& dirty_mirror, iove
                     any_copy = false;
                 }
             } else {
-                dirty_mirror->unavail.test_and_set(std::memory_order_acquire);
+                dirty_mirror->unavail.test_and_set(std::memory_order_acq_rel);
                 break;
             }
         }
@@ -377,7 +377,7 @@ bool Raid1ResyncTask::probe_mirror(MirrorDevice& mirror, uint64_t reserved_size)
         mirror.unavail.clear(std::memory_order_release);
         return true;
     }
-    mirror.unavail.test_and_set(std::memory_order_acquire);
+    mirror.unavail.test_and_set(std::memory_order_acq_rel);
     return false;
 }
 


### PR DESCRIPTION
## Summary

Fixes two RAID1 correctness bugs found in bitmap.cpp and raid1.cpp.

### Bug H4 — dirty_region/sync_to TOCTOU: dirty bits lost after crash (bitmap.cpp)

**What was wrong:** In `Bitmap::dirty_region()`, `loaded_from_disk` was cleared *after* the bit-setting loop. A concurrent `sync_to()` running between the last `fetch_or` and the `store(false)` would observe `loaded_from_disk=true` and skip flushing that page. A crash before the next `sync_to` would then permanently lose those dirty bits from disk. On restart the affected region would not be resynced, and the backup mirror could silently serve stale data.

**Fix:** Move `loaded_from_disk.store(false, memory_order_release)` to *before* the bit-setting loop. A `sync_to` observing `false` before all bits are written will simply re-flush the page on the next sync cycle — a harmless extra write. The reverse (missing dirty bits on disk) is data-corrupting.

### Bug M4 — test_and_set wrong memory order (raid1.cpp, raid1_resync_task.cpp)

**What was wrong:** `atomic_flag::test_and_set(memory_order_acquire)` was used at 7 sites. `test_and_set` is a read-modify-write operation; `acquire` only provides ordering for the read (load) part. The store of the set value carries no release semantics. On ARM/POWER architectures, other threads might not observe the updated `unavail` flag promptly, potentially routing IO to a device that was just marked failed.

**Fix:** Changed all `test_and_set(memory_order_acquire)` to `test_and_set(memory_order_acq_rel)` in:
- `raid1.cpp` — 5 sites (`swap_device`, `__become_degraded` ×2, `__failover_read_async`, `sync_iov`)
- `raid1_resync_task.cpp` — 2 sites (`__run`, `probe_mirror`)

Plain `test()` and `clear()` calls are unchanged — only RMW `test_and_set` is affected.

## Test plan

- [ ] Build with `conan build -s:h build_type=Debug --build missing .` passes all existing tests
- [ ] Thread sanitizer run (`sanitize=thread`) shows no new races
- [ ] Existing `sync_to_crash_scenarios` bitmap tests cover the TOCTOU scenario
- [ ] Existing `failover` and `degraded` tests exercise the `test_and_set` paths

Closes #269

🤖 Generated with [Claude Code](https://claude.com/claude-code)