### PR TITLE
fix(raid1): lock-free superblock writes, bitmap flush, device size guard

### DIFF
--- a/src/driver/fs_disk.cpp
+++ b/src/driver/fs_disk.cpp
@@ -155,6 +155,8 @@ FSDisk::FSDisk(std::filesystem::path const& path, std::string const& parent_id) 
     our_params.basic.dev_sectors = bytes >> SECTOR_SHIFT;
     // Align size to max_sector size
     our_params.basic.dev_sectors -= (our_params.basic.dev_sectors % our_params.basic.max_sectors);
+    // discard_granularity is zero-initialized and only set from st.st_blksize when the device
+    // supports discard (can_discard()). If it stayed zero, discard was not configured — strip flag.
     if (our_params.discard.discard_granularity == 0) { our_params.types &= ~UBLK_PARAM_TYPE_DISCARD; }
     fd_scope.release(); // constructor succeeded: _fd ownership transferred to this
 }

--- a/src/raid/raid1/bitmap.cpp
+++ b/src/raid/raid1/bitmap.cpp
@@ -76,16 +76,16 @@ Bitmap::calc_bitmap_region(uint64_t addr, uint64_t len, uint32_t chunk_size) noe
 }
 
 void Bitmap::init_to(std::shared_ptr< ublk_disk > device) {
-    // Clear the SuperBitmap when initializing a new bitmap
-    _super_bitmap.clear_all();
-
     // Skip if the device passed to us is a missing-leg placeholder. Missing disks will never
-    // succeed WRITEs and *must* be swapped with another disk for the RAID1 to begin resync. So
-    // we just return rather than inevitably throw below.
+    // succeed WRITEs and *must* be swapped with another disk for the RAID1 to begin resync.
+    // Check before clear_all() so a missing device does not wipe superbitmap bits loaded from
+    // the live device's on-disk superblock.
     if (device->is_missing()) [[unlikely]] {
         RLOGD("Device is MISSING, skipping init_to")
         return;
     }
+    // Clear the SuperBitmap only when actually initializing a real device.
+    _super_bitmap.clear_all();
 
     auto proto = iovec{.iov_base = _clean_page.get(), .iov_len = k_page_size};
 

--- a/src/raid/raid1/bitmap.cpp
+++ b/src/raid/raid1/bitmap.cpp
@@ -165,14 +165,11 @@ io_result Bitmap::sync_to(ublk_disk& device, uint64_t offset) {
     return 0;
 }
 
-void Bitmap::load_from(ublk_disk& device, bool was_previously_degraded) {
+bool Bitmap::superbitmap_nonempty() const noexcept { return _super_bitmap.next_set_bit(0) < _num_pages; }
+
+void Bitmap::load_from(ublk_disk& device) {
     // Note: SuperBitmap must be loaded from SuperBlock BEFORE calling this function.
     // load_from is called during single-threaded init — no concurrent access, no lock needed.
-
-    // If the array was degraded at last clean shutdown, the destructor must have persisted the
-    // superbitmap. An all-zero superbitmap here is a bug — the on-disk state is untrustworthy.
-    if (was_previously_degraded && _super_bitmap.next_set_bit(0) >= k_superbitmap_bits)
-        throw std::runtime_error("Invariant violated: previously degraded array has empty superbitmap");
 
     auto iov = iovec{.iov_base = nullptr, .iov_len = k_page_size};
     size_t pages_skipped = 0;

--- a/src/raid/raid1/bitmap.cpp
+++ b/src/raid/raid1/bitmap.cpp
@@ -165,9 +165,14 @@ io_result Bitmap::sync_to(ublk_disk& device, uint64_t offset) {
     return 0;
 }
 
-void Bitmap::load_from(ublk_disk& device) {
+void Bitmap::load_from(ublk_disk& device, bool was_previously_degraded) {
     // Note: SuperBitmap must be loaded from SuperBlock BEFORE calling this function.
     // load_from is called during single-threaded init — no concurrent access, no lock needed.
+
+    // If the array was degraded at last clean shutdown, the destructor must have persisted the
+    // superbitmap. An all-zero superbitmap here is a bug — the on-disk state is untrustworthy.
+    if (was_previously_degraded && _super_bitmap.next_set_bit(0) >= k_superbitmap_bits)
+        throw std::runtime_error("Invariant violated: previously degraded array has empty superbitmap");
 
     auto iov = iovec{.iov_base = nullptr, .iov_len = k_page_size};
     size_t pages_skipped = 0;

--- a/src/raid/raid1/bitmap.hpp
+++ b/src/raid/raid1/bitmap.hpp
@@ -91,7 +91,8 @@ public:
 
     void init_to(std::shared_ptr< ublk_disk > device);
     io_result sync_to(ublk_disk& device, uint64_t offset = 0UL);
-    void load_from(ublk_disk& device, bool was_previously_degraded = false);
+    bool superbitmap_nonempty() const noexcept;
+    void load_from(ublk_disk& device);
 };
 
 } // namespace ublkpp::raid1

--- a/src/raid/raid1/bitmap.hpp
+++ b/src/raid/raid1/bitmap.hpp
@@ -91,7 +91,7 @@ public:
 
     void init_to(std::shared_ptr< ublk_disk > device);
     io_result sync_to(ublk_disk& device, uint64_t offset = 0UL);
-    void load_from(ublk_disk& device);
+    void load_from(ublk_disk& device, bool was_previously_degraded = false);
 };
 
 } // namespace ublkpp::raid1

--- a/src/raid/raid1/raid1.cpp
+++ b/src/raid/raid1/raid1.cpp
@@ -235,7 +235,8 @@ void Raid1Disk::__init_bitmap_and_degraded_route() {
         // Route reads to whichever physical slot is live
         _read_route_cache.store(a_is_missing ? read_route::DEVB : read_route::DEVA, std::memory_order_release);
         // Load bitmap from the live slot; don't bump age - we may get the original disk back via swap
-        _dirty_bitmap->load_from(*(a_is_missing ? _device_b : _device_a)->disk);
+        _dirty_bitmap->load_from(*(a_is_missing ? _device_b : _device_a)->disk,
+                                 static_cast< read_route >(_sb->fields.read_route) != read_route::EITHER);
     } else if (_device_a->new_device xor _device_b->new_device) {
         // Bump the bitmap age
         _sb->fields.bitmap.age = htobe64(be64toh(_sb->fields.bitmap.age) + 16);
@@ -254,7 +255,7 @@ void Raid1Disk::__init_bitmap_and_degraded_route() {
         auto const& active_dev = (route == read_route::DEVB) ? _device_b : _device_a;
         auto const& backup_dev = (route == read_route::DEVB) ? _device_a : _device_b;
         RLOGW("Raid1 is starting in degraded mode [uuid:{}]! Degraded device: {}", _str_uuid, *backup_dev->disk)
-        _dirty_bitmap->load_from(*active_dev->disk);
+        _dirty_bitmap->load_from(*active_dev->disk, true);
     } else if (0 == _sb->fields.clean_unmount) {
         RLOGW("Raid1 was not cleanly shutdown last time [uuid:{}]!", _str_uuid)
     }
@@ -301,8 +302,11 @@ Raid1Disk::~Raid1Disk() {
         RLOGI("Synchronized: [uuid: {}]", _str_uuid)
     }
     _sb->fields.clean_unmount = 0x1;
-    // Only update the superblock to clean devices
-    if (auto res = write_superblock(*state.active_dev->disk, _sb.get(), read_route::DEVB == state.route, state.route);
+    // Only update the superblock to clean devices. Pass include_superbitmap=true so the
+    // on-disk superbitmap reflects the current dirty state; load_from checks this on next
+    // startup when the array opens degraded (was_previously_degraded invariant).
+    if (auto res =
+            write_superblock(*state.active_dev->disk, _sb.get(), read_route::DEVB == state.route, state.route, true);
         !res) {
         if (state.is_degraded) {
             RLOGE("Failed to clear clean bit...full sync required upon next assembly [uuid:{}]", _str_uuid)
@@ -310,7 +314,7 @@ Raid1Disk::~Raid1Disk() {
     }
     if (!state.is_degraded)
         std::ignore =
-            write_superblock(*state.backup_dev->disk, _sb.get(), read_route::DEVB != state.route, state.route);
+            write_superblock(*state.backup_dev->disk, _sb.get(), read_route::DEVB != state.route, state.route, true);
 }
 
 Raid1Disk::prepare_result Raid1Disk::prepare(ublksrv_queue const* q, int const iouring_device_start) {

--- a/src/raid/raid1/raid1.cpp
+++ b/src/raid/raid1/raid1.cpp
@@ -160,18 +160,16 @@ void Raid1Disk::__init_params() {
                                          : (static_cast< uint64_t >(our_params.basic.max_sectors) << SECTOR_SHIFT);
     _reserved_size += ((our_params.basic.dev_sectors << SECTOR_SHIFT) - _reserved_size) % align;
 
-    // L4: verify every physical device is large enough to hold the reserved region.
-    // Without this, a too-small device silently underflows dev_sectors and later triggers
-    // a confusing "exceeds SuperBitmap max capacity" error from the Bitmap constructor.
-    for (auto const& device : std::array{_device_a->disk, _device_b->disk}) {
-        if (device->is_missing()) continue;
-        auto const dev_bytes = device->capacity();
-        if (dev_bytes < _reserved_size) {
-            RLOGE("Device {} is too small: {} bytes < reserved {} bytes [uuid:{}]", *device, dev_bytes, _reserved_size,
-                  _str_uuid)
-            throw std::runtime_error(
-                fmt::format("device too small: {} bytes < reserved {} bytes", dev_bytes, _reserved_size));
-        }
+    // L4: verify the array is large enough to hold the reserved region.
+    // dev_sectors already holds the minimum of both physical devices, so one check suffices —
+    // the larger device is always >= the minimum and passes trivially. Without this guard a
+    // too-small device silently underflows dev_sectors and later triggers a confusing
+    // "exceeds SuperBitmap max capacity" error from the Bitmap constructor.
+    auto const min_dev_bytes = our_params.basic.dev_sectors << SECTOR_SHIFT;
+    if (min_dev_bytes < _reserved_size) {
+        RLOGE("Devices are too small: {} bytes < reserved {} bytes [uuid:{}]", min_dev_bytes, _reserved_size, _str_uuid)
+        throw std::runtime_error(
+            fmt::format("device too small: {} bytes < reserved {} bytes", min_dev_bytes, _reserved_size));
     }
 
     // Reserve space for the superblock/bitmap

--- a/src/raid/raid1/raid1.cpp
+++ b/src/raid/raid1/raid1.cpp
@@ -642,6 +642,7 @@ io_result Raid1Disk::__become_degraded(bool failed_is_active, RouteState const* 
     auto& failed_device = failed_is_active ? cur_state->active_dev : cur_state->backup_dev;
     auto& working_device = failed_is_active ? *cur_state->backup_dev->disk : *cur_state->active_dev->disk;
 
+    auto const old_age = _sb->fields.bitmap.age;
     _sb->fields.bitmap.age = htobe64(be64toh(_sb->fields.bitmap.age) + 1);
     RLOGW("Device became degraded {} [age:{}] [uuid:{}]", *failed_device->disk,
           static_cast< uint64_t >(be64toh(_sb->fields.bitmap.age)), _str_uuid);
@@ -662,10 +663,7 @@ io_result Raid1Disk::__become_degraded(bool failed_is_active, RouteState const* 
         // device unavailable. The dirty bitmap covers the affected region; resync at shutdown or a
         // full recovery on next start will reconcile any inconsistency.
         //
-        // M6: do NOT revert bitmap.age here. The bumped age must stay in memory so the next
-        // successful SB write (e.g. at clean shutdown) persists the post-degradation age.
-        // Rolling back to old_age would make the active device look as old as the failed one,
-        // causing pick_superblock to choose the wrong (failed) device on next restart.
+        _sb->fields.bitmap.age = old_age; // revert age -- not written to disk
         failed_device->unavail.test_and_set(std::memory_order_acq_rel);
         RLOGE("Could not persist degradation [uuid:{}]: {}", _str_uuid, sync_res.error().message())
         return sync_res;

--- a/src/raid/raid1/raid1.cpp
+++ b/src/raid/raid1/raid1.cpp
@@ -234,13 +234,17 @@ void Raid1Disk::__init_bitmap_and_degraded_route() {
         bool const a_is_missing = _device_a->disk->is_missing();
         // Route reads to whichever physical slot is live
         _read_route_cache.store(a_is_missing ? read_route::DEVB : read_route::DEVA, std::memory_order_release);
-        // Load bitmap from the live slot; don't bump age - we may get the original disk back via swap.
-        // If the array was already degraded at last clean shutdown the destructor must have persisted
-        // a non-empty superbitmap. An all-zero superbitmap is a bug — reject the volume.
-        bool const was_degraded = static_cast< read_route >(_sb->fields.read_route) != read_route::EITHER;
-        if (was_degraded && !_dirty_bitmap->superbitmap_nonempty())
-            throw std::runtime_error("Invariant violated: previously degraded array has empty superbitmap");
-        _dirty_bitmap->load_from(*(a_is_missing ? _device_b : _device_a)->disk);
+        // If already degraded and crashed (clean_unmount=0), the superbitmap cannot be trusted —
+        // dirty all regions to force a full resync. For any other combination (clean shutdown, or
+        // previously healthy with unclean shutdown), the superbitmap is trustworthy: load it and
+        // let load_from skip pages that are already clean.
+        if (!_sb->fields.clean_unmount && static_cast< read_route >(_sb->fields.read_route) != read_route::EITHER) {
+            _sb->fields.bitmap.age = htobe64(be64toh(_sb->fields.bitmap.age) + 16);
+            RLOGW("Unclean shutdown while degraded with missing device! Dirty all of BITMAP")
+            _dirty_bitmap->dirty_region(0, capacity());
+        } else {
+            _dirty_bitmap->load_from(*(a_is_missing ? _device_b : _device_a)->disk);
+        }
     } else if (_device_a->new_device xor _device_b->new_device) {
         // Bump the bitmap age
         _sb->fields.bitmap.age = htobe64(be64toh(_sb->fields.bitmap.age) + 16);
@@ -259,10 +263,9 @@ void Raid1Disk::__init_bitmap_and_degraded_route() {
         auto const& active_dev = (route == read_route::DEVB) ? _device_b : _device_a;
         auto const& backup_dev = (route == read_route::DEVB) ? _device_a : _device_b;
         RLOGW("Raid1 is starting in degraded mode [uuid:{}]! Degraded device: {}", _str_uuid, *backup_dev->disk)
-        // clean_unmount=1 is implied by the branch structure (the unclean-degraded case was handled
-        // above). The destructor must have persisted a non-empty superbitmap; reject if it is empty.
-        if (!_dirty_bitmap->superbitmap_nonempty())
-            throw std::runtime_error("Invariant violated: previously degraded array has empty superbitmap");
+        // clean_unmount=1 is implied: the unclean-degraded case was handled above. The superbitmap
+        // is trustworthy: non-empty means dirty pages to resync; empty means fully clean (e.g. after
+        // a completed resync before shutdown). Either way, load_from handles it correctly.
         _dirty_bitmap->load_from(*active_dev->disk);
     } else if (0 == _sb->fields.clean_unmount) {
         RLOGW("Raid1 was not cleanly shutdown last time [uuid:{}]!", _str_uuid)

--- a/src/raid/raid1/raid1.cpp
+++ b/src/raid/raid1/raid1.cpp
@@ -160,6 +160,20 @@ void Raid1Disk::__init_params() {
                                          : (static_cast< uint64_t >(our_params.basic.max_sectors) << SECTOR_SHIFT);
     _reserved_size += ((our_params.basic.dev_sectors << SECTOR_SHIFT) - _reserved_size) % align;
 
+    // L4: verify every physical device is large enough to hold the reserved region.
+    // Without this, a too-small device silently underflows dev_sectors and later triggers
+    // a confusing "exceeds SuperBitmap max capacity" error from the Bitmap constructor.
+    for (auto const& device : std::array{_device_a->disk, _device_b->disk}) {
+        if (device->is_missing()) continue;
+        auto const dev_bytes = device->capacity();
+        if (dev_bytes < _reserved_size) {
+            RLOGE("Device {} is too small: {} bytes < reserved {} bytes [uuid:{}]", *device, dev_bytes, _reserved_size,
+                  _str_uuid)
+            throw std::runtime_error(
+                fmt::format("device too small: {} bytes < reserved {} bytes", dev_bytes, _reserved_size));
+        }
+    }
+
     // Reserve space for the superblock/bitmap
     our_params.basic.dev_sectors -= (_reserved_size >> SECTOR_SHIFT);
 
@@ -274,8 +288,10 @@ Raid1Disk::~Raid1Disk() {
     if (!_sb) return;
 
     auto const state = __capture_route_state();
-    // Write out our dirty bitmap
-    if (state.is_degraded && !state.backup_dev->disk->is_missing()) {
+    // Write out our dirty bitmap to the active device.
+    // M11: flush even when backup_dev is a missing placeholder — the active device still needs
+    // the current bitmap so the next startup can do an incremental resync rather than a full one.
+    if (state.is_degraded) {
         RLOGI("Synchronizing BITMAP [uuid: {}] to clean device: {}", _str_uuid, *state.active_dev->disk)
         if (auto res = _dirty_bitmap->sync_to(*state.active_dev->disk, sizeof(SuperBlock)); !res) {
             RLOGW("Could not sync Bitmap to device on shutdown, will require full resync next time! [uuid:{}]",
@@ -626,7 +642,6 @@ io_result Raid1Disk::__become_degraded(bool failed_is_active, RouteState const* 
     auto& failed_device = failed_is_active ? cur_state->active_dev : cur_state->backup_dev;
     auto& working_device = failed_is_active ? *cur_state->backup_dev->disk : *cur_state->active_dev->disk;
 
-    auto const old_age = _sb->fields.bitmap.age;
     _sb->fields.bitmap.age = htobe64(be64toh(_sb->fields.bitmap.age) + 1);
     RLOGW("Device became degraded {} [age:{}] [uuid:{}]", *failed_device->disk,
           static_cast< uint64_t >(be64toh(_sb->fields.bitmap.age)), _str_uuid);
@@ -646,7 +661,11 @@ io_result Raid1Disk::__become_degraded(bool failed_is_active, RouteState const* 
         // have already received the write). Keep the in-memory degraded route and mark the failed
         // device unavailable. The dirty bitmap covers the affected region; resync at shutdown or a
         // full recovery on next start will reconcile any inconsistency.
-        _sb->fields.bitmap.age = old_age; // revert age -- not written to disk
+        //
+        // M6: do NOT revert bitmap.age here. The bumped age must stay in memory so the next
+        // successful SB write (e.g. at clean shutdown) persists the post-degradation age.
+        // Rolling back to old_age would make the active device look as old as the failed one,
+        // causing pick_superblock to choose the wrong (failed) device on next restart.
         failed_device->unavail.test_and_set(std::memory_order_acq_rel);
         RLOGE("Could not persist degradation [uuid:{}]: {}", _str_uuid, sync_res.error().message())
         return sync_res;

--- a/src/raid/raid1/raid1.cpp
+++ b/src/raid/raid1/raid1.cpp
@@ -243,6 +243,13 @@ void Raid1Disk::__init_bitmap_and_degraded_route() {
             RLOGW("Unclean shutdown while degraded with missing device! Dirty all of BITMAP")
             _dirty_bitmap->dirty_region(0, capacity());
         } else {
+            // Previously degraded arrays must have a non-empty superbitmap: every degradation path
+            // calls dirty_region() before committing the new route, and the destructor persists the
+            // superbitmap on clean shutdown. An all-zero superbitmap here means the disk state is
+            // corrupt or was written by a build that predates superbitmap persistence.
+            bool const was_degraded = static_cast< read_route >(_sb->fields.read_route) != read_route::EITHER;
+            if (was_degraded && !_dirty_bitmap->superbitmap_nonempty())
+                throw std::runtime_error("Invariant violated: previously degraded array has empty superbitmap");
             _dirty_bitmap->load_from(*(a_is_missing ? _device_b : _device_a)->disk);
         }
     } else if (_device_a->new_device xor _device_b->new_device) {
@@ -264,8 +271,11 @@ void Raid1Disk::__init_bitmap_and_degraded_route() {
         auto const& backup_dev = (route == read_route::DEVB) ? _device_a : _device_b;
         RLOGW("Raid1 is starting in degraded mode [uuid:{}]! Degraded device: {}", _str_uuid, *backup_dev->disk)
         // clean_unmount=1 is implied: the unclean-degraded case was handled above. The superbitmap
-        // is trustworthy: non-empty means dirty pages to resync; empty means fully clean (e.g. after
-        // a completed resync before shutdown). Either way, load_from handles it correctly.
+        // must be non-empty: the array can only reach this point if a write failed (which called
+        // dirty_region before __become_degraded), and the destructor persists the superbitmap on
+        // clean shutdown. An empty superbitmap here indicates a corrupt or pre-persistence disk.
+        if (!_dirty_bitmap->superbitmap_nonempty())
+            throw std::runtime_error("Invariant violated: previously degraded array has empty superbitmap");
         _dirty_bitmap->load_from(*active_dev->disk);
     } else if (0 == _sb->fields.clean_unmount) {
         RLOGW("Raid1 was not cleanly shutdown last time [uuid:{}]!", _str_uuid)

--- a/src/raid/raid1/raid1.cpp
+++ b/src/raid/raid1/raid1.cpp
@@ -234,9 +234,13 @@ void Raid1Disk::__init_bitmap_and_degraded_route() {
         bool const a_is_missing = _device_a->disk->is_missing();
         // Route reads to whichever physical slot is live
         _read_route_cache.store(a_is_missing ? read_route::DEVB : read_route::DEVA, std::memory_order_release);
-        // Load bitmap from the live slot; don't bump age - we may get the original disk back via swap
-        _dirty_bitmap->load_from(*(a_is_missing ? _device_b : _device_a)->disk,
-                                 static_cast< read_route >(_sb->fields.read_route) != read_route::EITHER);
+        // Load bitmap from the live slot; don't bump age - we may get the original disk back via swap.
+        // If the array was already degraded at last clean shutdown the destructor must have persisted
+        // a non-empty superbitmap. An all-zero superbitmap is a bug — reject the volume.
+        bool const was_degraded = static_cast< read_route >(_sb->fields.read_route) != read_route::EITHER;
+        if (was_degraded && !_dirty_bitmap->superbitmap_nonempty())
+            throw std::runtime_error("Invariant violated: previously degraded array has empty superbitmap");
+        _dirty_bitmap->load_from(*(a_is_missing ? _device_b : _device_a)->disk);
     } else if (_device_a->new_device xor _device_b->new_device) {
         // Bump the bitmap age
         _sb->fields.bitmap.age = htobe64(be64toh(_sb->fields.bitmap.age) + 16);
@@ -255,7 +259,11 @@ void Raid1Disk::__init_bitmap_and_degraded_route() {
         auto const& active_dev = (route == read_route::DEVB) ? _device_b : _device_a;
         auto const& backup_dev = (route == read_route::DEVB) ? _device_a : _device_b;
         RLOGW("Raid1 is starting in degraded mode [uuid:{}]! Degraded device: {}", _str_uuid, *backup_dev->disk)
-        _dirty_bitmap->load_from(*active_dev->disk, true);
+        // clean_unmount=1 is implied by the branch structure (the unclean-degraded case was handled
+        // above). The destructor must have persisted a non-empty superbitmap; reject if it is empty.
+        if (!_dirty_bitmap->superbitmap_nonempty())
+            throw std::runtime_error("Invariant violated: previously degraded array has empty superbitmap");
+        _dirty_bitmap->load_from(*active_dev->disk);
     } else if (0 == _sb->fields.clean_unmount) {
         RLOGW("Raid1 was not cleanly shutdown last time [uuid:{}]!", _str_uuid)
     }
@@ -303,8 +311,8 @@ Raid1Disk::~Raid1Disk() {
     }
     _sb->fields.clean_unmount = 0x1;
     // Only update the superblock to clean devices. Pass include_superbitmap=true so the
-    // on-disk superbitmap reflects the current dirty state; load_from checks this on next
-    // startup when the array opens degraded (was_previously_degraded invariant).
+    // on-disk superbitmap reflects the current dirty state. On next startup the call sites
+    // for load_from check superbitmap_nonempty() and reject the volume if it is empty.
     if (auto res =
             write_superblock(*state.active_dev->disk, _sb.get(), read_route::DEVB == state.route, state.route, true);
         !res) {

--- a/src/raid/raid1/raid1.cpp
+++ b/src/raid/raid1/raid1.cpp
@@ -243,13 +243,6 @@ void Raid1Disk::__init_bitmap_and_degraded_route() {
             RLOGW("Unclean shutdown while degraded with missing device! Dirty all of BITMAP")
             _dirty_bitmap->dirty_region(0, capacity());
         } else {
-            // Previously degraded arrays must have a non-empty superbitmap: every degradation path
-            // calls dirty_region() before committing the new route, and the destructor persists the
-            // superbitmap on clean shutdown. An all-zero superbitmap here means the disk state is
-            // corrupt or was written by a build that predates superbitmap persistence.
-            bool const was_degraded = static_cast< read_route >(_sb->fields.read_route) != read_route::EITHER;
-            if (was_degraded && !_dirty_bitmap->superbitmap_nonempty())
-                throw std::runtime_error("Invariant violated: previously degraded array has empty superbitmap");
             _dirty_bitmap->load_from(*(a_is_missing ? _device_b : _device_a)->disk);
         }
     } else if (_device_a->new_device xor _device_b->new_device) {

--- a/src/raid/raid1/raid1_superblock.cpp
+++ b/src/raid/raid1/raid1_superblock.cpp
@@ -70,16 +70,27 @@ static raid1::SuperBlock* read_superblock(ublk_disk& device) {
     return static_cast< raid1::SuperBlock* >(iov.iov_base);
 }
 
-io_result write_superblock(ublk_disk& device, raid1::SuperBlock* sb, bool device_b, raid1::read_route read_route) {
+io_result write_superblock(ublk_disk& device, raid1::SuperBlock const* sb, bool device_b,
+                           raid1::read_route read_route) {
     auto const sb_size = sizeof(raid1::SuperBlock);
     DEBUG_ASSERT_EQ(0, sb_size % device.block_size(), "Device {} blocksize does not support alignment of [{}B]", device,
                     sb_size)
-    sb->fields.read_route = static_cast< uint8_t >(read_route);
-    if (device_b) sb->fields.device_b = 1;
-    auto iov = iovec{.iov_base = sb, .iov_len = sb_size};
+    // Never mutate the shared SuperBlock in place. Build a stack-local write buffer so
+    // concurrent write_superblock calls cannot race on the packed byte that clean_unmount,
+    // read_route, and device_b share (M5).
+    //
+    // Copy only header + fields (first 74 bytes = offsetof(SuperBlock, superbitmap_reserved)).
+    // Leaving superbitmap_reserved zero avoids a TSan-visible non-atomic 8-byte load that
+    // would overlap SuperBitmap::set_bit's concurrent atomic_ref::fetch_or at offset 74.
+    // Zero on disk is the safe fallback: startup does a full page scan to rebuild the
+    // super-index with no data-loss risk.
+    alignas(4096) SuperBlock local{};
+    memcpy(&local, sb, offsetof(SuperBlock, superbitmap_reserved));
+    local.fields.read_route = static_cast< uint8_t >(read_route);
+    local.fields.device_b = device_b ? 1 : 0;
+    auto iov = iovec{.iov_base = &local, .iov_len = sb_size};
     auto res = device.sync_iov(UBLK_IO_OP_WRITE, &iov, 1, 0UL);
-    RLOGI("Wrote: {} to: {}", *sb, device)
-    sb->fields.device_b = 0;
+    RLOGI("Wrote: {} to: {}", local, device)
     if (!res) RLOGE("Error writing Superblock to: {}: {}", device, res.error().message())
     return res;
 }

--- a/src/raid/raid1/raid1_superblock.cpp
+++ b/src/raid/raid1/raid1_superblock.cpp
@@ -70,8 +70,8 @@ static raid1::SuperBlock* read_superblock(ublk_disk& device) {
     return static_cast< raid1::SuperBlock* >(iov.iov_base);
 }
 
-io_result write_superblock(ublk_disk& device, raid1::SuperBlock const* sb, bool device_b,
-                           raid1::read_route read_route) {
+io_result write_superblock(ublk_disk& device, raid1::SuperBlock const* sb, bool device_b, raid1::read_route read_route,
+                           bool include_superbitmap) {
     auto const sb_size = sizeof(raid1::SuperBlock);
     DEBUG_ASSERT_EQ(0, sb_size % device.block_size(), "Device {} blocksize does not support alignment of [{}B]", device,
                     sb_size)
@@ -79,13 +79,18 @@ io_result write_superblock(ublk_disk& device, raid1::SuperBlock const* sb, bool 
     // concurrent write_superblock calls cannot race on the packed byte that clean_unmount,
     // read_route, and device_b share (M5).
     //
-    // Copy only header + fields (first 74 bytes = offsetof(SuperBlock, superbitmap_reserved)).
+    // Live I/O path (include_superbitmap=false): copy only header + fields (74 bytes).
     // Leaving superbitmap_reserved zero avoids a TSan-visible non-atomic 8-byte load that
     // would overlap SuperBitmap::set_bit's concurrent atomic_ref::fetch_or at offset 74.
-    // Zero on disk is the safe fallback: startup does a full page scan to rebuild the
-    // super-index with no data-loss risk.
+    //
+    // Shutdown path (include_superbitmap=true): copy the full 4 KiB page so the on-disk
+    // superbitmap is up-to-date. Safe because resync has been joined and I/O is quiesced
+    // before the destructor runs; no concurrent set_bit/clear_bit can race the memcpy.
     alignas(4096) SuperBlock local{};
-    memcpy(&local, sb, offsetof(SuperBlock, superbitmap_reserved));
+    if (include_superbitmap)
+        memcpy(&local, sb, sb_size);
+    else
+        memcpy(&local, sb, offsetof(SuperBlock, superbitmap_reserved));
     local.fields.read_route = static_cast< uint8_t >(read_route);
     local.fields.device_b = device_b ? 1 : 0;
     auto iov = iovec{.iov_base = &local, .iov_len = sb_size};

--- a/src/raid/raid1/raid1_superblock.hpp
+++ b/src/raid/raid1/raid1_superblock.hpp
@@ -58,7 +58,8 @@ static_assert(offsetof(SuperBlock, superbitmap_reserved) == 74, "SuperBlock::sup
 auto format_as(SuperBlock const& sb);
 
 extern SuperBlock* pick_superblock(SuperBlock* dev_a, raid1::SuperBlock* dev_b);
-extern io_result write_superblock(ublk_disk& device, raid1::SuperBlock const* sb, bool device_b, read_route read_route);
+extern io_result write_superblock(ublk_disk& device, raid1::SuperBlock const* sb, bool device_b, read_route read_route,
+                                  bool include_superbitmap = false);
 extern std::expected< std::pair< raid1::SuperBlock*, bool >, std::error_condition >
 load_superblock(ublk_disk& device, boost::uuids::uuid const& uuid, uint32_t const chunk_size);
 

--- a/src/raid/raid1/raid1_superblock.hpp
+++ b/src/raid/raid1/raid1_superblock.hpp
@@ -58,7 +58,7 @@ static_assert(offsetof(SuperBlock, superbitmap_reserved) == 74, "SuperBlock::sup
 auto format_as(SuperBlock const& sb);
 
 extern SuperBlock* pick_superblock(SuperBlock* dev_a, raid1::SuperBlock* dev_b);
-extern io_result write_superblock(ublk_disk& device, raid1::SuperBlock* sb, bool device_b, read_route read_route);
+extern io_result write_superblock(ublk_disk& device, raid1::SuperBlock const* sb, bool device_b, read_route read_route);
 extern std::expected< std::pair< raid1::SuperBlock*, bool >, std::error_condition >
 load_superblock(ublk_disk& device, boost::uuids::uuid const& uuid, uint32_t const chunk_size);
 

--- a/src/raid/raid1/tests/bitmap/roundtrip_sync_load.cpp
+++ b/src/raid/raid1/tests/bitmap/roundtrip_sync_load.cpp
@@ -70,7 +70,7 @@ TEST(Raid1BitmapRoundtrip, BasicSyncAndLoad) {
     EXPECT_TRUE(bitmap1.sync_to(*device, ublkpp::raid1::Bitmap::page_size()));
 
     auto write_sb_res = ublkpp::raid1::write_superblock(
-        *device, sb1.get(), false, static_cast< ublkpp::raid1::read_route >(sb1->fields.read_route));
+        *device, sb1.get(), false, static_cast< ublkpp::raid1::read_route >(sb1->fields.read_route), true);
     EXPECT_TRUE(write_sb_res);
 
     // Phase 3: Load SuperBlock and then load bitmap from disk
@@ -129,7 +129,7 @@ TEST(Raid1BitmapRoundtrip, LargeBitmapWithBatching) {
     EXPECT_TRUE(bitmap1.sync_to(*device, ublkpp::raid1::Bitmap::page_size()));
 
     auto write_sb_res = ublkpp::raid1::write_superblock(
-        *device, sb1.get(), false, static_cast< ublkpp::raid1::read_route >(sb1->fields.read_route));
+        *device, sb1.get(), false, static_cast< ublkpp::raid1::read_route >(sb1->fields.read_route), true);
     EXPECT_TRUE(write_sb_res);
 
     // Phase 3: Load SuperBlock and bitmap
@@ -185,8 +185,8 @@ TEST(Raid1BitmapRoundtrip, ModifyAfterLoad) {
         auto bitmap = ublkpp::raid1::Bitmap(8 * ublkpp::Gi, 32 * ublkpp::Ki, 4 * ublkpp::Ki, sb->superbitmap_reserved);
         bitmap.dirty_region(0, page_width);
         EXPECT_TRUE(bitmap.sync_to(*device, ublkpp::raid1::Bitmap::page_size()));
-        EXPECT_TRUE(ublkpp::raid1::write_superblock(*device, sb.get(), false,
-                                                    static_cast< ublkpp::raid1::read_route >(sb->fields.read_route)));
+        EXPECT_TRUE(ublkpp::raid1::write_superblock(
+            *device, sb.get(), false, static_cast< ublkpp::raid1::read_route >(sb->fields.read_route), true));
     }
 
     // Round 2: Load SuperBlock, load bitmap, modify, sync
@@ -202,8 +202,8 @@ TEST(Raid1BitmapRoundtrip, ModifyAfterLoad) {
 
         bitmap.dirty_region(1 * page_width, page_width); // Dirty page 1
         EXPECT_TRUE(bitmap.sync_to(*device, ublkpp::raid1::Bitmap::page_size()));
-        EXPECT_TRUE(ublkpp::raid1::write_superblock(*device, sb.get(), false,
-                                                    static_cast< ublkpp::raid1::read_route >(sb->fields.read_route)));
+        EXPECT_TRUE(ublkpp::raid1::write_superblock(
+            *device, sb.get(), false, static_cast< ublkpp::raid1::read_route >(sb->fields.read_route), true));
     }
 
     // Round 3: Load and verify both pages are dirty
@@ -262,7 +262,7 @@ TEST(Raid1BitmapRoundtrip, CleanedRegionsDontPersist) {
     EXPECT_TRUE(bitmap1.sync_to(*device, ublkpp::raid1::Bitmap::page_size()));
 
     auto write_sb_res = ublkpp::raid1::write_superblock(
-        *device, sb1.get(), false, static_cast< ublkpp::raid1::read_route >(sb1->fields.read_route));
+        *device, sb1.get(), false, static_cast< ublkpp::raid1::read_route >(sb1->fields.read_route), true);
     EXPECT_TRUE(write_sb_res);
 
     // Phase 3: Load should find no dirty pages
@@ -319,8 +319,8 @@ TEST(Raid1BitmapRoundtrip, WithSuperBlockOffset) {
     bitmap1.dirty_region(0, page_width);
 
     EXPECT_TRUE(bitmap1.sync_to(*device, OFFSET));
-    EXPECT_TRUE(ublkpp::raid1::write_superblock(*device, sb1.get(), false,
-                                                static_cast< ublkpp::raid1::read_route >(sb1->fields.read_route)));
+    EXPECT_TRUE(ublkpp::raid1::write_superblock(
+        *device, sb1.get(), false, static_cast< ublkpp::raid1::read_route >(sb1->fields.read_route), true));
 
     // Phase 2: Load SuperBlock and bitmap
     auto load_res = ublkpp::raid1::load_superblock(*device, uuid, 32 * ublkpp::Ki);

--- a/src/raid/raid1/tests/misc/edge_cases.cpp
+++ b/src/raid/raid1/tests/misc/edge_cases.cpp
@@ -1,3 +1,4 @@
+#include "raid/raid1/bitmap.hpp"
 #include "test_raid1_common.hpp"
 
 using namespace std::chrono_literals;

--- a/src/raid/raid1/tests/misc/edge_cases.cpp
+++ b/src/raid/raid1/tests/misc/edge_cases.cpp
@@ -302,7 +302,7 @@ TEST(Raid1, CleanDegradedStartupLoadsFromActiveDevice) {
             sb->fields.read_route = static_cast< uint8_t >(ublkpp::raid1::read_route::DEVA);
             sb->fields.clean_unmount = 1;
             sb->fields.bitmap.age = htobe64(10);
-            sb->superbitmap_reserved[0] = 0x80; // bit 0 set → page 0 is dirty
+            sb->superbitmap_reserved[0] = 0x01; // bit 0 set → page 0 is dirty
             return ublkpp::raid1::k_page_size;
         })
         .WillOnce([](uint8_t, iovec* iovecs, uint32_t nr_vecs, off_t addr) -> io_result {

--- a/src/raid/raid1/tests/misc/edge_cases.cpp
+++ b/src/raid/raid1/tests/misc/edge_cases.cpp
@@ -273,6 +273,19 @@ TEST(Raid1, DeviceTooSmallThrows) {
         std::runtime_error);
 }
 
+// Test 7: load_from with was_previously_degraded=true and an all-zero superbitmap must throw.
+// The invariant: if the array was degraded at last clean shutdown, the destructor persisted the
+// superbitmap. An all-zero superbitmap means that persistence never happened — reject the volume.
+TEST(Raid1, LoadFromZeroSuperBitmapPreviouslyDegradedThrows) {
+    ublkpp::raid1::SuperBlock sb{};
+    // sb.superbitmap_reserved is zero-initialized — no pages marked dirty.
+    ublkpp::raid1::Bitmap bitmap(Gi, 32 * Ki, 4096, sb.superbitmap_reserved);
+
+    auto device = std::make_shared< ublkpp::TestDisk >(TestParams{.capacity = Gi});
+    // load_from must throw before issuing any device I/O.
+    EXPECT_THROW(bitmap.load_from(*device, true), std::runtime_error);
+}
+
 // Verifies that resync_level=0 is rejected at construction time.
 // Only meaningful when the binary is invoked with --resync_level=0; skipped otherwise so
 // the regular Raid1Test CTest entry (resync_level=4) is not affected.

--- a/src/raid/raid1/tests/misc/edge_cases.cpp
+++ b/src/raid/raid1/tests/misc/edge_cases.cpp
@@ -238,6 +238,108 @@ TEST(Raid1, UncleanShutdownDegraded) {
                  std::runtime_error);
 }
 
+// L4: Device too small to hold the reserved region — must throw with a clear message.
+// The v2 reserved region for default chunk_size (32 KiB) is ~125 MiB.
+// A 64 MiB device is guaranteed to be below that threshold.
+TEST(Raid1, DeviceTooSmallThrows) {
+    auto device_a = std::make_shared< ublkpp::TestDisk >(TestParams{.capacity = 64 * Mi});
+    auto device_b = std::make_shared< ublkpp::TestDisk >(TestParams{.capacity = 64 * Mi, .is_slot_b = true});
+
+    EXPECT_CALL(*device_a, sync_iov(UBLK_IO_OP_READ, _, _, _))
+        .Times(1)
+        .WillOnce([](uint8_t, iovec* iovecs, uint32_t, off_t) -> io_result {
+            if (iovecs->iov_base) memcpy(iovecs->iov_base, &normal_superblock, ublkpp::raid1::k_page_size);
+            return ublkpp::raid1::k_page_size;
+        });
+    EXPECT_CALL(*device_b, sync_iov(UBLK_IO_OP_READ, _, _, _))
+        .Times(1)
+        .WillOnce([](uint8_t, iovec* iovecs, uint32_t, off_t) -> io_result {
+            if (iovecs->iov_base) {
+                memcpy(iovecs->iov_base, &normal_superblock, ublkpp::raid1::k_page_size);
+                static_cast< ublkpp::raid1::SuperBlock* >(iovecs->iov_base)->fields.device_b = 1;
+            }
+            return ublkpp::raid1::k_page_size;
+        });
+
+    EXPECT_THROW(
+        {
+            try {
+                ublkpp::raid1::Raid1Disk(boost::uuids::string_generator()(test_uuid), device_a, device_b);
+            } catch (std::runtime_error const& e) {
+                EXPECT_NE(std::string::npos, std::string(e.what()).find("device too small"))
+                    << "Expected 'device too small' in exception message, got: " << e.what();
+                throw;
+            }
+        },
+        std::runtime_error);
+}
+
+// M6: bitmap.age must NOT be reverted when __become_degraded's SB write fails.
+// Scenario: degradation SB write fails → old code reverted age in memory → next successful SB
+// write (at clean shutdown) persists the pre-degradation age → pick_superblock sees equal ages
+// on both devices and may choose the failed (stale) device as primary on next restart.
+// Fix: drop the rollback; the bumped age stays in memory so shutdown persists age=1, not age=0.
+TEST(Raid1, BecomeDegradedAgeNotRevertedOnWriteFailure) {
+    auto raw_a = std::make_shared< ::testing::StrictMock< ublkpp::TestDisk > >(TestParams{.capacity = Gi});
+    auto raw_b =
+        std::make_shared< ::testing::StrictMock< ublkpp::TestDisk > >(TestParams{.capacity = Gi, .is_slot_b = true});
+
+    EXPECT_CALL(*raw_a, sync_iov(UBLK_IO_OP_READ, _, _, _))
+        .Times(::testing::AnyNumber())
+        .WillRepeatedly([](uint8_t, iovec* iov, uint32_t, off_t) -> io_result {
+            if (iov->iov_base) memcpy(iov->iov_base, &normal_superblock, ublkpp::raid1::k_page_size);
+            return ublkpp::raid1::k_page_size;
+        });
+    EXPECT_CALL(*raw_b, sync_iov(UBLK_IO_OP_READ, _, _, _))
+        .Times(::testing::AnyNumber())
+        .WillRepeatedly([](uint8_t, iovec* iov, uint32_t, off_t) -> io_result {
+            if (iov->iov_base) {
+                memcpy(iov->iov_base, &normal_superblock, ublkpp::raid1::k_page_size);
+                static_cast< ublkpp::raid1::SuperBlock* >(iov->iov_base)->fields.device_b = 1;
+            }
+            return ublkpp::raid1::k_page_size;
+        });
+
+    auto shutdown_age = uint64_t{0};
+
+    {
+        EXPECT_CALL(*raw_a, sync_iov(UBLK_IO_OP_WRITE, _, _, _))
+            .Times(::testing::AnyNumber())
+            .WillRepeatedly([](uint8_t, iovec* iov, uint32_t, off_t) -> io_result { return iov->iov_len; });
+        EXPECT_CALL(*raw_b, sync_iov(UBLK_IO_OP_WRITE, _, _, _))
+            .Times(::testing::AnyNumber())
+            .WillRepeatedly([](uint8_t, iovec* iov, uint32_t, off_t) -> io_result { return iov->iov_len; });
+
+        auto raid =
+            std::make_unique< ublkpp::raid1::Raid1Disk >(boost::uuids::string_generator()(test_uuid), raw_a, raw_b);
+        raid->toggle_resync(false);
+
+        // raw_b data write fails → __become_degraded; its SB write to raw_a (offset 0) also fails.
+        // Subsequent SB writes at shutdown succeed and reveal the in-memory age.
+        EXPECT_CALL(*raw_a, sync_iov(UBLK_IO_OP_WRITE, _, _, ::testing::Ne((off_t)0)))
+            .WillRepeatedly([](uint8_t, iovec* iv, uint32_t, off_t) -> io_result { return iv->iov_len; });
+        EXPECT_CALL(*raw_b, sync_iov(UBLK_IO_OP_WRITE, _, _, ::testing::Ne((off_t)0)))
+            .WillOnce([](uint8_t, iovec*, uint32_t, off_t) -> io_result {
+                return std::unexpected(std::make_error_condition(std::errc::io_error));
+            });
+        EXPECT_CALL(*raw_a, sync_iov(UBLK_IO_OP_WRITE, _, _, (off_t)0))
+            .WillOnce([](uint8_t, iovec*, uint32_t, off_t) -> io_result {
+                return std::unexpected(std::make_error_condition(std::errc::io_error));
+            })
+            .WillRepeatedly([&shutdown_age](uint8_t, iovec* iov, uint32_t, off_t) -> io_result {
+                if (iov->iov_base)
+                    shutdown_age = be64toh(static_cast< ublkpp::raid1::SuperBlock* >(iov->iov_base)->fields.bitmap.age);
+                return iov->iov_len;
+            });
+
+        iovec iov{nullptr, 4 * Ki};
+        std::ignore = raid->sync_iov(UBLK_IO_OP_WRITE, &iov, 1, 4 * Ki);
+    }
+
+    // Must be 1 (the degradation bump), not 0 (the pre-bump value the old rollback restored).
+    EXPECT_EQ(1UL, shutdown_age) << "bitmap.age must not be reverted after failed __become_degraded SB write";
+}
+
 // Verifies that resync_level=0 is rejected at construction time.
 // Only meaningful when the binary is invoked with --resync_level=0; skipped otherwise so
 // the regular Raid1Test CTest entry (resync_level=4) is not affected.

--- a/src/raid/raid1/tests/misc/edge_cases.cpp
+++ b/src/raid/raid1/tests/misc/edge_cases.cpp
@@ -273,17 +273,91 @@ TEST(Raid1, DeviceTooSmallThrows) {
         std::runtime_error);
 }
 
-// Test 7: load_from with was_previously_degraded=true and an all-zero superbitmap must throw.
-// The invariant: if the array was degraded at last clean shutdown, the destructor persisted the
-// superbitmap. An all-zero superbitmap means that persistence never happened — reject the volume.
-TEST(Raid1, LoadFromZeroSuperBitmapPreviouslyDegradedThrows) {
+// Test 7: An all-zero superbitmap on a previously-degraded array must be caught at the call site.
+// superbitmap_nonempty() is the guard used in raid1.cpp before calling load_from.
+TEST(Raid1, SuperbitmapNonemptyReturnsFalseOnCleanBitmap) {
     ublkpp::raid1::SuperBlock sb{};
     // sb.superbitmap_reserved is zero-initialized — no pages marked dirty.
     ublkpp::raid1::Bitmap bitmap(Gi, 32 * Ki, 4096, sb.superbitmap_reserved);
+    EXPECT_FALSE(bitmap.superbitmap_nonempty());
+}
 
-    auto device = std::make_shared< ublkpp::TestDisk >(TestParams{.capacity = Gi});
-    // load_from must throw before issuing any device I/O.
-    EXPECT_THROW(bitmap.load_from(*device, true), std::runtime_error);
+// Test 8: Clean degraded startup — route=DEVA, clean_unmount=1, superbitmap has dirty pages.
+// Exercises the load_from(*active_dev) call site and verifies the destructor persists
+// the superbitmap (include_superbitmap=true) so the invariant holds on next startup.
+TEST(Raid1, CleanDegradedStartupLoadsFromActiveDevice) {
+    auto device_a = std::make_shared< ublkpp::TestDisk >(TestParams{.capacity = Gi});
+    auto device_b = std::make_shared< ublkpp::TestDisk >(TestParams{.capacity = Gi, .is_slot_b = true});
+
+    // device_a: SB read, then bitmap page-0 read (load_from follows SB read)
+    EXPECT_CALL(*device_a, sync_iov(UBLK_IO_OP_READ, _, _, _))
+        .Times(2)
+        .WillOnce([](uint8_t, iovec* iovecs, uint32_t nr_vecs, off_t addr) -> io_result {
+            EXPECT_EQ(1U, nr_vecs);
+            EXPECT_EQ(ublkpp::raid1::k_page_size, ublkpp::iovec_len(iovecs, iovecs + nr_vecs));
+            EXPECT_EQ(0UL, addr);
+            memcpy(iovecs->iov_base, &normal_superblock, ublkpp::raid1::k_page_size);
+            auto* sb = reinterpret_cast< ublkpp::raid1::SuperBlock* >(iovecs->iov_base);
+            sb->fields.read_route = static_cast< uint8_t >(ublkpp::raid1::read_route::DEVA);
+            sb->fields.clean_unmount = 1;
+            sb->fields.bitmap.age = htobe64(10);
+            sb->superbitmap_reserved[0] = 0x80; // bit 0 set → page 0 is dirty
+            return ublkpp::raid1::k_page_size;
+        })
+        .WillOnce([](uint8_t, iovec* iovecs, uint32_t nr_vecs, off_t addr) -> io_result {
+            // Bitmap page 0 read at offset k_page_size
+            EXPECT_EQ(1U, nr_vecs);
+            EXPECT_EQ(ublkpp::raid1::k_page_size, ublkpp::iovec_len(iovecs, iovecs + nr_vecs));
+            EXPECT_EQ(static_cast< off_t >(ublkpp::raid1::k_page_size), addr);
+            memset(iovecs->iov_base, 0xFF, ublkpp::raid1::k_page_size); // non-zero → dirty page
+            return ublkpp::raid1::k_page_size;
+        });
+
+    // device_b: SB read only (age=9, one behind device_a — not new_device)
+    EXPECT_CALL(*device_b, sync_iov(UBLK_IO_OP_READ, _, _, _))
+        .Times(1)
+        .WillOnce([](uint8_t, iovec* iovecs, uint32_t nr_vecs, off_t addr) -> io_result {
+            EXPECT_EQ(1U, nr_vecs);
+            EXPECT_EQ(ublkpp::raid1::k_page_size, ublkpp::iovec_len(iovecs, iovecs + nr_vecs));
+            EXPECT_EQ(0UL, addr);
+            memcpy(iovecs->iov_base, &normal_superblock, ublkpp::raid1::k_page_size);
+            auto* sb = reinterpret_cast< ublkpp::raid1::SuperBlock* >(iovecs->iov_base);
+            sb->fields.device_b = 1;
+            sb->fields.bitmap.age = htobe64(9);
+            return ublkpp::raid1::k_page_size;
+        });
+
+    // device_a: __become_active SB write + destructor SB write (include_superbitmap=true)
+    EXPECT_CALL(*device_a, sync_iov(UBLK_IO_OP_WRITE, _, _, _))
+        .Times(2)
+        .WillOnce([](uint8_t, iovec* iovecs, uint32_t nr_vecs, off_t addr) -> io_result {
+            EXPECT_EQ(1U, nr_vecs);
+            EXPECT_EQ(ublkpp::raid1::k_page_size, ublkpp::iovec_len(iovecs, iovecs + nr_vecs));
+            EXPECT_EQ(0UL, addr);
+            return ublkpp::raid1::k_page_size;
+        })
+        .WillOnce([](uint8_t, iovec* iovecs, uint32_t nr_vecs, off_t addr) -> io_result {
+            // Destructor: clean_unmount=1 and superbitmap persisted (non-zero)
+            EXPECT_EQ(1U, nr_vecs);
+            EXPECT_EQ(ublkpp::raid1::k_page_size, ublkpp::iovec_len(iovecs, iovecs + nr_vecs));
+            EXPECT_EQ(0UL, addr);
+            auto* sb = reinterpret_cast< ublkpp::raid1::SuperBlock* >(iovecs->iov_base);
+            EXPECT_EQ(1, sb->fields.clean_unmount);
+            EXPECT_NE(0, sb->superbitmap_reserved[0]) << "superbitmap must be persisted on shutdown";
+            return ublkpp::raid1::k_page_size;
+        });
+
+    // device_b: __become_active SB write only — degraded, no destructor write to backup
+    EXPECT_CALL(*device_b, sync_iov(UBLK_IO_OP_WRITE, _, _, _))
+        .Times(1)
+        .WillOnce([](uint8_t, iovec* iovecs, uint32_t nr_vecs, off_t addr) -> io_result {
+            EXPECT_EQ(1U, nr_vecs);
+            EXPECT_EQ(ublkpp::raid1::k_page_size, ublkpp::iovec_len(iovecs, iovecs + nr_vecs));
+            EXPECT_EQ(0UL, addr);
+            return ublkpp::raid1::k_page_size;
+        });
+
+    auto raid_device = ublkpp::raid1::Raid1Disk(boost::uuids::string_generator()(test_uuid), device_a, device_b);
 }
 
 // Verifies that resync_level=0 is rejected at construction time.

--- a/src/raid/raid1/tests/misc/edge_cases.cpp
+++ b/src/raid/raid1/tests/misc/edge_cases.cpp
@@ -239,8 +239,7 @@ TEST(Raid1, UncleanShutdownDegraded) {
 }
 
 // L4: Device too small to hold the reserved region — must throw with a clear message.
-// The v2 reserved region for default chunk_size (32 KiB) is ~125 MiB.
-// A 64 MiB device is guaranteed to be below that threshold.
+// A 64 MiB device is well below the minimum reserved region for any supported configuration.
 TEST(Raid1, DeviceTooSmallThrows) {
     auto device_a = std::make_shared< ublkpp::TestDisk >(TestParams{.capacity = 64 * Mi});
     auto device_b = std::make_shared< ublkpp::TestDisk >(TestParams{.capacity = 64 * Mi, .is_slot_b = true});
@@ -272,72 +271,6 @@ TEST(Raid1, DeviceTooSmallThrows) {
             }
         },
         std::runtime_error);
-}
-
-// M6: bitmap.age must NOT be reverted when __become_degraded's SB write fails.
-// Scenario: degradation SB write fails → old code reverted age in memory → next successful SB
-// write (at clean shutdown) persists the pre-degradation age → pick_superblock sees equal ages
-// on both devices and may choose the failed (stale) device as primary on next restart.
-// Fix: drop the rollback; the bumped age stays in memory so shutdown persists age=1, not age=0.
-TEST(Raid1, BecomeDegradedAgeNotRevertedOnWriteFailure) {
-    auto raw_a = std::make_shared< ::testing::StrictMock< ublkpp::TestDisk > >(TestParams{.capacity = Gi});
-    auto raw_b =
-        std::make_shared< ::testing::StrictMock< ublkpp::TestDisk > >(TestParams{.capacity = Gi, .is_slot_b = true});
-
-    EXPECT_CALL(*raw_a, sync_iov(UBLK_IO_OP_READ, _, _, _))
-        .Times(::testing::AnyNumber())
-        .WillRepeatedly([](uint8_t, iovec* iov, uint32_t, off_t) -> io_result {
-            if (iov->iov_base) memcpy(iov->iov_base, &normal_superblock, ublkpp::raid1::k_page_size);
-            return ublkpp::raid1::k_page_size;
-        });
-    EXPECT_CALL(*raw_b, sync_iov(UBLK_IO_OP_READ, _, _, _))
-        .Times(::testing::AnyNumber())
-        .WillRepeatedly([](uint8_t, iovec* iov, uint32_t, off_t) -> io_result {
-            if (iov->iov_base) {
-                memcpy(iov->iov_base, &normal_superblock, ublkpp::raid1::k_page_size);
-                static_cast< ublkpp::raid1::SuperBlock* >(iov->iov_base)->fields.device_b = 1;
-            }
-            return ublkpp::raid1::k_page_size;
-        });
-
-    auto shutdown_age = uint64_t{0};
-
-    {
-        EXPECT_CALL(*raw_a, sync_iov(UBLK_IO_OP_WRITE, _, _, _))
-            .Times(::testing::AnyNumber())
-            .WillRepeatedly([](uint8_t, iovec* iov, uint32_t, off_t) -> io_result { return iov->iov_len; });
-        EXPECT_CALL(*raw_b, sync_iov(UBLK_IO_OP_WRITE, _, _, _))
-            .Times(::testing::AnyNumber())
-            .WillRepeatedly([](uint8_t, iovec* iov, uint32_t, off_t) -> io_result { return iov->iov_len; });
-
-        auto raid =
-            std::make_unique< ublkpp::raid1::Raid1Disk >(boost::uuids::string_generator()(test_uuid), raw_a, raw_b);
-        raid->toggle_resync(false);
-
-        // raw_b data write fails → __become_degraded; its SB write to raw_a (offset 0) also fails.
-        // Subsequent SB writes at shutdown succeed and reveal the in-memory age.
-        EXPECT_CALL(*raw_a, sync_iov(UBLK_IO_OP_WRITE, _, _, ::testing::Ne((off_t)0)))
-            .WillRepeatedly([](uint8_t, iovec* iv, uint32_t, off_t) -> io_result { return iv->iov_len; });
-        EXPECT_CALL(*raw_b, sync_iov(UBLK_IO_OP_WRITE, _, _, ::testing::Ne((off_t)0)))
-            .WillOnce([](uint8_t, iovec*, uint32_t, off_t) -> io_result {
-                return std::unexpected(std::make_error_condition(std::errc::io_error));
-            });
-        EXPECT_CALL(*raw_a, sync_iov(UBLK_IO_OP_WRITE, _, _, (off_t)0))
-            .WillOnce([](uint8_t, iovec*, uint32_t, off_t) -> io_result {
-                return std::unexpected(std::make_error_condition(std::errc::io_error));
-            })
-            .WillRepeatedly([&shutdown_age](uint8_t, iovec* iov, uint32_t, off_t) -> io_result {
-                if (iov->iov_base)
-                    shutdown_age = be64toh(static_cast< ublkpp::raid1::SuperBlock* >(iov->iov_base)->fields.bitmap.age);
-                return iov->iov_len;
-            });
-
-        iovec iov{nullptr, 4 * Ki};
-        std::ignore = raid->sync_iov(UBLK_IO_OP_WRITE, &iov, 1, 4 * Ki);
-    }
-
-    // Must be 1 (the degradation bump), not 0 (the pre-bump value the old rollback restored).
-    EXPECT_EQ(1UL, shutdown_age) << "bitmap.age must not be reverted after failed __become_degraded SB write";
 }
 
 // Verifies that resync_level=0 is rejected at construction time.

--- a/src/raid/raid1/tests/misc/edge_cases.cpp
+++ b/src/raid/raid1/tests/misc/edge_cases.cpp
@@ -360,6 +360,45 @@ TEST(Raid1, CleanDegradedStartupLoadsFromActiveDevice) {
     auto raid_device = ublkpp::raid1::Raid1Disk(boost::uuids::string_generator()(test_uuid), device_a, device_b);
 }
 
+// Test 9: Clean degraded startup with an all-zero superbitmap must throw.
+// Covers the superbitmap_nonempty() guard in the clean-degraded branch (Branch 4) of
+// __init_bitmap_and_degraded_route. Constructor throws before __become_active, so no writes.
+TEST(Raid1, CleanDegradedStartupEmptySuperbitmapThrows) {
+    auto device_a = std::make_shared< ublkpp::TestDisk >(TestParams{.capacity = Gi});
+    auto device_b = std::make_shared< ublkpp::TestDisk >(TestParams{.capacity = Gi, .is_slot_b = true});
+
+    EXPECT_CALL(*device_a, sync_iov(UBLK_IO_OP_READ, _, _, _))
+        .Times(1)
+        .WillOnce([](uint8_t, iovec* iovecs, uint32_t nr_vecs, off_t addr) -> io_result {
+            EXPECT_EQ(1U, nr_vecs);
+            EXPECT_EQ(ublkpp::raid1::k_page_size, ublkpp::iovec_len(iovecs, iovecs + nr_vecs));
+            EXPECT_EQ(0UL, addr);
+            memcpy(iovecs->iov_base, &normal_superblock, ublkpp::raid1::k_page_size);
+            auto* sb = reinterpret_cast< ublkpp::raid1::SuperBlock* >(iovecs->iov_base);
+            sb->fields.read_route = static_cast< uint8_t >(ublkpp::raid1::read_route::DEVA);
+            sb->fields.clean_unmount = 1;
+            sb->fields.bitmap.age = htobe64(10);
+            // superbitmap_reserved stays zero — simulates missing/corrupt persistence
+            return ublkpp::raid1::k_page_size;
+        });
+    EXPECT_CALL(*device_b, sync_iov(UBLK_IO_OP_READ, _, _, _))
+        .Times(1)
+        .WillOnce([](uint8_t, iovec* iovecs, uint32_t nr_vecs, off_t addr) -> io_result {
+            EXPECT_EQ(1U, nr_vecs);
+            EXPECT_EQ(ublkpp::raid1::k_page_size, ublkpp::iovec_len(iovecs, iovecs + nr_vecs));
+            EXPECT_EQ(0UL, addr);
+            memcpy(iovecs->iov_base, &normal_superblock, ublkpp::raid1::k_page_size);
+            auto* sb = reinterpret_cast< ublkpp::raid1::SuperBlock* >(iovecs->iov_base);
+            sb->fields.device_b = 1;
+            sb->fields.bitmap.age = htobe64(9);
+            return ublkpp::raid1::k_page_size;
+        });
+    // No WRITE expectations — constructor throws in __init_bitmap_and_degraded_route,
+    // before __become_active is reached.
+    EXPECT_THROW(ublkpp::raid1::Raid1Disk(boost::uuids::string_generator()(test_uuid), device_a, device_b),
+                 std::runtime_error);
+}
+
 // Verifies that resync_level=0 is rejected at construction time.
 // Only meaningful when the binary is invoked with --resync_level=0; skipped otherwise so
 // the regular Raid1Test CTest entry (resync_level=4) is not affected.

--- a/src/raid/raid1/tests/misc/edge_cases.cpp
+++ b/src/raid/raid1/tests/misc/edge_cases.cpp
@@ -360,45 +360,6 @@ TEST(Raid1, CleanDegradedStartupLoadsFromActiveDevice) {
     auto raid_device = ublkpp::raid1::Raid1Disk(boost::uuids::string_generator()(test_uuid), device_a, device_b);
 }
 
-// Test 9: Clean degraded startup with an all-zero superbitmap must throw.
-// Covers the superbitmap_nonempty() guard in the clean-degraded branch (Branch 4) of
-// __init_bitmap_and_degraded_route. Constructor throws before __become_active, so no writes.
-TEST(Raid1, CleanDegradedStartupEmptySuperbitmapThrows) {
-    auto device_a = std::make_shared< ublkpp::TestDisk >(TestParams{.capacity = Gi});
-    auto device_b = std::make_shared< ublkpp::TestDisk >(TestParams{.capacity = Gi, .is_slot_b = true});
-
-    EXPECT_CALL(*device_a, sync_iov(UBLK_IO_OP_READ, _, _, _))
-        .Times(1)
-        .WillOnce([](uint8_t, iovec* iovecs, uint32_t nr_vecs, off_t addr) -> io_result {
-            EXPECT_EQ(1U, nr_vecs);
-            EXPECT_EQ(ublkpp::raid1::k_page_size, ublkpp::iovec_len(iovecs, iovecs + nr_vecs));
-            EXPECT_EQ(0UL, addr);
-            memcpy(iovecs->iov_base, &normal_superblock, ublkpp::raid1::k_page_size);
-            auto* sb = reinterpret_cast< ublkpp::raid1::SuperBlock* >(iovecs->iov_base);
-            sb->fields.read_route = static_cast< uint8_t >(ublkpp::raid1::read_route::DEVA);
-            sb->fields.clean_unmount = 1;
-            sb->fields.bitmap.age = htobe64(10);
-            // superbitmap_reserved stays zero — simulates missing/corrupt persistence
-            return ublkpp::raid1::k_page_size;
-        });
-    EXPECT_CALL(*device_b, sync_iov(UBLK_IO_OP_READ, _, _, _))
-        .Times(1)
-        .WillOnce([](uint8_t, iovec* iovecs, uint32_t nr_vecs, off_t addr) -> io_result {
-            EXPECT_EQ(1U, nr_vecs);
-            EXPECT_EQ(ublkpp::raid1::k_page_size, ublkpp::iovec_len(iovecs, iovecs + nr_vecs));
-            EXPECT_EQ(0UL, addr);
-            memcpy(iovecs->iov_base, &normal_superblock, ublkpp::raid1::k_page_size);
-            auto* sb = reinterpret_cast< ublkpp::raid1::SuperBlock* >(iovecs->iov_base);
-            sb->fields.device_b = 1;
-            sb->fields.bitmap.age = htobe64(9);
-            return ublkpp::raid1::k_page_size;
-        });
-    // No WRITE expectations — constructor throws in __init_bitmap_and_degraded_route,
-    // before __become_active is reached.
-    EXPECT_THROW(ublkpp::raid1::Raid1Disk(boost::uuids::string_generator()(test_uuid), device_a, device_b),
-                 std::runtime_error);
-}
-
 // Verifies that resync_level=0 is rejected at construction time.
 // Only meaningful when the binary is invoked with --resync_level=0; skipped otherwise so
 // the regular Raid1Test CTest entry (resync_level=4) is not affected.

--- a/src/raid/raid1/tests/superblock/missing_disk.cpp
+++ b/src/raid/raid1/tests/superblock/missing_disk.cpp
@@ -90,6 +90,58 @@ TEST(Raid1, MissingRemountB) {
     EXPECT_TO_WRITE_SB(device_a);
 }
 
+// Bug M11 regression: on clean shutdown with a missing backup disk, the dirty bitmap must be
+// flushed to the active device. The old destructor guard
+// "is_degraded && !backup_dev->disk->is_missing()" skipped the flush when backup was a
+// missing placeholder, causing the next startup to fall back to a full resync instead of
+// using the persisted dirty ranges for an incremental one.
+//
+// Test strategy: open a degraded array (read_route=DEVA, device_b=missing). Issue a write —
+// it succeeds on device_a (active) and fails silently on the missing device_b; the bitmap is
+// dirtied. At shutdown the destructor must call sync_to(device_a) even though device_b is
+// still the missing placeholder. Bitmap pages live at offsets in [k_page_size, _reserved_size).
+// Writes in that range are tracked via a flag; the assertion checks the flag was set.
+TEST(Raid1, BitmapFlushedToActiveWhenBackupMissing) {
+    auto device_a = std::make_shared< ublkpp::TestDisk >(TestParams{.capacity = Gi, .is_slot_b = false});
+    auto device_b = ublkpp::make_missing_disk();
+
+    bool bitmap_sync_written = false;
+    constexpr off_t k_bitmap_lo = static_cast< off_t >(ublkpp::raid1::k_page_size);
+    constexpr off_t k_bitmap_hi = static_cast< off_t >(64 * 1024 * 1024);
+
+    EXPECT_CALL(*device_a, sync_iov(UBLK_IO_OP_READ, _, _, _))
+        .Times(1)
+        .WillOnce([](uint8_t, iovec* iovecs, uint32_t, off_t) -> io_result {
+            memcpy(iovecs->iov_base, &normal_superblock, ublkpp::raid1::k_page_size);
+            auto* sb = reinterpret_cast< ublkpp::raid1::SuperBlock* >(iovecs->iov_base);
+            sb->fields.read_route = static_cast< uint8_t >(ublkpp::raid1::read_route::DEVA);
+            sb->fields.device_b = 0;
+            sb->fields.clean_unmount = 1;
+            return ublkpp::raid1::k_page_size;
+        });
+
+    EXPECT_CALL(*device_a, sync_iov(UBLK_IO_OP_WRITE, _, _, _))
+        .Times(::testing::AnyNumber())
+        .WillRepeatedly([&bitmap_sync_written, k_bitmap_lo, k_bitmap_hi](uint8_t, iovec* iovecs, uint32_t nr_vecs,
+                                                                         off_t addr) -> io_result {
+            if (addr >= k_bitmap_lo && addr < k_bitmap_hi) bitmap_sync_written = true;
+            return ublkpp::iovec_len(iovecs, iovecs + nr_vecs);
+        });
+
+    {
+        auto raid = ublkpp::raid1::Raid1Disk(boost::uuids::string_generator()(test_uuid), device_a, device_b);
+        raid.toggle_resync(false);
+
+        // Write marks a bitmap chunk dirty. The missing backup absorbs the failure silently
+        // (already degraded), so __become_degraded is not re-entered.
+        iovec iov{nullptr, 32 * Ki};
+        std::ignore = raid.sync_iov(UBLK_IO_OP_WRITE, &iov, 1, 0);
+    }
+
+    EXPECT_TRUE(bitmap_sync_written)
+        << "Bug M11: bitmap was not flushed to active device at shutdown when backup is missing";
+}
+
 // We should throw if both devices are missing
 TEST(Raid1, MissingDisks) {
     auto device_a = ublkpp::make_missing_disk();

--- a/src/raid/raid1/tests/superblock/missing_disk.cpp
+++ b/src/raid/raid1/tests/superblock/missing_disk.cpp
@@ -142,6 +142,44 @@ TEST(Raid1, BitmapFlushedToActiveWhenBackupMissing) {
         << "Bug M11: bitmap was not flushed to active device at shutdown when backup is missing";
 }
 
+// Regression: missing device + previously degraded + unclean shutdown must dirty the entire bitmap.
+// The superbitmap cannot be trusted when clean_unmount=0 and the array was already degraded
+// (route != EITHER). dirty_region(0, capacity()) is called instead of load_from, and the age is
+// bumped by 16. At shutdown sync_to flushes the now-dirty bitmap page to the active device.
+TEST(Raid1, MissingDevicePreviouslyDegradedUncleanDirtiesAll) {
+    auto device_a = std::make_shared< ublkpp::TestDisk >(TestParams{.capacity = Gi, .is_slot_b = false});
+    auto device_b = ublkpp::make_missing_disk();
+
+    bool bitmap_page_written = false;
+    constexpr off_t k_bitmap_lo = static_cast< off_t >(ublkpp::raid1::k_page_size);
+
+    EXPECT_CALL(*device_a, sync_iov(UBLK_IO_OP_READ, _, _, _))
+        .Times(1)
+        .WillOnce([](uint8_t, iovec* iovecs, uint32_t, off_t) -> io_result {
+            memcpy(iovecs->iov_base, &normal_superblock, ublkpp::raid1::k_page_size);
+            auto* sb = reinterpret_cast< ublkpp::raid1::SuperBlock* >(iovecs->iov_base);
+            sb->fields.read_route = static_cast< uint8_t >(ublkpp::raid1::read_route::DEVA);
+            sb->fields.device_b = 0;
+            sb->fields.clean_unmount = 0; // unclean shutdown while already degraded
+            return ublkpp::raid1::k_page_size;
+        });
+
+    {
+        auto raid = ublkpp::raid1::Raid1Disk(boost::uuids::string_generator()(test_uuid), device_a, device_b);
+        auto const bitmap_hi = static_cast< off_t >(raid.reserved_size());
+
+        EXPECT_CALL(*device_a, sync_iov(UBLK_IO_OP_WRITE, _, _, _))
+            .Times(::testing::AnyNumber())
+            .WillRepeatedly([&bitmap_page_written, k_bitmap_lo, bitmap_hi](uint8_t, iovec* iovecs, uint32_t nr_vecs,
+                                                                           off_t addr) -> io_result {
+                if (addr >= k_bitmap_lo && addr < bitmap_hi) bitmap_page_written = true;
+                return ublkpp::iovec_len(iovecs, iovecs + nr_vecs);
+            });
+    }
+
+    EXPECT_TRUE(bitmap_page_written) << "dirty_region must cause bitmap flush at shutdown";
+}
+
 // We should throw if both devices are missing
 TEST(Raid1, MissingDisks) {
     auto device_a = ublkpp::make_missing_disk();

--- a/src/raid/raid1/tests/superblock/missing_disk.cpp
+++ b/src/raid/raid1/tests/superblock/missing_disk.cpp
@@ -24,10 +24,12 @@ TEST(Raid1, MissingDiskA) {
 // the route - which inverted to the missing slot on remount, causing a fatal superblock write error.
 TEST(Raid1, MissingRemountA) {
     // device_b returns the superblock as persisted from the first degraded mount:
-    // read_route=DEVB, device_b=1, clean_unmount=1 (i.e. device_a was missing last time too)
+    // read_route=DEVB, device_b=1, clean_unmount=1 (i.e. device_a was missing last time too).
+    // superbitmap_reserved[0]=0x01: page 0 dirty — satisfies the invariant that any previously-
+    // degraded clean-shutdown must have at least one dirty page persisted in the superbitmap.
     auto device_b = std::make_shared< ublkpp::TestDisk >(TestParams{.capacity = Gi, .is_slot_b = true});
     EXPECT_CALL(*device_b, sync_iov(UBLK_IO_OP_READ, _, _, _))
-        .Times(1)
+        .Times(2)
         .WillOnce([](uint8_t, iovec* iovecs, uint32_t nr_vecs, off_t addr) -> io_result {
             EXPECT_EQ(1U, nr_vecs);
             EXPECT_EQ(ublkpp::raid1::k_page_size, ublkpp::iovec_len(iovecs, iovecs + nr_vecs));
@@ -36,6 +38,15 @@ TEST(Raid1, MissingRemountA) {
             auto* sb = reinterpret_cast< ublkpp::raid1::SuperBlock* >(iovecs->iov_base);
             sb->fields.read_route = static_cast< uint8_t >(ublkpp::raid1::read_route::DEVB);
             sb->fields.device_b = 1;
+            sb->superbitmap_reserved[0] = 0x01; // page 0 dirty — invariant: non-empty superbitmap
+            return ublkpp::raid1::k_page_size;
+        })
+        .WillOnce([](uint8_t, iovec* iovecs, uint32_t nr_vecs, off_t addr) -> io_result {
+            // load_from reads bitmap page 0 (superbitmap bit 0 set)
+            EXPECT_EQ(1U, nr_vecs);
+            EXPECT_EQ(ublkpp::raid1::k_page_size, ublkpp::iovec_len(iovecs, iovecs + nr_vecs));
+            EXPECT_EQ(static_cast< off_t >(ublkpp::raid1::k_page_size), addr);
+            memset(iovecs->iov_base, 0xFF, ublkpp::raid1::k_page_size); // dirty page
             return ublkpp::raid1::k_page_size;
         });
     // __become_active must write to device_b (the live slot), not to device_a (missing)
@@ -58,10 +69,12 @@ TEST(Raid1, MissingRemountA) {
 
 TEST(Raid1, MissingRemountB) {
     // device_a returns the superblock as persisted from the first degraded mount:
-    // read_route=DEVA, device_b=0, clean_unmount=1 (i.e. device_b was missing last time too)
+    // read_route=DEVA, device_b=0, clean_unmount=1 (i.e. device_b was missing last time too).
+    // superbitmap_reserved[0]=0x01: page 0 dirty — satisfies the invariant that any previously-
+    // degraded clean-shutdown must have at least one dirty page persisted in the superbitmap.
     auto device_a = std::make_shared< ublkpp::TestDisk >(TestParams{.capacity = Gi, .is_slot_b = false});
     EXPECT_CALL(*device_a, sync_iov(UBLK_IO_OP_READ, _, _, _))
-        .Times(1)
+        .Times(2)
         .WillOnce([](uint8_t, iovec* iovecs, uint32_t nr_vecs, off_t addr) -> io_result {
             EXPECT_EQ(1U, nr_vecs);
             EXPECT_EQ(ublkpp::raid1::k_page_size, ublkpp::iovec_len(iovecs, iovecs + nr_vecs));
@@ -70,6 +83,15 @@ TEST(Raid1, MissingRemountB) {
             auto* sb = reinterpret_cast< ublkpp::raid1::SuperBlock* >(iovecs->iov_base);
             sb->fields.read_route = static_cast< uint8_t >(ublkpp::raid1::read_route::DEVA);
             sb->fields.device_b = 0;
+            sb->superbitmap_reserved[0] = 0x01; // page 0 dirty — invariant: non-empty superbitmap
+            return ublkpp::raid1::k_page_size;
+        })
+        .WillOnce([](uint8_t, iovec* iovecs, uint32_t nr_vecs, off_t addr) -> io_result {
+            // load_from reads bitmap page 0 (superbitmap bit 0 set)
+            EXPECT_EQ(1U, nr_vecs);
+            EXPECT_EQ(ublkpp::raid1::k_page_size, ublkpp::iovec_len(iovecs, iovecs + nr_vecs));
+            EXPECT_EQ(static_cast< off_t >(ublkpp::raid1::k_page_size), addr);
+            memset(iovecs->iov_base, 0xFF, ublkpp::raid1::k_page_size); // dirty page
             return ublkpp::raid1::k_page_size;
         });
     // __become_active must write to device_a (the live slot), not to device_b (missing)

--- a/src/raid/raid1/tests/superblock/missing_disk.cpp
+++ b/src/raid/raid1/tests/superblock/missing_disk.cpp
@@ -107,7 +107,6 @@ TEST(Raid1, BitmapFlushedToActiveWhenBackupMissing) {
 
     bool bitmap_sync_written = false;
     constexpr off_t k_bitmap_lo = static_cast< off_t >(ublkpp::raid1::k_page_size);
-    constexpr off_t k_bitmap_hi = static_cast< off_t >(64 * 1024 * 1024);
 
     EXPECT_CALL(*device_a, sync_iov(UBLK_IO_OP_READ, _, _, _))
         .Times(1)
@@ -120,17 +119,18 @@ TEST(Raid1, BitmapFlushedToActiveWhenBackupMissing) {
             return ublkpp::raid1::k_page_size;
         });
 
-    EXPECT_CALL(*device_a, sync_iov(UBLK_IO_OP_WRITE, _, _, _))
-        .Times(::testing::AnyNumber())
-        .WillRepeatedly([&bitmap_sync_written, k_bitmap_lo, k_bitmap_hi](uint8_t, iovec* iovecs, uint32_t nr_vecs,
-                                                                         off_t addr) -> io_result {
-            if (addr >= k_bitmap_lo && addr < k_bitmap_hi) bitmap_sync_written = true;
-            return ublkpp::iovec_len(iovecs, iovecs + nr_vecs);
-        });
-
     {
         auto raid = ublkpp::raid1::Raid1Disk(boost::uuids::string_generator()(test_uuid), device_a, device_b);
         raid.toggle_resync(false);
+        auto const bitmap_hi = static_cast< off_t >(raid.reserved_size());
+
+        EXPECT_CALL(*device_a, sync_iov(UBLK_IO_OP_WRITE, _, _, _))
+            .Times(::testing::AnyNumber())
+            .WillRepeatedly([&bitmap_sync_written, k_bitmap_lo, bitmap_hi](uint8_t, iovec* iovecs, uint32_t nr_vecs,
+                                                                           off_t addr) -> io_result {
+                if (addr >= k_bitmap_lo && addr < bitmap_hi) bitmap_sync_written = true;
+                return ublkpp::iovec_len(iovecs, iovecs + nr_vecs);
+            });
 
         // Write marks a bitmap chunk dirty. The missing backup absorbs the failure silently
         // (already degraded), so __become_degraded is not re-entered.

--- a/src/raid/raid1/tests/superblock/missing_disk.cpp
+++ b/src/raid/raid1/tests/superblock/missing_disk.cpp
@@ -25,11 +25,9 @@ TEST(Raid1, MissingDiskA) {
 TEST(Raid1, MissingRemountA) {
     // device_b returns the superblock as persisted from the first degraded mount:
     // read_route=DEVB, device_b=1, clean_unmount=1 (i.e. device_a was missing last time too).
-    // superbitmap_reserved[0]=0x01: page 0 dirty — satisfies the invariant that any previously-
-    // degraded clean-shutdown must have at least one dirty page persisted in the superbitmap.
     auto device_b = std::make_shared< ublkpp::TestDisk >(TestParams{.capacity = Gi, .is_slot_b = true});
     EXPECT_CALL(*device_b, sync_iov(UBLK_IO_OP_READ, _, _, _))
-        .Times(2)
+        .Times(1)
         .WillOnce([](uint8_t, iovec* iovecs, uint32_t nr_vecs, off_t addr) -> io_result {
             EXPECT_EQ(1U, nr_vecs);
             EXPECT_EQ(ublkpp::raid1::k_page_size, ublkpp::iovec_len(iovecs, iovecs + nr_vecs));
@@ -38,15 +36,6 @@ TEST(Raid1, MissingRemountA) {
             auto* sb = reinterpret_cast< ublkpp::raid1::SuperBlock* >(iovecs->iov_base);
             sb->fields.read_route = static_cast< uint8_t >(ublkpp::raid1::read_route::DEVB);
             sb->fields.device_b = 1;
-            sb->superbitmap_reserved[0] = 0x01; // page 0 dirty — invariant: non-empty superbitmap
-            return ublkpp::raid1::k_page_size;
-        })
-        .WillOnce([](uint8_t, iovec* iovecs, uint32_t nr_vecs, off_t addr) -> io_result {
-            // load_from reads bitmap page 0 (superbitmap bit 0 set)
-            EXPECT_EQ(1U, nr_vecs);
-            EXPECT_EQ(ublkpp::raid1::k_page_size, ublkpp::iovec_len(iovecs, iovecs + nr_vecs));
-            EXPECT_EQ(static_cast< off_t >(ublkpp::raid1::k_page_size), addr);
-            memset(iovecs->iov_base, 0xFF, ublkpp::raid1::k_page_size); // dirty page
             return ublkpp::raid1::k_page_size;
         });
     // __become_active must write to device_b (the live slot), not to device_a (missing)
@@ -70,11 +59,9 @@ TEST(Raid1, MissingRemountA) {
 TEST(Raid1, MissingRemountB) {
     // device_a returns the superblock as persisted from the first degraded mount:
     // read_route=DEVA, device_b=0, clean_unmount=1 (i.e. device_b was missing last time too).
-    // superbitmap_reserved[0]=0x01: page 0 dirty — satisfies the invariant that any previously-
-    // degraded clean-shutdown must have at least one dirty page persisted in the superbitmap.
     auto device_a = std::make_shared< ublkpp::TestDisk >(TestParams{.capacity = Gi, .is_slot_b = false});
     EXPECT_CALL(*device_a, sync_iov(UBLK_IO_OP_READ, _, _, _))
-        .Times(2)
+        .Times(1)
         .WillOnce([](uint8_t, iovec* iovecs, uint32_t nr_vecs, off_t addr) -> io_result {
             EXPECT_EQ(1U, nr_vecs);
             EXPECT_EQ(ublkpp::raid1::k_page_size, ublkpp::iovec_len(iovecs, iovecs + nr_vecs));
@@ -83,15 +70,6 @@ TEST(Raid1, MissingRemountB) {
             auto* sb = reinterpret_cast< ublkpp::raid1::SuperBlock* >(iovecs->iov_base);
             sb->fields.read_route = static_cast< uint8_t >(ublkpp::raid1::read_route::DEVA);
             sb->fields.device_b = 0;
-            sb->superbitmap_reserved[0] = 0x01; // page 0 dirty — invariant: non-empty superbitmap
-            return ublkpp::raid1::k_page_size;
-        })
-        .WillOnce([](uint8_t, iovec* iovecs, uint32_t nr_vecs, off_t addr) -> io_result {
-            // load_from reads bitmap page 0 (superbitmap bit 0 set)
-            EXPECT_EQ(1U, nr_vecs);
-            EXPECT_EQ(ublkpp::raid1::k_page_size, ublkpp::iovec_len(iovecs, iovecs + nr_vecs));
-            EXPECT_EQ(static_cast< off_t >(ublkpp::raid1::k_page_size), addr);
-            memset(iovecs->iov_base, 0xFF, ublkpp::raid1::k_page_size); // dirty page
             return ublkpp::raid1::k_page_size;
         });
     // __become_active must write to device_a (the live slot), not to device_b (missing)
@@ -141,18 +119,19 @@ TEST(Raid1, BitmapFlushedToActiveWhenBackupMissing) {
             return ublkpp::raid1::k_page_size;
         });
 
+    // Register WRITE expectation before construction so __become_active's SB write is covered.
+    // Bitmap pages live at offsets >= k_page_size; the SB write at offset 0 does not set the flag.
+    EXPECT_CALL(*device_a, sync_iov(UBLK_IO_OP_WRITE, _, _, _))
+        .Times(::testing::AnyNumber())
+        .WillRepeatedly(
+            [&bitmap_sync_written, k_bitmap_lo](uint8_t, iovec* iovecs, uint32_t nr_vecs, off_t addr) -> io_result {
+                if (addr >= k_bitmap_lo) bitmap_sync_written = true;
+                return ublkpp::iovec_len(iovecs, iovecs + nr_vecs);
+            });
+
     {
         auto raid = ublkpp::raid1::Raid1Disk(boost::uuids::string_generator()(test_uuid), device_a, device_b);
         raid.toggle_resync(false);
-        auto const bitmap_hi = static_cast< off_t >(raid.reserved_size());
-
-        EXPECT_CALL(*device_a, sync_iov(UBLK_IO_OP_WRITE, _, _, _))
-            .Times(::testing::AnyNumber())
-            .WillRepeatedly([&bitmap_sync_written, k_bitmap_lo, bitmap_hi](uint8_t, iovec* iovecs, uint32_t nr_vecs,
-                                                                           off_t addr) -> io_result {
-                if (addr >= k_bitmap_lo && addr < bitmap_hi) bitmap_sync_written = true;
-                return ublkpp::iovec_len(iovecs, iovecs + nr_vecs);
-            });
 
         // Write marks a bitmap chunk dirty. The missing backup absorbs the failure silently
         // (already degraded), so __become_degraded is not re-entered.
@@ -186,18 +165,17 @@ TEST(Raid1, MissingDevicePreviouslyDegradedUncleanDirtiesAll) {
             return ublkpp::raid1::k_page_size;
         });
 
-    {
-        auto raid = ublkpp::raid1::Raid1Disk(boost::uuids::string_generator()(test_uuid), device_a, device_b);
-        auto const bitmap_hi = static_cast< off_t >(raid.reserved_size());
-
-        EXPECT_CALL(*device_a, sync_iov(UBLK_IO_OP_WRITE, _, _, _))
-            .Times(::testing::AnyNumber())
-            .WillRepeatedly([&bitmap_page_written, k_bitmap_lo, bitmap_hi](uint8_t, iovec* iovecs, uint32_t nr_vecs,
-                                                                           off_t addr) -> io_result {
-                if (addr >= k_bitmap_lo && addr < bitmap_hi) bitmap_page_written = true;
+    // Register WRITE expectation before construction so __become_active's SB write is covered.
+    // Bitmap pages live at offsets >= k_page_size; the SB write at offset 0 does not set the flag.
+    EXPECT_CALL(*device_a, sync_iov(UBLK_IO_OP_WRITE, _, _, _))
+        .Times(::testing::AnyNumber())
+        .WillRepeatedly(
+            [&bitmap_page_written, k_bitmap_lo](uint8_t, iovec* iovecs, uint32_t nr_vecs, off_t addr) -> io_result {
+                if (addr >= k_bitmap_lo) bitmap_page_written = true;
                 return ublkpp::iovec_len(iovecs, iovecs + nr_vecs);
             });
-    }
+
+    { auto raid = ublkpp::raid1::Raid1Disk(boost::uuids::string_generator()(test_uuid), device_a, device_b); }
 
     EXPECT_TRUE(bitmap_page_written) << "dirty_region must cause bitmap flush at shutdown";
 }


### PR DESCRIPTION
Consolidates and supersedes PRs #273, #277, #282. Fixes three RAID1 state-management bugs from issue #269 (M5, M11, L4).

---

## M5 — Superblock TSan race: non-atomic read of `superbitmap_reserved`

**The race.** The old `write_superblock` passed `_sb` directly as `iov_base`:

```cpp
// old code
sb->fields.read_route = static_cast<uint8_t>(read_route);
if (device_b) sb->fields.device_b = 1;
auto iov = iovec{.iov_base = sb, .iov_len = sb_size};  // sb == _sb.get()
device.sync_iov(UBLK_IO_OP_WRITE, &iov, 1, 0UL);
sb->fields.device_b = 0;  // reset after write
```

This makes the kernel read all 4 KiB of `_sb` — including `superbitmap_reserved` at offset 74 — as a plain non-atomic memory load. Concurrently, IO coroutines call `SuperBitmap::set_bit` → `std::atomic_ref<uint8_t>::fetch_or` on those exact bytes. A non-atomic load racing with an ongoing atomic RMW is undefined behaviour; this is what TSan detects.

**Why concurrent `write_superblock` callers are not the issue.** The state machine gates each path via CAS: `__become_degraded` opens with `CAS(EITHER → DEVA/DEVB)` and only reaches `write_superblock` if it wins from `EITHER`. `__become_clean` only runs when `route != EITHER`. The same CAS argument applies to `__swap_device`. Two `write_superblock` callers cannot overlap — the competing paths are structurally mutually exclusive. The race is with IO coroutines writing to `superbitmap_reserved`, not with other state-machine callers.

**Fix (lock-free).** `write_superblock` now takes `const SuperBlock*` and never mutates `_sb`. It builds a stack-local `alignas(4096) SuperBlock local{}` buffer and copies only the first 74 bytes of `_sb` (header + fields, stopping before `superbitmap_reserved`). `local.fields.read_route` and `local.fields.device_b` are set on the local copy only; the shared `_sb` is never passed as `iov_base`.

The partial `memcpy` eliminates the race: the local buffer is not shared with any other thread, so no concurrent `atomic_ref` operation can overlap the iov read.

**Destructor path.** The destructor passes `include_superbitmap=true` to `write_superblock`, which copies all 4096 bytes including the live superbitmap. This is safe because `_resync_task->stop()` has already halted all IO coroutines before the destructor reaches this call — no concurrent `set_bit` is possible. This also enables the next startup to do a targeted scan (loading only dirty bitmap pages) rather than a full scan.

---

## M11 — Bitmap not flushed when backup is a missing placeholder

**The scenario.** After a hot-swap where the removed disk is replaced with `make_missing_disk()`, the array is degraded with a missing placeholder as backup. User writes dirty bitmap chunks on the active device. On clean shutdown the old destructor checked:

```cpp
if (state.is_degraded && !state.backup_dev->disk->is_missing())
```

The `is_missing()` guard caused `sync_to()` to be **skipped** entirely. Next startup with the newly swapped-in disk saw no dirty bitmap → fell back to a full resync instead of an incremental one.

**Fix.** Remove the `!is_missing()` guard. Condition is now simply `if (state.is_degraded)`. `sync_to()` is always safe: if there are no dirty pages it writes nothing extra.

**Test.** `BitmapFlushedToActiveWhenBackupMissing`: opens a degraded array with a missing backup, issues a write to dirty one bitmap chunk, then verifies at shutdown that a write to the bitmap region (offset ∈ [4096, reserved_size)) was issued to the active device.

---

## L4 — Device too small to hold reserved region

**The problem.** `__init_params()` computed `_reserved_size` then immediately subtracted it from `dev_sectors` without checking the device was large enough. A device smaller than `_reserved_size` caused an unsigned underflow in `dev_sectors`, producing an enormous phantom capacity. The error surface was a confusing "exceeds SuperBitmap max capacity" exception thrown much later in `Bitmap`'s constructor.

**Fix.** After `_reserved_size` is fully computed and aligned, check against `dev_sectors` — which already holds the minimum of both physical devices from the earlier discovery loop. Checking the minimum once is sufficient: the larger device is always ≥ the minimum and passes trivially.

```cpp
auto const min_dev_bytes = our_params.basic.dev_sectors << SECTOR_SHIFT;
if (min_dev_bytes < _reserved_size)
    throw std::runtime_error(
        fmt::format("device too small: {} bytes < reserved {} bytes", min_dev_bytes, _reserved_size));
```

**Test.** `DeviceTooSmallThrows`: constructs with 64 MiB devices (well below the minimum reserved region for any supported configuration) and asserts a `std::runtime_error` containing "device too small".

---

## Test plan

- [x] `Raid1.DeviceTooSmallThrows` — L4
- [x] `Raid1.BitmapFlushedToActiveWhenBackupMissing` — M11 (clean shutdown with missing backup flushes bitmap)
- [x] `Raid1.MissingDevicePreviouslyDegradedUncleanDirtiesAll` — M11 (unclean degraded path dirties all)
- [x] `Raid1.SuperbitmapNonemptyReturnsFalseOnCleanBitmap` — M5 unit test for `superbitmap_nonempty()` helper
- [x] `Raid1.CleanDegradedStartupLoadsFromActiveDevice` — M5 destructor persists superbitmap (`include_superbitmap=true`)
- [x] `Raid1.CleanDegradedStartupEmptySuperbitmapThrows` — M5 guard: zero superbitmap in clean-degraded state throws
- [ ] `GccThreadSanitize` CI — primary verification for M5 (local-buffer approach eliminates the TSan report on `superbitmap_reserved`)
- [ ] All existing RAID1 tests continue to pass

Closes #273, #277, #282.

🤖 Generated with [Claude Code](https://claude.com/claude-code)