### PR TITLE
fix(raid1): B1 — gate __become_clean CAS on active SB write

### DIFF
--- a/src/raid/raid1/raid1.cpp
+++ b/src/raid/raid1/raid1.cpp
@@ -625,13 +625,19 @@ void Raid1Disk::__become_clean() {
     // - When route == DEVB: active_dev is B (is_device_b=true), backup_dev is A (is_device_b=false)
     bool const active_is_device_b = (state.route == read_route::DEVB);
 
-    if (auto sync_res = write_superblock(*state.active_dev->disk, _sb.get(), active_is_device_b, read_route::EITHER);
-        !sync_res) {
-        RLOGW("Could not become clean [uuid:{}]: {}", _str_uuid, sync_res.error().message())
+    // Active device write must succeed before we CAS to EITHER. If it fails, leave the
+    // in-memory route at DEVA/DEVB so it matches the still-degraded on-disk state; diverging
+    // the two would produce wrong startup behaviour on the next mount.
+    if (auto active_res = write_superblock(*state.active_dev->disk, _sb.get(), active_is_device_b, read_route::EITHER);
+        !active_res) {
+        RLOGE("Could not become clean [uuid:{}]: active SB write failed: {}", _str_uuid, active_res.error().message())
+        return;
     }
     if (auto sync_res = write_superblock(*state.backup_dev->disk, _sb.get(), !active_is_device_b, read_route::EITHER);
         !sync_res) {
-        RLOGW("Could not become clean [uuid:{}]: {}", _str_uuid, sync_res.error().message())
+        // Backup write failure is non-fatal: the active device already has the clean SB.
+        // On next restart pick_superblock will choose the active (higher age) device correctly.
+        RLOGW("Could not write clean SB to backup [uuid:{}]: {}", _str_uuid, sync_res.error().message())
     }
 
     // Avoid checking DirtyBitmap going forward on reads/writes

--- a/src/raid/raid1/tests/syncio/CMakeLists.txt
+++ b/src/raid/raid1/tests/syncio/CMakeLists.txt
@@ -11,5 +11,6 @@ list(APPEND RAID1_TEST_SRCS
   syncio/write_degraded_dirty_skips_backup.cpp
   syncio/write_fail_deva.cpp
   syncio/write_fail_devb.cpp
+  syncio/become_clean_sb_fail.cpp
 )
 set(RAID1_TEST_SRCS "${RAID1_TEST_SRCS}" PARENT_SCOPE)

--- a/src/raid/raid1/tests/syncio/become_clean_sb_fail.cpp
+++ b/src/raid/raid1/tests/syncio/become_clean_sb_fail.cpp
@@ -1,0 +1,101 @@
+#include "test_raid1_common.hpp"
+
+#include <atomic>
+#include <condition_variable>
+#include <mutex>
+
+using namespace ublkpp::raid1;
+
+// Regression test for RAID1-B1: __become_clean must not CAS to EITHER when the active device
+// SB write fails.  If the CAS fires despite the failure, in-memory route becomes EITHER while
+// on-disk route stays DEVA — diverged state on next restart (startup would see clean SB on
+// device_a but route=DEVA on device_b and pick the wrong device as primary).
+//
+// Setup: degraded array (route=DEVA, both devices present, clean bitmap).  toggle_resync(true)
+// causes the resync thread to fire complete() immediately (0 dirty pages), which calls
+// __become_clean.  The active device write is made to fail.  With the fix, __become_clean
+// returns without the CAS so the shutdown SB still shows route=DEVA; without the fix it would
+// show EITHER.
+TEST(Raid1, BecomeCleanActiveWriteFailNoCas) {
+    auto device_a = std::make_shared< ublkpp::TestDisk >(TestParams{.capacity = Gi});
+    auto device_b = std::make_shared< ublkpp::TestDisk >(TestParams{.capacity = Gi, .is_slot_b = true});
+
+    // device_a: SB with route=DEVA, age=2 (wins pick_superblock)
+    EXPECT_CALL(*device_a, sync_iov(UBLK_IO_OP_READ, _, _, _))
+        .WillRepeatedly([](uint8_t, iovec* iovecs, uint32_t, off_t addr) -> io_result {
+            if (addr == 0UL) {
+                memcpy(iovecs->iov_base, &normal_superblock, k_page_size);
+                auto* sb = static_cast< SuperBlock* >(iovecs->iov_base);
+                sb->fields.read_route = static_cast< uint8_t >(read_route::DEVA);
+                sb->fields.device_b = 0;
+                sb->fields.clean_unmount = 1;
+                sb->fields.bitmap.age = htobe64(2);
+                // Bit 0 set so superbitmap_nonempty() passes the invariant check in the
+                // constructor. load_from will read the page (all-zeros per the else branch
+                // below), detect it empty via isal_zero_detect, and clear_bit(0) — leaving
+                // dirty_pages()==0 after startup, which triggers the resync complete path.
+                sb->superbitmap_reserved[0] = 0x01;
+            } else {
+                memset(iovecs->iov_base, 0x00, iovecs->iov_len); // empty bitmap pages
+            }
+            return k_page_size;
+        });
+
+    // device_b: SB with route=DEVA, age=1 (loses pick_superblock; age diff == 1 → not new_device)
+    EXPECT_CALL(*device_b, sync_iov(UBLK_IO_OP_READ, _, _, _))
+        .WillRepeatedly([](uint8_t, iovec* iovecs, uint32_t, off_t) -> io_result {
+            memcpy(iovecs->iov_base, &normal_superblock, k_page_size);
+            auto* sb = static_cast< SuperBlock* >(iovecs->iov_base);
+            sb->fields.read_route = static_cast< uint8_t >(read_route::DEVA);
+            sb->fields.device_b = 1;
+            sb->fields.clean_unmount = 1;
+            sb->fields.bitmap.age = htobe64(1);
+            return k_page_size;
+        });
+
+    // device_b accepts any writes (only gets the __become_active SB write; no destructor write
+    // since is_degraded=true; no __become_clean write since active write fails first with fix)
+    EXPECT_CALL(*device_b, sync_iov(UBLK_IO_OP_WRITE, _, _, _))
+        .WillRepeatedly([](uint8_t, iovec* iov, uint32_t, off_t) -> io_result { return iov->iov_len; });
+
+    std::mutex mtx;
+    std::condition_variable cv;
+    bool become_clean_attempted = false;
+    read_route shutdown_route = read_route::EITHER; // initialised to EITHER to detect absence
+
+    // Writes to device_a at offset 0:
+    //   1st: __become_active succeeds
+    //   2nd: __become_clean active write — fail it and signal the test
+    //   later: destructor shutdown SB — capture the route
+    EXPECT_CALL(*device_a, sync_iov(UBLK_IO_OP_WRITE, _, _, (off_t)0))
+        .WillOnce([](uint8_t, iovec* iov, uint32_t, off_t) -> io_result { return iov->iov_len; })
+        .WillOnce([&](uint8_t, iovec*, uint32_t, off_t) -> io_result {
+            {
+                std::lock_guard< std::mutex > lk(mtx);
+                become_clean_attempted = true;
+            }
+            cv.notify_one();
+            return std::unexpected(std::make_error_condition(std::errc::io_error));
+        })
+        .WillRepeatedly([&](uint8_t, iovec* iov, uint32_t, off_t) -> io_result {
+            auto const* sb = static_cast< SuperBlock const* >(iov->iov_base);
+            if (sb->fields.clean_unmount) shutdown_route = static_cast< read_route >(sb->fields.read_route);
+            return iov->iov_len;
+        });
+
+    // Bitmap-area writes are accepted but not expected to occur (empty bitmap)
+    EXPECT_CALL(*device_a, sync_iov(UBLK_IO_OP_WRITE, _, _, testing::Gt((off_t)0)))
+        .WillRepeatedly([](uint8_t, iovec* iov, uint32_t, off_t) -> io_result { return iov->iov_len; });
+
+    {
+        auto raid = ublkpp::raid1::Raid1Disk(boost::uuids::string_generator()(test_uuid), device_a, device_b);
+        raid.toggle_resync(true);
+
+        std::unique_lock< std::mutex > lk(mtx);
+        ASSERT_TRUE(cv.wait_for(lk, std::chrono::seconds(2), [&] { return become_clean_attempted; }))
+            << "resync complete callback did not fire within 2 seconds";
+    } // destructor: stop() joins resync thread, then writes shutdown SB to device_a with current route
+
+    EXPECT_EQ(read_route::DEVA, shutdown_route)
+        << "RAID1-B1: CAS to EITHER must not fire when active SB write fails in __become_clean";
+}


### PR DESCRIPTION
## Summary

One confirmed bug in the RAID1 state machine (from issue #284).

---

### B1 — `__become_clean`: unconditional CAS on active SB write failure

#### The bug

When resync finishes (`dirty_pages() == 0`), `__become_clean()` is called to
promote the array from degraded to healthy. It does three things in sequence:

1. Write the new SB (`clean_unmount=1, route=EITHER`) to the **active** device.
2. Write the new SB to the **backup** device.
3. CAS `_read_route_cache`: `DEVA/DEVB → EITHER`.

Pre-fix, if step 1 fails the function logs `RLOGW` and **falls through** —
steps 2 and 3 still execute. The CAS fires unconditionally.

#### Consequences of the bug

After the CAS:

- **In memory**: `_read_route_cache = EITHER` (healthy).
- **On disk (active)**: SB write failed → disk still has `clean_unmount=0,
  route=DEVA/DEVB` (unclean degraded).

While the process lives there is no data hazard: EITHER-mode routes writes to
both mirrors and both devices are already in sync. The problem surfaces on the
next restart.

**On restart**, `pick_superblock` loads the SB from the active device and sees
`clean_unmount=0` + `route=DEVA/DEVB`. That matches the "previously degraded,
unclean shutdown" branch, which forces a full resync from the active device to
the backup — even though both devices were already identical. The unnecessary
resync can take hours on large volumes.

If the process crashes between the failed SB write and the CAS, the situation
is the same: disk is unclean-degraded, memory never reached EITHER. Next
restart triggers full resync regardless.

#### The fix

Gate the CAS on the active write succeeding. If the write fails → `RLOGE`
(elevated from `RLOGW` — this is a critical event) and `return` without the
CAS.

**Runtime effect when the early return fires:**

- `_read_route_cache` stays at `DEVA/DEVB`, matching the on-disk state.
- The resync task finishes and goes IDLE. `dirty_pages() == 0` — both mirrors
  are in sync.
- Writes continue to fan out to both devices: `is_dirty(addr,len) == false`
  → `__backup_writable()` returns true → both mirrors receive every write.
- Reads go only to the active device (no round-robin) — suboptimal but
  correct.
- `__become_clean` is not retried automatically. The array stays in degraded
  mode until the process is restarted.
- **On restart**: disk shows `clean_unmount=0, route=DEVA/DEVB` → full
  resync. This is still an unnecessary resync (both devices are in sync), but
  it is the same penalty as pre-fix — not worse. After resync, `__become_clean`
  is called again; if the SB write now succeeds the array reaches EITHER and
  full health is restored.

Backup write failure (step 2) remains non-fatal: `RLOGW` only, no early
return. `pick_superblock` will select the active device (which has the clean SB)
on next restart and proceed correctly.

---

## Regression test

`syncio/become_clean_sb_fail.cpp` — starts a degraded array (`route=DEVA`,
`dirty_pages()==0`), makes the active device SB write fail, triggers resync,
and asserts that the shutdown SB written by the destructor still carries
`route=DEVA` (proving the CAS did not fire).

## Test plan

- [ ] `Raid1.BecomeCleanActiveWriteFailNoCas` passes
- [ ] Existing related tests pass: `SyncIoWriteBackupFailDegradeFail`, `ResyncRelaunchAfterComplete`, `SwapDeviceB`, `SwapDeviceA`
- [ ] CI: GccAddressSanitize, GccThreadSanitize, GccCoverage, ClangRelease all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)