### PR TITLE
chore(claude): add /bugs-hunt agentic command

### DIFF
--- a/.claude/commands/bugs-hunt.md
+++ b/.claude/commands/bugs-hunt.md
@@ -1,11 +1,13 @@
 # Bug Hunt — ublkpp
 
+<!-- Last updated: 2026-05-31. KFP entries reflect code as of this date — re-verify before applying if significant time has passed. -->
+
 Systematic correctness audit using parallel discovery agents followed by independent
 verification. Each finding must survive a separate clean-context challenge before it
 is reported as real.
 
-**Scope**: implementation files only (`src/`). Public headers (`include/ublkpp/`) and
-interface-level contracts are out of scope for this hunt.
+**Scope**: implementation files only (`src/`), including internal headers under `src/`.
+Out of scope: public API headers (`include/ublkpp/`) and interface-level contracts.
 
 ---
 
@@ -24,6 +26,17 @@ Operate accordingly:
 
 ---
 
+## Session Setup
+
+Before spawning any agents, choose a session prefix (e.g., last 6 digits of the current
+epoch seconds) and use it as a prefix for **every** output file in this run. This prevents
+silent overwrites on re-runs or concurrent hunts.
+
+Example: prefix `947312` → `/tmp/bh-947312-agent1.md`, `/tmp/bh-947312-verify-01.md`,
+`/tmp/bh-947312-report.md`. Replace `{PREFIX}` with your chosen value throughout.
+
+---
+
 ## Phase 1 — Parallel Discovery (5 agents)
 
 Spawn **5 agents in parallel** using the Agent tool. Send all 5 in a single message so
@@ -32,15 +45,15 @@ files in full, and writes its candidates to a dedicated output file.
 
 | Agent | Scope | Output file |
 |---|---|---|
-| 1 | `src/raid/raid1/bitmap.cpp`, `bitmap.hpp`, `super_bitmap.*` | `/tmp/bh-agent1.md` |
-| 2 | `src/raid/raid1/raid1.cpp` — **runtime** state transitions only (`__become_degraded`, `__become_clean`, `__swap_device`, `async_iov`, `prepare`); `src/raid/raid1/raid1_resync_task.*` | `/tmp/bh-agent2.md` |
-| 3 | `src/raid/raid1/raid1_superblock.*`; startup path in `raid1.cpp` (`__init_*`, `__load_*`, **`__become_active`**) — pay particular attention to `__become_active` failing mid-startup and delegating to `__become_degraded` | `/tmp/bh-agent3.md` |
-| 4 | `src/target/ublkpp_tgt.cpp`, `src/lib/disk_task.*` | `/tmp/bh-agent4.md` |
-| 5 | `src/raid/raid0/raid0.cpp`, `src/driver/`, `src/metrics/` | `/tmp/bh-agent5.md` |
+| 1 | `src/raid/raid1/bitmap.cpp`, `bitmap.hpp`, `super_bitmap.*` | `/tmp/bh-{PREFIX}-agent1.md` |
+| 2 | `src/raid/raid1/raid1.cpp` — **runtime** state transitions only (`__become_degraded`, `__become_clean`, `__swap_device`, `async_iov`, `prepare`); `src/raid/raid1/raid1_resync_task.*`. **Owns `__become_degraded` — Agent 3 treats it as a black box.** | `/tmp/bh-{PREFIX}-agent2.md` |
+| 3 | `src/raid/raid1/raid1_superblock.*`; startup path in `raid1.cpp` (`__init_*`, `__load_*`, **`__become_active`**) — pay particular attention to `__become_active` failing mid-startup and delegating to `__become_degraded`. **Treat `__become_degraded` as a black box; note any concerns for Agent 2 to verify.** | `/tmp/bh-{PREFIX}-agent3.md` |
+| 4 | `src/target/ublkpp_tgt.cpp`, `src/lib/disk_task.*` | `/tmp/bh-{PREFIX}-agent4.md` |
+| 5 | `src/raid/raid0/raid0.cpp`, `src/driver/`, `src/metrics/` | `/tmp/bh-{PREFIX}-agent5.md` |
 
 **Discovery agent prompt must include:**
 - Assigned files (read them in full — do not skim)
-- The Analysis Framework section below
+- The Analysis Framework section below — **paste it verbatim, do not summarize**
 - The million-dollar rule
 - This output format — write raw candidates to the output file, no filtering yet:
 
@@ -65,19 +78,26 @@ files in full, and writes its candidates to a dedicated output file.
 ## Phase 2 — Independent Verification
 
 After all 5 discovery agents complete:
-1. Read **all 5 output files** (`/tmp/bh-agent1.md` through `/tmp/bh-agent5.md`) and collect
-   every candidate into a working list before spawning any verification agent.
-2. Assign each candidate a flat sequential index (01, 02, 03 …) regardless of which discovery
-   agent produced it.
-3. Spawn verification agents in batches of **at most 8 at a time**. The runtime queues excess
-   agents automatically, but keeping batches small avoids overwhelming the context budget.
-   Batch Low-confidence candidates that target the same source file into a single agent.
+1. Read **all 5 output files** (`/tmp/bh-{PREFIX}-agent1.md` through
+   `/tmp/bh-{PREFIX}-agent5.md`) and collect every candidate into a working list
+   before spawning any verification agent. **If any file is missing or empty, report
+   it explicitly** (e.g., "Agent 3 output missing — that subsystem was not audited")
+   before continuing. Do not silently skip it.
+2. **If the working list is empty**: skip Phase 2 and emit `Bug Hunt Report: 0 candidates
+   found.` Do not proceed to Phase 3.
+3. Assign each candidate a flat sequential index (01, 02, 03 …) regardless of which
+   discovery agent produced it.
+4. Spawn verification agents in batches of **at most 8 at a time** (the per-turn concurrency
+   limit in Claude Code's Agent tool). Batch Low-confidence candidates that target the same
+   source file into a single agent (note: batched agents share file context — an acceptable
+   cost/independence tradeoff for Low-confidence candidates only).
 
-Each verification agent:
+Each verification agent receives: the candidate text, the full Analysis Framework section
+(**paste verbatim**), and the million-dollar rule. It has **no knowledge of what discovery
+agents found** — no other candidates, no discovery reasoning.
 
-- Has **no knowledge of what discovery agents found** — it receives only the candidate text,
-  not the discovery agents' reasoning or other candidates
-- Reads the candidate verbatim from the output file
+The verification agent:
+- Reads the candidate verbatim
 - Reads the relevant source files from scratch, following call chains as needed
 - Applies the million-dollar rule as the only criterion
 - Delivers a verdict: **CONFIRM**, **REJECT**, or **ESCALATE**
@@ -90,16 +110,25 @@ Each verification agent:
 5. **CONFIRM** if the sequence is definitively reachable and produces the claimed harm
 6. **ESCALATE** if uncertain after full investigation — do not guess; ask the user
 
-**Verification output per candidate** — write to `/tmp/bh-verify-NN.md` using the flat
-sequential index assigned in step 2 above (e.g. `/tmp/bh-verify-01.md`, `/tmp/bh-verify-02.md`).
-Batched candidates share one file; list all their IDs in the filename comment:
-```
-### [CONFIRMED | REJECTED | ESCALATE] Candidate [N.X]: [Title]
+**Verification output per candidate** — write to `/tmp/bh-{PREFIX}-verify-NN.md` where NN
+is the **flat sequential index** assigned in step 3 above (e.g. `/tmp/bh-{PREFIX}-verify-01.md`).
+For batched candidates, name the file after the **first** candidate's index and list all IDs
+in a header comment. Use one verdict block per candidate, referenced by flat index:
 
-**Verdict**: ...
+```
+<!-- Candidates: 04, 05, 07 -->
+
+### [CONFIRMED] Candidate 04: [Title]
+**Verdict**: CONFIRMED
 **Evidence**: [exact code path, line numbers, CAS values]
-**REJECTED — blocked by**: [specific gate that prevents it]
-**ESCALATE — scenario for user**: "Please consider: [precise, concrete sequence].
+
+### [REJECTED] Candidate 05: [Title]
+**Verdict**: REJECTED
+**Blocked by**: [specific gate that prevents it, cite the line]
+
+### [ESCALATE] Candidate 07: [Title]
+**Verdict**: ESCALATE
+**Scenario for user**: "Please consider: [precise, concrete sequence].
   Is this execution possible in your deployment?"
 ```
 
@@ -107,8 +136,11 @@ Batched candidates share one file; list all their IDs in the filename comment:
 
 ## Phase 3 — Final Report
 
-After all verification agents complete, read all `/tmp/bh-verify-*.md` files and
-synthesize into one consolidated report:
+After all verification agents complete, read all `/tmp/bh-{PREFIX}-verify-*.md` files and
+synthesize into one consolidated report. **Write the report to `/tmp/bh-{PREFIX}-report.md`**
+and then emit it as a response. After writing the report, clean up intermediate files:
+`rm /tmp/bh-{PREFIX}-agent*.md /tmp/bh-{PREFIX}-verify-*.md` — keep only the report and
+escalations files.
 
 ```
 ## Bug Hunt Report
@@ -121,7 +153,10 @@ synthesize into one consolidated report:
 ### Confirmed Bugs
 
 #### [B1] Title — P0 | P1 | P2
-<!-- Severity: P0 = data loss / corruption | P1 = crash / unavailability | P2 = extra resync / silent wrong behaviour -->
+<!-- Severity:
+     P0 = data loss / corruption
+     P1 = crash / unavailability
+     P2 = extra resync / degraded performance / unnecessary I/O — no data loss or crash path -->
 
 **Location**: file.cpp:line
 **Type**: ...
@@ -138,15 +173,20 @@ synthesize into one consolidated report:
 
 | ID | Title | Rejected because |
 |---|---|---|
-| N.X | ... | CAS at raid1.cpp:620 prevents concurrent entry |
+| 03 | ... | CAS at raid1.cpp:620 prevents concurrent entry |
 
 ---
 
 ### Escalations — Human Review Needed
 
+Write escalations to `/tmp/bh-{PREFIX}-escalations.md` and list them here. For each one,
+present the precise scenario question to the user. After the user responds, spawn a new
+targeted verification agent for any scenario confirmed as possible, adding the deployment
+context to the candidate prompt.
+
 #### [E1] Title
 
-Please consider this scenario: [precise sequence]. Is this possible in your deployment?
+Please consider this scenario: [precise sequence]. Is this execution possible in your deployment?
 ```
 
 ---
@@ -236,6 +276,10 @@ record of the inconsistency. If the ack fires only on the error path (EIO return
 
 ### RAID1 Known False Positives — Verify Before Reporting
 
+> **Staleness warning**: these entries reflect the code as of 2026-05-31. If significant
+> time has passed or the code has changed, re-trace the guard from scratch before applying
+> a pre-emptive REJECT — a stale KFP entry can suppress a real bug.
+
 These patterns look dangerous on first inspection but are structurally impossible. Confirm each
 applies before flagging a finding; if anything in the code path has changed, re-trace from scratch.
 
@@ -264,12 +308,12 @@ Two `write_superblock` calls cannot overlap — the state machine prevents it st
 - The same CAS argument excludes `__swap_device`.
 
 **What TSan actually detects is a different, safe-direction race:** the old code passed `_sb`
-directly as `iov_base`, causing a non-atomic read of `superbitmap_reserved` (bytes 74–4095)
-while IO coroutines call `SuperBitmap::set_bit` → `atomic_ref<uint8_t>::fetch_or` on those same
-bytes. Under the core invariant this race can only go in the safe direction — `fetch_or` only
-sets bits, so memory gets dirtier than disk, never cleaner. It is a TSan warning, not a
-correctness bug. The fix (local-copy buffer stopping at byte 74) silences TSan and is a correct
-cleanup, but the concurrent-callers framing is wrong.
+directly as `iov_base`, causing a non-atomic read of the `superbitmap_reserved` field while IO
+coroutines call `SuperBitmap::set_bit` → `atomic_ref<uint8_t>::fetch_or` on those same bytes.
+Under the core invariant this race can only go in the safe direction — `fetch_or` only sets
+bits, so memory gets dirtier than disk, never cleaner. It is a TSan warning, not a correctness
+bug. The fix (local-copy buffer stopping before `superbitmap_reserved`) silences TSan and is a
+correct cleanup, but the concurrent-callers framing is wrong.
 
 **REJECT** any candidate claiming two concurrent `write_superblock` callers.
 
@@ -286,6 +330,8 @@ Check each explicitly during both discovery and verification:
   - `dirty_pages() == 0` then `complete()` — new dirty page appears between the two calls
 - [ ] CAS loser acts on context captured before the CAS (stale premise)
 - [ ] Signal before check: `sem_post` / completion fires before the `if (success)` guard
+- [ ] Stale capture across `co_await`: value loaded before suspension used after resumption
+  without re-read — another coroutine may have mutated shared state while this one was suspended
 
 **Error handling**
 - [ ] Error from device A sets `unavail` / triggers `__become_degraded` on device B

--- a/.claude/commands/bugs-hunt.md
+++ b/.claude/commands/bugs-hunt.md
@@ -1,6 +1,7 @@
 # Bug Hunt — ublkpp
 
-<!-- Last updated: 2026-05-31. KFP entries reflect code as of this date — re-verify before applying if significant time has passed. -->
+> **KFP last verified: 2026-05-31.** Re-verify Known False Positive entries before running
+> after any refactor touching `Raid1Disk`, `__become_*`, `write_superblock`, or `SuperBitmap`.
 
 Systematic correctness audit using parallel discovery agents followed by independent
 verification. Each finding must survive a separate clean-context challenge before it
@@ -23,6 +24,9 @@ Operate accordingly:
 - "This looks suspicious" is not a finding. "This exact sequence produces data loss:
   1. Thread A does X, 2. Thread B does Y, 3. result Z is wrong" is a finding.
 - Removing a false positive is always correct. Keeping an uncertain finding is never correct.
+- **"No bugs found" is a valid and valuable outcome.** If the code is correct, say so. Do
+  not manufacture findings to justify the run — a clean report is the most useful output
+  when the codebase is actually sound.
 
 ---
 
@@ -40,15 +44,23 @@ Use the output (e.g., `3847201`) as a prefix for **every** output file and shell
 in this run. This prevents silent overwrites on re-runs or concurrent hunts — a timestamp
 suffix is not used because two runs starting in the same second would collide.
 
-After generating the prefix, verify no prior run left files with it:
+After generating the prefix, announce it prominently in your response so it stays visible
+in the conversation context throughout the session:
+
+```
+SESSION PREFIX: 3847201 — substitute this value for every {PREFIX} in this workflow.
+```
+
+Then verify no prior run left conflicting files:
 
 ```bash
 ls /tmp/bh-3847201-* 2>/dev/null && echo "conflict — regenerate prefix" || echo "prefix clear"
 ```
 
-Find-and-replace `{PREFIX}` in every agent prompt and shell command before emitting — do
-not pass the literal string `{PREFIX}` to agents or the cleanup command. (The Setup section
-example shows the substitution: `{PREFIX}` → `3847201` → `/tmp/bh-3847201-agent1.md`.)
+**{PREFIX} substitution is LLM-enforced**: there is no mechanical check. If the literal
+string `{PREFIX}` is passed to an agent, the sentinel check passes vacuously (no files
+found) and Phase 2 will report all agents as unaudited. The announced prefix above is the
+guard — reference it explicitly when constructing each agent prompt.
 
 Example: prefix `3847201` → `/tmp/bh-3847201-agent1.md`, `/tmp/bh-3847201-verify-01.md`,
 `/tmp/bh-3847201-report.md`. The PREFIX is preserved in the report and escalations filenames
@@ -76,7 +88,8 @@ files in full, and writes its candidates to a dedicated output file.
 **Discovery agent prompt must include:**
 - Assigned files (read them in full — do not skim)
 - The Analysis Framework section below — **paste it verbatim, do not summarize**
-  (this is intentional; the token cost buys consistent reasoning across all agents)
+  (intentional: ~300 tokens × 15+ agents ≈ 4–5k tokens overhead per run; accepted cost
+  for consistent reasoning)
 - The million-dollar rule
 - This output format — write raw candidates to the output file, no filtering yet:
 
@@ -136,18 +149,18 @@ After all 5 discovery agents complete:
    are the same issue if they point to the same code location AND the trigger sequence
    produces the same harmful outcome — merge them into one rather than spawning two
    independent verifiers. Same location but different harmful outcome = keep both.
-2. **If the working list is empty**: skip Phase 2 and emit `Bug Hunt Report: 0 candidates
-   found.` Do not proceed to Phase 3.
-3. Assign each candidate a flat sequential index (01, 02, 03 …) regardless of which
-   discovery agent produced it.
-4. Each candidate gets its own agent. Prefer batches of **≤ 8 agents per turn** to stay
-   within the context window budget; if you have strong reason to exceed this, proceed but
-   note the quality risk. If there are more than 8 candidates total, run them in rounds of
-   8 — read all outputs from round N (applying the same sentinel-check as for discovery
-   files) before spawning round N+1. Only if a single round has more than 8 **Low-confidence**
-   candidates targeting the same source file: batch those into one agent (never High or
-   Medium — batched agents share agent context, and a finding in candidate A may anchor
-   reasoning for candidate B).
+2. **If the working list is empty**: emit `Bug Hunt Report: 0 candidates found — no bugs
+   detected in audited subsystems.` Clean up discovery files (`rm /tmp/bh-{PREFIX}-agent*.md`)
+   and do not proceed to Phase 3.
+3. Sort candidates by agent number, then by candidate number within each agent, then assign
+   a flat sequential index (01, 02, 03 …). Consistent ordering ensures batching by source
+   file groups same-file Low-confidence candidates together naturally.
+4. Each candidate gets its own agent — do not batch unless the user explicitly instructs it
+   (batched agents share context, and a finding in candidate A can anchor reasoning for B).
+   Never batch High or Medium confidence candidates. Prefer **≤ 8 agents per turn** to stay
+   within the context window budget. If there are more than 8 candidates total, run them in
+   rounds of 8 — read all outputs from round N, applying the same sentinel-check
+   (`<!-- END VERIFY NN -->`) as for discovery files, before spawning round N+1.
 
 Each verification agent receives: the candidate text, the full Analysis Framework section
 (**paste verbatim**), and the million-dollar rule. It has **no knowledge of what discovery
@@ -187,7 +200,12 @@ in a header comment. Use one verdict block per candidate, referenced by flat ind
 **Verdict**: ESCALATE
 **Scenario for user**: "Please consider: [precise, concrete sequence].
   Is this execution possible in your deployment?"
+
+<!-- END VERIFY NN -->
 ```
+
+The sentinel `<!-- END VERIFY NN -->` is required on every verify file (NN = flat index).
+Apply the same truncation check as for discovery files before proceeding to the next round.
 
 ---
 
@@ -203,15 +221,17 @@ synthesize into one consolidated report:
    bytes, and every verify file was read without exception. Substitute the actual prefix
    before running (same rule as Phase 1 prompts):
    `rm /tmp/bh-{PREFIX}-agent*.md /tmp/bh-{PREFIX}-verify-*.md`
-   If the `rm` fails (permissions, already deleted), note it but do not treat it as a
-   Phase 3 failure — the report is already written. The report and escalations files are
-   always kept. Do not run if Phase 3 failed mid-synthesis (intermediates needed to retry).
+   Note: the glob `verify-*.md` matches escalation re-verification files (`verify-ENN.md`)
+   as well — this is intentional. If the `rm` fails (permissions, already deleted), note it
+   but do not treat it as a Phase 3 failure — the report is already written. The report and
+   escalations files are always kept. Do not run if Phase 3 failed mid-synthesis.
 
 ```
 ## Bug Hunt Report
 
 **Scope**: [subsystems]
 **Candidates**: N total — Confirmed: X | Rejected: Y | Escalated: Z
+**Coverage**: All 5 agents audited | *or* Agent N unaudited (truncated/missing — [reason])
 
 ---
 
@@ -348,7 +368,9 @@ record of the inconsistency. If the ack fires only on the error path (EIO return
 RAID0, driver, or metrics code. Skip this section when scoped to Agent 5.
 
 **Staleness gate**: re-audit this entire section before running after any refactor touching
-`Raid1Disk`, `__become_*`, `write_superblock`, or `SuperBitmap`.
+`Raid1Disk`, `__become_*`, `write_superblock`, or `SuperBitmap`. There is no automated
+check — if you modify these functions, manually verify the relevant KFP entries still hold
+before the next hunt run.
 
 These patterns look dangerous on first inspection but are structurally impossible. Each entry
 is anchored to a specific invariant — if that invariant changes in the code, re-trace from

--- a/.claude/commands/bugs-hunt.md
+++ b/.claude/commands/bugs-hunt.md
@@ -55,7 +55,7 @@ files in full, and writes its candidates to a dedicated output file.
 | 1 | `src/raid/raid1/bitmap.cpp`, `src/raid/raid1/bitmap.hpp`, `src/raid/raid1/super_bitmap.cpp`, `src/raid/raid1/super_bitmap.hpp` | `/tmp/bh-{PREFIX}-agent1.md` |
 | 2 | `src/raid/raid1/raid1.cpp` — **runtime** state transitions only (`__become_degraded`, `__become_clean`, `__swap_device`, `async_iov`, `prepare`); `src/raid/raid1/raid1_resync_task.*`. **Owns `__become_degraded` — Agent 3 treats it as a black box.** | `/tmp/bh-{PREFIX}-agent2.md` |
 | 3 | `src/raid/raid1/raid1_superblock.*`; startup path in `raid1.cpp` (`__init_*`, `__load_*`, **`__become_active`**) — pay particular attention to `__become_active` failing mid-startup and delegating to `__become_degraded`. **Treat `__become_degraded` as a black box; log cross-boundary concerns in the XB section (see output format below).** | `/tmp/bh-{PREFIX}-agent3.md` |
-| 4 | `src/target/ublkpp_tgt.cpp`, `src/target/ublkpp_tgt_impl.hpp`, `src/lib/disk_task.hpp`, `src/lib/disk_task.cpp`, `src/lib/cqe_state.hpp` | `/tmp/bh-{PREFIX}-agent4.md` |
+| 4 | `src/target/ublkpp_tgt.cpp`, `src/target/ublkpp_tgt_impl.hpp`, `src/lib/ublk_disk.cpp` | `/tmp/bh-{PREFIX}-agent4.md` |
 | 5 | `src/raid/raid0/raid0.cpp`, `src/driver/`, `src/metrics/` | `/tmp/bh-{PREFIX}-agent5.md` |
 
 **Discovery agent prompt must include:**
@@ -100,18 +100,20 @@ After all 5 discovery agents complete:
    `/tmp/bh-{PREFIX}-agent5.md`) and collect every candidate into a working list
    before spawning any verification agent. **If any file is missing or empty, report
    it explicitly** (e.g., "Agent 3 output missing — that subsystem was not audited")
-   before continuing. Do not silently skip it. Also collect any `## Cross-Boundary
-   Concerns` sections from `agent3.md` — merge each XB entry with Agent 2's candidates
-   and treat it as a single candidate for verification.
+   before continuing. Do not silently skip it — a missing agent output means that
+   subsystem is unaudited; do not synthesize a partial report. Also collect any
+   `## Cross-Boundary Concerns` sections from `agent3.md` — merge each XB entry with
+   Agent 2's candidates and treat it as a single candidate for verification.
 2. **If the working list is empty**: skip Phase 2 and emit `Bug Hunt Report: 0 candidates
    found.` Do not proceed to Phase 3.
 3. Assign each candidate a flat sequential index (01, 02, 03 …) regardless of which
    discovery agent produced it.
 4. Spawn verification agents in batches of **at most 8 at a time** (the per-turn concurrency
    limit in Claude Code's Agent tool). Each candidate gets its own agent. If there are more
-   than 8 candidates total and batching is unavoidable, batch only **Low-confidence** candidates
-   targeting the same source file — never High or Medium (batched agents share agent context:
-   a finding in candidate A may anchor reasoning for candidate B).
+   than 8 candidates total, run them in rounds of 8 — read all outputs from round N before
+   spawning round N+1. Only if forced by the limit: batch **Low-confidence** candidates
+   targeting the same source file into one agent (never High or Medium — batched agents share
+   agent context, and a finding in candidate A may anchor reasoning for candidate B).
 
 Each verification agent receives: the candidate text, the full Analysis Framework section
 (**paste verbatim**), and the million-dollar rule. It has **no knowledge of what discovery
@@ -207,8 +209,10 @@ synthesize into one consolidated report:
 
 List escalations here and in `/tmp/bh-{PREFIX}-escalations.md` (omit the file if none).
 For each one, present the precise scenario question to the user. After the user responds,
-spawn a new targeted verification agent for any scenario confirmed as possible, adding the
-deployment context to the candidate prompt.
+spawn one verification agent per scenario confirmed as possible, passing the candidate text
+plus the user's deployment context. If confirmed, append findings to a
+`### Confirmed Bugs (Post-Escalation)` section at the bottom of the existing report file.
+Do not re-run Phases 1–3.
 
 #### [E1] Title
 
@@ -302,14 +306,13 @@ record of the inconsistency. If the ack fires only on the error path (EIO return
 
 ### RAID1 Known False Positives — Verify Before Reporting
 
-> **Staleness warning**: these entries reflect the code as of 2026-05-31. If significant
-> time has passed or the code has changed, re-trace the guard from scratch before applying
-> a pre-emptive REJECT — a stale KFP entry can suppress a real bug.
-
-These patterns look dangerous on first inspection but are structurally impossible. Confirm each
-applies before flagging a finding; if anything in the code path has changed, re-trace from scratch.
+These patterns look dangerous on first inspection but are structurally impossible. Each entry
+is anchored to a specific invariant — if that invariant changes in the code, re-trace from
+scratch before applying a pre-emptive REJECT.
 
 #### 1. Destructor races with IO coroutines (phantom)
+
+<!-- Valid while: _resync_task->stop() is the first call in ~Raid1Disk and blocks until all coroutines and in-flight I/O drain before returning. If the destructor order or stop() semantics change, re-verify. -->
 
 `Raid1Disk::~Raid1Disk` is called **after** all IO queues are stopped.
 `_resync_task->stop()` is the first call in the destructor — it joins the resync coroutine
@@ -324,6 +327,8 @@ there are **zero active IO coroutines**. Nothing in the destructor can race with
 
 #### 2a. Concurrent `write_superblock` callers (phantom)
 
+<!-- Valid while: __become_degraded opens with CAS(EITHER→DEVA/DEVB) and reaches write_superblock only on CAS success; __become_clean only runs when route≠EITHER; __swap_device is guarded by the same CAS. If any of these CAS gates are removed or bypassed, re-verify. -->
+
 Two `write_superblock` calls cannot overlap — the state machine prevents it structurally:
 
 - `__become_degraded` opens with `CAS(EITHER → DEVA/DEVB)`. It only proceeds past the CAS —
@@ -336,6 +341,8 @@ Two `write_superblock` calls cannot overlap — the state machine prevents it st
 **REJECT** any candidate claiming two concurrent `write_superblock` callers.
 
 #### 2b. TSan report on `superbitmap_reserved` during superblock write (safe direction)
+
+<!-- Valid while: SuperBitmap::set_bit uses atomic_ref<uint8_t>::fetch_or (set-only); write_superblock copies the superblock buffer excluding superbitmap_reserved. If set_bit gains a clear path or write_superblock includes superbitmap_reserved in the copy, re-verify. -->
 
 TSan may flag a race between `write_superblock` reading `_sb` as raw bytes (via `iov_base`)
 and IO coroutines calling `SuperBitmap::set_bit` → `atomic_ref<uint8_t>::fetch_or` on the

--- a/.claude/commands/bugs-hunt.md
+++ b/.claude/commands/bugs-hunt.md
@@ -32,34 +32,36 @@ Operate accordingly:
 
 ## Session Setup
 
-Run the following via the Bash tool to create the working directory:
+All output files go in `.claude/bugs-hunt/` (repo-scoped, survives reboots). Re-running
+overwrites all previous files including the report — this is intentional.
 
-```bash
-mkdir -p /tmp/bugs-hunt
-```
-
-All output files go in `/tmp/bugs-hunt/`. Re-running the command overwrites previous
-results — this is intentional. Before starting, check whether KFP-relevant code has changed since you last ran this command.
-If `Raid1Disk`, `__become_*`, `write_superblock`, or `SuperBitmap` were modified in recent
-commits, re-verify the Known False Positive entries before trusting them.
+Before starting, check whether KFP-relevant code has changed since you last ran this
+command. If `Raid1Disk`, `__become_*`, `write_superblock`, or `SuperBitmap` were modified
+in recent commits, re-verify the Known False Positive entries before trusting them.
 
 ---
 
 ## Phase 1 — Parallel Discovery (5 agents)
 
-Spawn **5 agents in parallel** using the Agent tool. Send all 5 in a single message so
-they run concurrently. Each agent is scoped to one subsystem, reads the relevant source
-files in full, and writes its candidates to a dedicated output file.
+Create the working directory, then spawn **5 agents in parallel** using the Agent tool.
+Send all 5 in a single message so they run concurrently.
+
+```bash
+mkdir -p .claude/bugs-hunt
+```
+
+Each agent is scoped to one subsystem, reads the relevant source files in full, and writes
+its candidates to a dedicated output file.
 
 <!-- Scope last reviewed: 2026-05-31. Update when src/ files are renamed, moved, or new subsystems added. -->
 
 | Agent | Scope | Output file |
 |---|---|---|
-| 1 | `src/raid/raid1/bitmap.cpp`, `src/raid/raid1/bitmap.hpp`, `src/raid/raid1/super_bitmap.cpp`, `src/raid/raid1/super_bitmap.hpp` | `/tmp/bugs-hunt/bh-agent1.md` |
-| 2 | `src/raid/raid1/raid1.cpp` — **runtime** state transitions only (`__become_degraded`, `__become_clean`, `__swap_device`, `async_iov`, `prepare`); `src/raid/raid1/raid1_resync_task.*`. **Owns `__become_degraded` — Agent 3 treats it as a black box.** | `/tmp/bugs-hunt/bh-agent2.md` |
-| 3 | `src/raid/raid1/raid1_superblock.*`; startup path in `raid1.cpp` (`__init_*`, `__load_*`, **`__become_active`**) — pay particular attention to `__become_active` failing mid-startup and delegating to `__become_degraded`. **Treat `__become_degraded` as a black box; log cross-boundary concerns in the XB section (see output format below).** | `/tmp/bugs-hunt/bh-agent3.md` |
-| 4 | `src/target/ublkpp_tgt.cpp`, `src/target/ublkpp_tgt_impl.hpp`, `src/lib/ublk_disk.cpp` | `/tmp/bugs-hunt/bh-agent4.md` |
-| 5 | `src/raid/raid0/raid0.cpp`, `src/driver/`, `src/metrics/` | `/tmp/bugs-hunt/bh-agent5.md` |
+| 1 | `src/raid/raid1/bitmap.cpp`, `src/raid/raid1/bitmap.hpp`, `src/raid/raid1/super_bitmap.cpp`, `src/raid/raid1/super_bitmap.hpp` | `.claude/bugs-hunt/bh-agent1.md` |
+| 2 | `src/raid/raid1/raid1.cpp` — **runtime** state transitions only (`__become_degraded`, `__become_clean`, `__swap_device`, `async_iov`, `prepare`); `src/raid/raid1/raid1_resync_task.*`. **Owns `__become_degraded` — Agent 3 treats it as a black box.** | `.claude/bugs-hunt/bh-agent2.md` |
+| 3 | `src/raid/raid1/raid1_superblock.*`; startup path in `raid1.cpp` (`__init_*`, `__load_*`, **`__become_active`**) — pay particular attention to `__become_active` failing mid-startup and delegating to `__become_degraded`. **Treat `__become_degraded` as a black box; log cross-boundary concerns in the XB section (see output format below).** | `.claude/bugs-hunt/bh-agent3.md` |
+| 4 | `src/target/ublkpp_tgt.cpp`, `src/target/ublkpp_tgt_impl.hpp`, `src/lib/ublk_disk.cpp` | `.claude/bugs-hunt/bh-agent4.md` |
+| 5 | `src/raid/raid0/raid0.cpp`, `src/driver/`, `src/metrics/` | `.claude/bugs-hunt/bh-agent5.md` |
 
 **Discovery agent prompt must include:**
 - Assigned files (read them in full — do not skim)
@@ -118,7 +120,7 @@ candidate and note the dependency in its Uncertainty field.
 After all 5 discovery agents complete:
 1. Run a pre-read sentinel check before processing any file:
    ```bash
-   grep -rL "END AGENT" /tmp/bugs-hunt/bh-agent*.md 2>/dev/null
+   grep -rL "END AGENT" .claude/bugs-hunt/bh-agent*.md 2>/dev/null
    ```
    Any file listed by this command is missing its sentinel (truncated or failed). For each:
    ask the user whether to rerun that agent (with the same output file target) or continue
@@ -131,7 +133,7 @@ After all 5 discovery agents complete:
    issue if they point to the same code location AND the trigger sequence produces the same
    harmful outcome — merge them. Same location but different harmful outcome = keep both.
 3. **If the working list is empty**: emit `Bug Hunt Report: 0 candidates found — no bugs
-   detected in audited subsystems.` Clean up discovery files (`rm /tmp/bugs-hunt/bh-agent*.md`)
+   detected in audited subsystems.` Clean up discovery files (`rm .claude/bugs-hunt/bh-agent*.md`)
    and do not proceed to Phase 3.
 4. **If there are ≥ 20 candidates total**: escalate all Low-confidence candidates directly
    to the report as ESCALATE (without spawning verifiers) — treat discovery-time
@@ -141,12 +143,15 @@ After all 5 discovery agents complete:
    sequential index (01, 02, 03 …).
 6. **By default, one candidate per agent.** Run **≤ 8 agents per turn** (sized for the
    current context window; adjust if model context limits change). If there are more than 8
-   candidates total, run them in rounds of 8 — read all outputs from round N, applying the
-   sentinel-check (`<!-- END VERIFY NN -->`) before round N+1. If a discovery agent produces
-   no output after a reasonable wait, treat it as failed and apply the missing-agent protocol
-   (ask user to rerun). **Budget exception only**: if candidate volume makes individual agents
-   impractical, you may put multiple Low-confidence candidates in one agent — never High or
-   Medium.
+   candidates total, run them in rounds of 8. Before each new round, run:
+   ```bash
+   grep -rL "END VERIFY" .claude/bugs-hunt/bh-verify-*.md 2>/dev/null
+   ```
+   Any file listed is truncated — apply the missing-agent protocol before continuing.
+   If a discovery agent produces no output after a reasonable wait, treat it as failed
+   and ask the user to rerun. **Budget exception**: if there are more than 16 Low-confidence
+   candidates in a single round, batch same-file Low-confidence candidates into one agent
+   (never High or Medium).
 
 Each verification agent receives: the candidate text, the full Analysis Framework section
 (**paste verbatim**), and the million-dollar rule. It has **no knowledge of what discovery
@@ -166,8 +171,8 @@ The verification agent:
 5. **CONFIRM** if the sequence is definitively reachable and produces the claimed harm
 6. **ESCALATE** if uncertain after full investigation — do not guess; ask the user
 
-**Verification output per candidate** — write to `/tmp/bugs-hunt/bh-verify-NN.md` where NN
-is the **flat sequential index** assigned in step 3 above (e.g. `/tmp/bugs-hunt/bh-verify-01.md`).
+**Verification output per candidate** — write to `.claude/bugs-hunt/bh-verify-NN.md` where NN
+is the **flat sequential index** assigned in step 3 above (e.g. `.claude/bugs-hunt/bh-verify-01.md`).
 For batched candidates, name the file after the **first** candidate's index and list all IDs
 in a header comment. Use one verdict block per candidate, referenced by flat index:
 
@@ -199,17 +204,16 @@ sentinel check, masking the truncation. Apply the sentinel check before the next
 
 ## Phase 3 — Final Report
 
-After all verification agents complete, read all `/tmp/bugs-hunt/bh-verify-*.md` files and
+After all verification agents complete, read all `.claude/bugs-hunt/bh-verify-*.md` files and
 synthesize into one consolidated report:
-1. **Write the report to `/tmp/bugs-hunt/bh-report.md`** and emit it as a response.
-2. If any escalations exist, **also write them to `/tmp/bugs-hunt/bh-escalations.md`**
+1. **Write the report to `.claude/bugs-hunt/bh-report.md`** and emit it as a response.
+   As the final line of the report, write: `<!-- BUG HUNT COMPLETE -->`
+2. If any escalations exist, **also write them to `.claude/bugs-hunt/bh-escalations.md`**
    (so the user can re-read them without parsing the full report). Omit this file if there
-   are no escalations.
-3. **Conditionally** clean up intermediate files — only if the report contains the
-   `### Rejected (False Positives)` section header (present in every complete report,
-   absent if synthesis was interrupted), and every verify file was read without exception. Substitute the actual prefix
-   before running (same rule as Phase 1 prompts):
-   `rm /tmp/bugs-hunt/bh-agent*.md /tmp/bugs-hunt/bh-verify-*.md`
+   are no escalations. This file is intentionally kept across re-runs (not cleaned up).
+3. **Conditionally** clean up intermediate files — only if `bh-report.md` ends with
+   `<!-- BUG HUNT COMPLETE -->` and every verify file was read without exception:
+   `rm .claude/bugs-hunt/bh-agent*.md .claude/bugs-hunt/bh-verify-*.md`
    Note: the glob `verify-*.md` matches escalation re-verification files (`verify-ENN.md`)
    as well — this is intentional. If the `rm` fails (permissions, already deleted), note it
    but do not treat it as a Phase 3 failure — the report is already written. The report and
@@ -255,13 +259,13 @@ synthesize into one consolidated report:
 
 ### Escalations — Human Review Needed
 
-List escalations here and in `/tmp/bugs-hunt/bh-escalations.md` (omit the file if none).
+List escalations here and in `.claude/bugs-hunt/bh-escalations.md` (omit the file if none).
 For each one, present the precise scenario question to the user. After the user responds,
 spawn one verification agent per scenario confirmed as possible, passing the candidate text
 plus the user's deployment context. Write each agent's output to
-`/tmp/bugs-hunt/bh-verify-ENN.md` (E prefix for escalation re-verification, NN is the
+`.claude/bugs-hunt/bh-verify-ENN.md` (E prefix for escalation re-verification, NN is the
 escalation number). If confirmed, write findings to a **separate file**
-`/tmp/bugs-hunt/bh-report-escalations.md` (do not append to the existing report — appending
+`.claude/bugs-hunt/bh-report-escalations.md` (do not append to the existing report — appending
 requires read-modify-write which risks partial corruption if synthesis fails mid-write).
 Tell the user to read both the main report and the escalations supplement together.
 Do not re-run Phases 1–3.

--- a/.claude/commands/bugs-hunt.md
+++ b/.claude/commands/bugs-hunt.md
@@ -68,7 +68,7 @@ its candidates to a dedicated output file.
 | 3 | `src/raid/raid1/raid1_superblock.*`; startup path in `raid1.cpp` (`__init_*`, `__load_*`, **`__become_active`**) — pay particular attention to `__become_active` failing mid-startup and delegating to `__become_degraded`. **Treat `__become_degraded` as a black box; log cross-boundary concerns in the XB section (see output format below).** | `.claude/bugs-hunt/bh-agent3.md` |
 | 4 | `src/target/ublkpp_tgt.cpp`, `src/target/ublkpp_tgt_impl.hpp`, `src/lib/ublk_disk.cpp` | `.claude/bugs-hunt/bh-agent4.md` |
 | 5 | `src/raid/raid0/raid0.cpp`, `src/driver/`, `src/metrics/` | `.claude/bugs-hunt/bh-agent5.md` |
-| 6 | **All `.cpp` files in `src/`** (every subsystem) — focused exclusively on arithmetic & geometry invariants: capacity formulas, size computations, stride/alignment assumptions, and cross-subsystem invariant propagation. Must read **both** the consumer (e.g. `raid0.cpp`) and the supplier (e.g. `raid1.cpp`) to verify cross-subsystem alignment guarantees hold. See dedicated brief below. | `.claude/bugs-hunt/bh-agent6.md` |
+| 6 | **All `.cpp` and internal `.hpp` files in `src/`** excluding test subdirectories — focused exclusively on arithmetic & geometry invariants: capacity formulas, size computations, stride/alignment assumptions, and cross-subsystem invariant propagation. Must read **both** the consumer (e.g. `raid0.cpp`) and the supplier (e.g. `raid1.cpp`) to verify cross-subsystem alignment guarantees hold. See dedicated brief below. | `.claude/bugs-hunt/bh-agent6.md` |
 
 **Discovery agent prompt must include:**
 - Assigned files (read them in full — do not skim)
@@ -85,7 +85,7 @@ its candidates to a dedicated output file.
 
 ### Candidate [N.X]: [Title]
 **Location**: file.cpp:line
-**Type**: race | power-loss | TOCTOU | wrong-device | sequencing | version-bounds | other
+**Type**: race | power-loss | TOCTOU | wrong-device | sequencing | version-bounds | arithmetic | other
 **Claim**: [one sentence — what goes wrong and what the impact is]
 **Trigger sequence**:
   1. [exact step]
@@ -105,40 +105,6 @@ its candidates to a dedicated output file.
 The orchestrator uses this to detect truncation — a file that exists but lacks the sentinel
 was interrupted mid-run and should be treated as missing (report explicitly, do not skip).
 
-**Agent 6 only** — dedicated arithmetic & geometry analysis. Ignore races, power-loss,
-and state-machine issues (those are covered by Agents 1–5). Focus entirely on:
-
-**1. Implicit alignment assumptions.**
-For every formula `(x - stride) * n` or `x * n / stride` — what supplies `x`? Is `x`
-guaranteed to be a multiple of `stride`? Read the supplier's implementation (not just its
-callers), check version history, and verify the guarantee holds across all config paths.
-
-**2. Remainder amplification.**
-When a per-unit value is multiplied by a count, any remainder is amplified:
-```
-wrong:  total = (x - reserved) * n       // (x % stride) * n of phantom space
-right:  floor(x, stride) first, then compute
-```
-Phantom space maps to per-unit offsets past the end of the backing device → EIO on
-top-of-device reads (GPT / partition-table scans are a common trigger).
-
-**3. Cross-subsystem invariant propagation.**
-Trace capacity values from supplier to consumer across subsystem boundaries. Example:
-RAID1 leg capacity feeds RAID0's constructor — if RAID1 drops its padding guarantee in a
-new version, RAID0 silently over-reports. The bug is in the consumer (missing floor), not
-the supplier.
-
-**4. Integer division and sector-shift arithmetic.**
-`x >> SECTOR_SHIFT` and `x / stride` truncate; verify that truncation is intentional and
-not a silently-wrong substitute for floor-to-multiple. Check for unit mismatches (bytes
-vs sectors vs chunks).
-
-Agent 6 must read **all `.cpp` files in `src/`** to find every capacity/size formula and
-every cross-subsystem value flow. Pay particular attention to constructors that compute
-`dev_sectors` or `capacity()` from child device values.
-
----
-
 **Agent 3 only** — append a cross-boundary section for anything that doesn't clear the
 Candidate confidence bar but touches `__become_degraded`. Note: the XB channel is the
 **only** path for startup-path findings that straddle the Agent 2/3 boundary — Agent 3
@@ -155,6 +121,35 @@ High-confidence bar, it should write it as an ESCALATE candidate (not suppress i
 **Concern**: [what needs investigating in __become_degraded]
 **Context**: [what Agent 3 observed in __become_active that triggered this]
 ```
+
+**Agent 6 only** — dedicated arithmetic & geometry analysis. Ignore races, power-loss,
+and state-machine issues (Agents 1–5 cover those). Use candidate type `arithmetic`. Focus:
+
+**1. Implicit alignment assumptions.** For every formula `(x - stride) * n` — what supplies
+`x`? Is `x` guaranteed to be a multiple of `stride`? Read the supplier's implementation
+(not just callers), check version history, verify the guarantee holds across all configs.
+
+**2. Remainder amplification.** When a per-unit value is multiplied by a count, any
+remainder is amplified — `(x % stride) * n` of phantom address space past the backing
+device → EIO on top-of-device reads (GPT / partition-table scans are a common trigger):
+```
+wrong:  total = (x - reserved) * n       // remainder × n = phantom space
+right:  floor(x, stride) first, then compute
+```
+
+**3. Cross-subsystem invariant propagation.** Trace capacity values from supplier to
+consumer across subsystem boundaries. The bug lives in the consumer (missing floor), not
+the supplier. Example: RAID1 leg capacity → RAID0 constructor; RAID1 dropping its padding
+guarantee silently breaks RAID0's formula.
+
+**4. Integer division and unit mismatches.** `x >> SECTOR_SHIFT` and `x / stride`
+truncate — verify truncation is intentional and not a silently-wrong substitute for
+floor-to-multiple. Check for bytes vs sectors vs chunks confusion.
+
+Read all `.cpp` and internal `.hpp` files in `src/` (excluding `tests/` subdirectories).
+Pay particular attention to constructors computing `dev_sectors` or `capacity()` from
+child device values. Because Agent 6 reads across subsystems, it can write High-confidence
+arithmetic candidates directly — no XB channel needed.
 
 ---
 
@@ -178,10 +173,10 @@ After all 6 discovery agents complete:
 3. **If the working list is empty**: emit `Bug Hunt Report: 0 candidates found — no bugs
    detected in audited subsystems.` Clean up discovery files (`rm .claude/bugs-hunt/bh-agent*.md`)
    and do not proceed to Phase 3.
-4. **If there are ≥ 20 candidates total**: escalate all Low-confidence candidates directly
+4. **If there are ≥ 24 candidates total**: escalate all Low-confidence candidates directly
    to the report as ESCALATE (without spawning verifiers) — treat discovery-time
    Low-confidence as insufficient evidence when discovery is this broad. <!-- threshold:
-   keep Phase 2 ≤ 4 rounds × 8 agents; recalibrate for larger codebases -->
+   6 agents × ~4 candidates average = ~24; keep Phase 2 ≤ 4 rounds × 8 agents -->
 5. **If High+Medium candidates after step 4 exceed 32**: cap at the top 32 by confidence
    tier then agent number; note the truncation in the Coverage line of the report.
 6. Sort remaining candidates by agent number, then candidate number, then assign a flat
@@ -201,6 +196,10 @@ After all 6 discovery agents complete:
 Each verification agent receives: the candidate text, the full Analysis Framework section
 (**paste verbatim**), and the million-dollar rule. It has **no knowledge of what discovery
 agents found** — no other candidates, no discovery reasoning.
+
+For **Agent 6 (arithmetic) candidates**: the verification agent must read **both** the
+consumer file (where the formula is) and the supplier file (where the input value is
+produced) to verify the cross-subsystem alignment claim. Cite both in Evidence.
 
 The verification agent:
 - Reads the candidate verbatim

--- a/.claude/commands/bugs-hunt.md
+++ b/.claude/commands/bugs-hunt.md
@@ -28,19 +28,22 @@ Operate accordingly:
 
 ## Session Setup
 
-Run the following via the Bash tool to get a stable session prefix:
+Run the following via the Bash tool to get a unique session prefix:
 
 ```bash
-date +%s | tail -c 7
+shuf -i 1000000-9999999 -n1
 ```
 
-Use the output (e.g., `947312`) as a prefix for **every** output file in this run. This
-prevents silent overwrites on re-runs or concurrent hunts. Find-and-replace `{PREFIX}` in
-every agent prompt and shell command before emitting — do not pass the literal string
-`{PREFIX}` to agents or the cleanup command.
+Use the output (e.g., `3847201`) as a prefix for **every** output file and shell command
+in this run. This prevents silent overwrites on re-runs or concurrent hunts — a timestamp
+suffix is not used because two runs starting in the same second would collide.
 
-Example: prefix `947312` → `/tmp/bh-947312-agent1.md`, `/tmp/bh-947312-verify-01.md`,
-`/tmp/bh-947312-report.md`.
+Find-and-replace `{PREFIX}` in every agent prompt and shell command before emitting — do
+not pass the literal string `{PREFIX}` to agents or the cleanup command. (The Setup section
+example shows the substitution: `{PREFIX}` → `3847201` → `/tmp/bh-3847201-agent1.md`.)
+
+Example: prefix `3847201` → `/tmp/bh-3847201-agent1.md`, `/tmp/bh-3847201-verify-01.md`,
+`/tmp/bh-3847201-report.md`.
 
 ---
 
@@ -80,6 +83,15 @@ files in full, and writes its candidates to a dedicated output file.
 **Uncertainty**: [what you're not sure about, if anything]
 ```
 
+**Last line of every agent output file must be the sentinel:**
+
+```
+<!-- END AGENT [N] -->
+```
+
+The orchestrator uses this to detect truncation — a file that exists but lacks the sentinel
+was interrupted mid-run and should be treated as missing (report explicitly, do not skip).
+
 **Agent 3 only** — append a cross-boundary section for anything that doesn't clear the
 Candidate confidence bar but touches `__become_degraded`:
 
@@ -98,18 +110,20 @@ Candidate confidence bar but touches `__become_degraded`:
 After all 5 discovery agents complete:
 1. Read **all 5 output files** (`/tmp/bh-{PREFIX}-agent1.md` through
    `/tmp/bh-{PREFIX}-agent5.md`) and collect every candidate into a working list
-   before spawning any verification agent. **If any file is missing or empty, report
-   it explicitly** (e.g., "Agent 3 output missing — that subsystem was not audited")
-   before continuing. Do not silently skip it — a missing agent output means that
-   subsystem is unaudited; do not synthesize a partial report. Also collect any
-   `## Cross-Boundary Concerns` sections from `agent3.md` — merge each XB entry with
-   Agent 2's candidates and treat it as a single candidate for verification.
+   before spawning any verification agent. For each file: verify it exists, is non-empty,
+   and ends with `<!-- END AGENT N -->`. A file that fails any check was interrupted —
+   **report it explicitly** (e.g., "Agent 3 truncated — that subsystem is unaudited") and
+   halt. Do not synthesize a partial report. Also collect any `## Cross-Boundary Concerns`
+   sections from `agent3.md` and merge each XB entry into the working list as a candidate.
+   After collecting all candidates, **dedup by (source file, claim) before assigning flat
+   indices** — if Agent 2 and an XB entry describe the same issue, merge them into one
+   candidate rather than spawning two independent verifiers.
 2. **If the working list is empty**: skip Phase 2 and emit `Bug Hunt Report: 0 candidates
    found.` Do not proceed to Phase 3.
 3. Assign each candidate a flat sequential index (01, 02, 03 …) regardless of which
    discovery agent produced it.
-4. Spawn verification agents in batches of **at most 8 at a time** (the per-turn concurrency
-   limit in Claude Code's Agent tool). Each candidate gets its own agent. If there are more
+4. Spawn verification agents in batches of **at most 8 at a time** (to stay within the
+   context window budget per turn — not a hard cap, but exceeding it degrades quality). Each candidate gets its own agent. If there are more
    than 8 candidates total, run them in rounds of 8 — read all outputs from round N before
    spawning round N+1. Only if forced by the limit: batch **Low-confidence** candidates
    targeting the same source file into one agent (never High or Medium — batched agents share
@@ -165,9 +179,10 @@ synthesize into one consolidated report:
 2. If any escalations exist, **also write them to `/tmp/bh-{PREFIX}-escalations.md`**
    (so the user can re-read them without parsing the full report). Omit this file if there
    are no escalations.
-3. **Optionally** clean up intermediate files after confirming the report is complete:
+3. **Conditionally** clean up intermediate files — only if `/tmp/bh-{PREFIX}-report.md` is
+   non-empty and Phase 3 completed without error:
    `rm /tmp/bh-{PREFIX}-agent*.md /tmp/bh-{PREFIX}-verify-*.md`
-   Do not run this if Phase 3 failed mid-synthesis — the intermediates are needed to retry.
+   Do not run if Phase 3 failed mid-synthesis (intermediates needed to retry).
    The report and escalations files are always kept.
 
 ```
@@ -210,9 +225,10 @@ synthesize into one consolidated report:
 List escalations here and in `/tmp/bh-{PREFIX}-escalations.md` (omit the file if none).
 For each one, present the precise scenario question to the user. After the user responds,
 spawn one verification agent per scenario confirmed as possible, passing the candidate text
-plus the user's deployment context. If confirmed, append findings to a
-`### Confirmed Bugs (Post-Escalation)` section at the bottom of the existing report file.
-Do not re-run Phases 1–3.
+plus the user's deployment context. Write each agent's output to
+`/tmp/bh-{PREFIX}-verify-ENN.md` (E prefix for escalation re-verification, NN is the
+escalation number). If confirmed, append findings to a `### Confirmed Bugs (Post-Escalation)`
+section at the bottom of the existing report file. Do not re-run Phases 1–3.
 
 #### [E1] Title
 
@@ -306,6 +322,9 @@ record of the inconsistency. If the ack fires only on the error path (EIO return
 
 ### RAID1 Known False Positives — Verify Before Reporting
 
+<!-- Re-audit this entire section before running after any refactor touching
+     Raid1Disk, __become_*, write_superblock, or SuperBitmap. -->
+
 These patterns look dangerous on first inspection but are structurally impossible. Each entry
 is anchored to a specific invariant — if that invariant changes in the code, re-trace from
 scratch before applying a pre-emptive REJECT.
@@ -373,6 +392,9 @@ Check each explicitly during both discovery and verification:
   body may outlive the referent if the owning object is destroyed while the coroutine is suspended
 - [ ] Relaxed atomic as a branch guard: `load(relaxed)` used as a condition without a subsequent
   `acquire` fence — the load can be reordered past dependent loads it was intended to gate
+- [ ] Convention-only protection: field assumed single-threaded but guarded only by a
+  "callers must ensure X" invariant with no lock or atomic — verify the invariant holds on
+  every call path (these don't appear in TSan if the convention is always honored but are fragile)
 
 **Error handling**
 - [ ] Error from device A sets `unavail` / triggers `__become_degraded` on device B

--- a/.claude/commands/bugs-hunt.md
+++ b/.claude/commands/bugs-hunt.md
@@ -72,11 +72,12 @@ its candidates to a dedicated output file.
 **Discovery agent prompt must include:**
 - Assigned files (read them in full — do not skim)
 - The Analysis Framework section below — **paste it verbatim, do not summarize**
-  (~300 tokens × (5 discovery + N verify) agents; at 10 candidates ≈ 4.5k overhead; accepted)
 - If you encounter an unfamiliar pattern (SISL macros, coroutine idioms, etc.), check
   `CLAUDE.md` for project conventions before flagging it as a bug candidate
 - The million-dollar rule
 - This output format — write raw candidates to the output file, no filtering yet:
+
+*(Operator note: framework paste costs ~300 tokens × agent count; at 10 candidates ≈ 4k total overhead — intentional for consistency.)*
 
 ```
 ## Candidate Findings — Agent [N] — [Subsystem]
@@ -144,23 +145,22 @@ After all 5 discovery agents complete:
    and do not proceed to Phase 3.
 4. **If there are ≥ 20 candidates total**: escalate all Low-confidence candidates directly
    to the report as ESCALATE (without spawning verifiers) — treat discovery-time
-   Low-confidence as insufficient evidence when discovery is this broad. <!-- threshold rule:
+   Low-confidence as insufficient evidence when discovery is this broad. <!-- threshold:
    keep Phase 2 ≤ 4 rounds × 8 agents; recalibrate for larger codebases -->
-   Step 6 budget exception applies only after step 4; Low-confidence candidates escalated
-   here don't reach step 6. If High+Medium candidates after dedup exceed 32, cap at the
-   top 32 by confidence tier then agent number, and note the truncation in the report.
-5. Sort remaining candidates by agent number, then candidate number, then assign a flat
+5. **If High+Medium candidates after step 4 exceed 32**: cap at the top 32 by confidence
+   tier then agent number; note the truncation in the Coverage line of the report.
+6. Sort remaining candidates by agent number, then candidate number, then assign a flat
    sequential index (01, 02, 03 …).
-6. **By default, one candidate per agent.** Run **≤ 8 agents per turn** (sized for the
-   current context window; adjust if model context limits change). If there are more than 8
-   candidates total, run them in rounds of 8. Before each new round, run:
+7. **One candidate per agent.** Run **≤ 8 agents per turn** (sized for the current context
+   window; adjust if model context limits change). If there are more than 8 candidates
+   total, run them in rounds of 8. Before each new round, run:
    ```bash
    grep -rL "END VERIFY" .claude/bugs-hunt/bh-verify-*.md 2>/dev/null
    ```
    Any file listed is truncated — apply the missing-agent protocol before continuing.
-   If a discovery agent produces no output after a reasonable wait, treat it as failed
+   If a verification agent produces no output after a reasonable wait, treat it as failed
    and ask the user to rerun. **Budget exception**: if there are more than 16 Low-confidence
-   candidates in a single round, batch same-file Low-confidence candidates into one agent
+   candidates total, batch same-file Low-confidence candidates into one agent per file group
    (never High or Medium).
 
 Each verification agent receives: the candidate text, the full Analysis Framework section
@@ -222,10 +222,11 @@ synthesize into one consolidated report:
    As the final line of the report, write: `<!-- BUG HUNT COMPLETE -->`
 2. If any escalations exist, **also write them to `.claude/bugs-hunt/bh-escalations.md`**
    (so the user can re-read them without parsing the full report). Omit this file if there
-   are no escalations. This file is intentionally kept across re-runs (not cleaned up).
+   are no escalations. This file survives the current run's cleanup but is removed at the
+   start of the next run (Phase 1 setup).
 3. **Conditionally** clean up intermediate files — only if `bh-report.md` ends with
-   `<!-- BUG HUNT COMPLETE -->` and every file listed by
-   `ls .claude/bugs-hunt/bh-verify-*.md` was included in the synthesis:
+   `<!-- BUG HUNT COMPLETE -->` (Phase 2 sentinel checks already confirmed verify files
+   are complete, so no additional check is needed):
    `rm .claude/bugs-hunt/bh-agent*.md .claude/bugs-hunt/bh-verify-*.md`
    Note: `verify-ENN.md` escalation re-verification files are created after Phase 3, so
    they won't exist yet at this cleanup step — the glob will not match them here. They'll

--- a/.claude/commands/bugs-hunt.md
+++ b/.claude/commands/bugs-hunt.md
@@ -32,69 +32,28 @@ Operate accordingly:
 
 ## Session Setup
 
-Run the following via the Bash tool to get a unique session prefix (use the Python fallback
-if `shuf` is absent, e.g. on macOS dev machines):
+Run the following via the Bash tool to create the working directory:
 
 ```bash
-shuf -i 1000000-9999999 -n1
-# fallback: python3 -c "import random; print(random.randint(1000000,9999999))"
+mkdir -p /tmp/bugs-hunt
 ```
 
-Use the output (e.g., `3847201`) as a prefix for **every** output file and shell command
-in this run. This prevents silent overwrites on re-runs or concurrent hunts — a timestamp
-suffix is not used because two runs starting in the same second would collide.
+All output files go in `/tmp/bugs-hunt/`. Re-running the command overwrites previous
+results — this is intentional. Check for KFP staleness before Phase 1:
 
-After generating the prefix, announce it prominently in your response so it stays visible
-in the conversation context throughout the session:
-
-```
-SESSION PREFIX: 3847201 — substitute this value for every {PREFIX} in this workflow.
-```
-
-Then verify no prior run left conflicting files:
-
-```bash
-ls /tmp/bh-3847201-* 2>/dev/null && echo "conflict — regenerate prefix" || echo "prefix clear"
-```
-
-**{PREFIX} substitution is LLM-enforced**. Run this mechanical backstop after announcing
-the prefix — the escaped-brace glob only matches if the literal string `{PREFIX}` leaked:
-
-```bash
-ls /tmp/bh-\{PREFIX\}-* 2>/dev/null && echo "LITERAL BRACE DETECTED — substitution failed" || true
-```
-
-If the literal string is passed to an agent, the sentinel check passes vacuously (no files
-found) and Phase 2 will report all agents as unaudited. The announced prefix and this
-check together are the guards — reference the prefix explicitly in every agent prompt.
-
-Also check for KFP staleness before Phase 1. The KFP entries were last verified at
-commit `f984348`. Run:
 ```bash
 # KFP §1 (destructor) and §2a (CAS gate) — anchored to raid1.cpp:
 git log f984348..HEAD --oneline src/raid/raid1/raid1.cpp
 # KFP §2b (superbitmap safe-direction race) — anchored to super_bitmap.*:
 git log f984348..HEAD --oneline src/raid/raid1/super_bitmap.cpp src/raid/raid1/super_bitmap.hpp
 ```
-Non-empty output for the first command → re-verify §1 and §2a.
-Non-empty output for the second → re-verify §2b.
-If you re-verify and the entries still hold, update the anchor commit hash above.
-Failing to update the hash is not a correctness problem — agents will re-investigate
-already-cleared false positives unnecessarily, but won't miss real bugs.
 
-Example: prefix `3847201` → `/tmp/bh-3847201-agent1.md`, `/tmp/bh-3847201-verify-01.md`,
-`/tmp/bh-3847201-report.md`. The PREFIX is preserved in the report and escalations filenames
-— these are the only files kept after cleanup, so the PREFIX remains recoverable.
+Non-empty output for the first → re-verify §1 and §2a. Second → re-verify §2b. If entries
+still hold after re-verification, update the anchor hash `f984348` above.
 
 ---
 
 ## Phase 1 — Parallel Discovery (5 agents)
-
-**Pre-spawn verification**: emit the 5 actual output filenames before spawning (e.g.,
-`/tmp/bh-3847201-agent1.md` through `/tmp/bh-3847201-agent5.md`), then confirm they match
-the announced SESSION PREFIX. If any contains the literal string `{PREFIX}`, substitution
-failed — stop and re-announce the prefix. This forces the LLM to demonstrate correct
-substitution before any agent is spawned.
 
 Spawn **5 agents in parallel** using the Agent tool. Send all 5 in a single message so
 they run concurrently. Each agent is scoped to one subsystem, reads the relevant source
@@ -104,20 +63,18 @@ files in full, and writes its candidates to a dedicated output file.
 
 | Agent | Scope | Output file |
 |---|---|---|
-| 1 | `src/raid/raid1/bitmap.cpp`, `src/raid/raid1/bitmap.hpp`, `src/raid/raid1/super_bitmap.cpp`, `src/raid/raid1/super_bitmap.hpp` | `/tmp/bh-{PREFIX}-agent1.md` |
-| 2 | `src/raid/raid1/raid1.cpp` — **runtime** state transitions only (`__become_degraded`, `__become_clean`, `__swap_device`, `async_iov`, `prepare`); `src/raid/raid1/raid1_resync_task.*`. **Owns `__become_degraded` — Agent 3 treats it as a black box.** | `/tmp/bh-{PREFIX}-agent2.md` |
-| 3 | `src/raid/raid1/raid1_superblock.*`; startup path in `raid1.cpp` (`__init_*`, `__load_*`, **`__become_active`**) — pay particular attention to `__become_active` failing mid-startup and delegating to `__become_degraded`. **Treat `__become_degraded` as a black box; log cross-boundary concerns in the XB section (see output format below).** | `/tmp/bh-{PREFIX}-agent3.md` |
-| 4 | `src/target/ublkpp_tgt.cpp`, `src/target/ublkpp_tgt_impl.hpp`, `src/lib/ublk_disk.cpp` | `/tmp/bh-{PREFIX}-agent4.md` |
-| 5 | `src/raid/raid0/raid0.cpp`, `src/driver/`, `src/metrics/` | `/tmp/bh-{PREFIX}-agent5.md` |
+| 1 | `src/raid/raid1/bitmap.cpp`, `src/raid/raid1/bitmap.hpp`, `src/raid/raid1/super_bitmap.cpp`, `src/raid/raid1/super_bitmap.hpp` | `/tmp/bugs-hunt/bh-agent1.md` |
+| 2 | `src/raid/raid1/raid1.cpp` — **runtime** state transitions only (`__become_degraded`, `__become_clean`, `__swap_device`, `async_iov`, `prepare`); `src/raid/raid1/raid1_resync_task.*`. **Owns `__become_degraded` — Agent 3 treats it as a black box.** | `/tmp/bugs-hunt/bh-agent2.md` |
+| 3 | `src/raid/raid1/raid1_superblock.*`; startup path in `raid1.cpp` (`__init_*`, `__load_*`, **`__become_active`**) — pay particular attention to `__become_active` failing mid-startup and delegating to `__become_degraded`. **Treat `__become_degraded` as a black box; log cross-boundary concerns in the XB section (see output format below).** | `/tmp/bugs-hunt/bh-agent3.md` |
+| 4 | `src/target/ublkpp_tgt.cpp`, `src/target/ublkpp_tgt_impl.hpp`, `src/lib/ublk_disk.cpp` | `/tmp/bugs-hunt/bh-agent4.md` |
+| 5 | `src/raid/raid0/raid0.cpp`, `src/driver/`, `src/metrics/` | `/tmp/bugs-hunt/bh-agent5.md` |
 
 **Discovery agent prompt must include:**
 - Assigned files (read them in full — do not skim)
 - The Analysis Framework section below — **paste it verbatim, do not summarize**
+  (~300 tokens × (5 discovery + N verify) agents; at 10 candidates ≈ 4.5k overhead; accepted)
 - If you encounter an unfamiliar pattern (SISL macros, coroutine idioms, etc.), check
   `CLAUDE.md` for project conventions before flagging it as a bug candidate
-  (intentional: ~300 tokens × (5 discovery + N verify) agents; at 10 candidates ≈ 4.5k
-   overhead; accepted cost
-  for consistent reasoning)
 - The million-dollar rule
 - This output format — write raw candidates to the output file, no filtering yet:
 
@@ -169,7 +126,7 @@ candidate and note the dependency in its Uncertainty field.
 After all 5 discovery agents complete:
 1. Run a pre-read sentinel check before processing any file:
    ```bash
-   grep -rL "END AGENT" /tmp/bh-{PREFIX}-agent*.md 2>/dev/null
+   grep -rL "END AGENT" /tmp/bugs-hunt/bh-agent*.md 2>/dev/null
    ```
    Any file listed by this command is missing its sentinel (truncated or failed). For each:
    ask the user whether to rerun that agent (with the same output file target) or continue
@@ -182,7 +139,7 @@ After all 5 discovery agents complete:
    issue if they point to the same code location AND the trigger sequence produces the same
    harmful outcome — merge them. Same location but different harmful outcome = keep both.
 3. **If the working list is empty**: emit `Bug Hunt Report: 0 candidates found — no bugs
-   detected in audited subsystems.` Clean up discovery files (`rm /tmp/bh-{PREFIX}-agent*.md`)
+   detected in audited subsystems.` Clean up discovery files (`rm /tmp/bugs-hunt/bh-agent*.md`)
    and do not proceed to Phase 3.
 4. **If there are ≥ 20 candidates total**: escalate all Low-confidence candidates directly
    to the report as ESCALATE (without spawning verifiers) — treat discovery-time
@@ -217,8 +174,8 @@ The verification agent:
 5. **CONFIRM** if the sequence is definitively reachable and produces the claimed harm
 6. **ESCALATE** if uncertain after full investigation — do not guess; ask the user
 
-**Verification output per candidate** — write to `/tmp/bh-{PREFIX}-verify-NN.md` where NN
-is the **flat sequential index** assigned in step 3 above (e.g. `/tmp/bh-{PREFIX}-verify-01.md`).
+**Verification output per candidate** — write to `/tmp/bugs-hunt/bh-verify-NN.md` where NN
+is the **flat sequential index** assigned in step 3 above (e.g. `/tmp/bugs-hunt/bh-verify-01.md`).
 For batched candidates, name the file after the **first** candidate's index and list all IDs
 in a header comment. Use one verdict block per candidate, referenced by flat index:
 
@@ -250,17 +207,17 @@ sentinel check, masking the truncation. Apply the sentinel check before the next
 
 ## Phase 3 — Final Report
 
-After all verification agents complete, read all `/tmp/bh-{PREFIX}-verify-*.md` files and
+After all verification agents complete, read all `/tmp/bugs-hunt/bh-verify-*.md` files and
 synthesize into one consolidated report:
-1. **Write the report to `/tmp/bh-{PREFIX}-report.md`** and emit it as a response.
-2. If any escalations exist, **also write them to `/tmp/bh-{PREFIX}-escalations.md`**
+1. **Write the report to `/tmp/bugs-hunt/bh-report.md`** and emit it as a response.
+2. If any escalations exist, **also write them to `/tmp/bugs-hunt/bh-escalations.md`**
    (so the user can re-read them without parsing the full report). Omit this file if there
    are no escalations.
 3. **Conditionally** clean up intermediate files — only if the report contains the
    `### Rejected (False Positives)` section header (present in every complete report,
    absent if synthesis was interrupted), and every verify file was read without exception. Substitute the actual prefix
    before running (same rule as Phase 1 prompts):
-   `rm /tmp/bh-{PREFIX}-agent*.md /tmp/bh-{PREFIX}-verify-*.md`
+   `rm /tmp/bugs-hunt/bh-agent*.md /tmp/bugs-hunt/bh-verify-*.md`
    Note: the glob `verify-*.md` matches escalation re-verification files (`verify-ENN.md`)
    as well — this is intentional. If the `rm` fails (permissions, already deleted), note it
    but do not treat it as a Phase 3 failure — the report is already written. The report and
@@ -306,13 +263,13 @@ synthesize into one consolidated report:
 
 ### Escalations — Human Review Needed
 
-List escalations here and in `/tmp/bh-{PREFIX}-escalations.md` (omit the file if none).
+List escalations here and in `/tmp/bugs-hunt/bh-escalations.md` (omit the file if none).
 For each one, present the precise scenario question to the user. After the user responds,
 spawn one verification agent per scenario confirmed as possible, passing the candidate text
 plus the user's deployment context. Write each agent's output to
-`/tmp/bh-{PREFIX}-verify-ENN.md` (E prefix for escalation re-verification, NN is the
+`/tmp/bugs-hunt/bh-verify-ENN.md` (E prefix for escalation re-verification, NN is the
 escalation number). If confirmed, write findings to a **separate file**
-`/tmp/bh-{PREFIX}-report-escalations.md` (do not append to the existing report — appending
+`/tmp/bugs-hunt/bh-report-escalations.md` (do not append to the existing report — appending
 requires read-modify-write which risks partial corruption if synthesis fails mid-write).
 Tell the user to read both the main report and the escalations supplement together.
 Do not re-run Phases 1–3.

--- a/.claude/commands/bugs-hunt.md
+++ b/.claude/commands/bugs-hunt.md
@@ -4,6 +4,9 @@ Systematic correctness audit using parallel discovery agents followed by indepen
 verification. Each finding must survive a separate clean-context challenge before it
 is reported as real.
 
+**Scope**: implementation files only (`src/`). Public headers (`include/ublkpp/`) and
+interface-level contracts are out of scope for this hunt.
+
 ---
 
 ## Mindset — The Million-Dollar Rule
@@ -64,12 +67,16 @@ files in full, and writes its candidates to a dedicated output file.
 After all 5 discovery agents complete:
 1. Read **all 5 output files** (`/tmp/bh-agent1.md` through `/tmp/bh-agent5.md`) and collect
    every candidate into a working list before spawning any verification agent.
-2. Spawn **one verification agent per candidate** (batch Low-confidence candidates that target
-   the same source file into a single agent to reduce redundant reads).
+2. Assign each candidate a flat sequential index (01, 02, 03 …) regardless of which discovery
+   agent produced it.
+3. Spawn verification agents in batches of **at most 8 at a time**. The runtime queues excess
+   agents automatically, but keeping batches small avoids overwhelming the context budget.
+   Batch Low-confidence candidates that target the same source file into a single agent.
 
 Each verification agent:
 
-- Has **clean context** — no memory of the discovery phase, no shared state with other agents
+- Has **no knowledge of what discovery agents found** — it receives only the candidate text,
+  not the discovery agents' reasoning or other candidates
 - Reads the candidate verbatim from the output file
 - Reads the relevant source files from scratch, following call chains as needed
 - Applies the million-dollar rule as the only criterion
@@ -83,8 +90,9 @@ Each verification agent:
 5. **CONFIRM** if the sequence is definitively reachable and produces the claimed harm
 6. **ESCALATE** if uncertain after full investigation — do not guess; ask the user
 
-**Verification output per candidate** — write to `/tmp/bh-verify-[N][X].md`
-(e.g. `/tmp/bh-verify-2a.md` for Candidate 2.A; batched candidates share one file):
+**Verification output per candidate** — write to `/tmp/bh-verify-NN.md` using the flat
+sequential index assigned in step 2 above (e.g. `/tmp/bh-verify-01.md`, `/tmp/bh-verify-02.md`).
+Batched candidates share one file; list all their IDs in the filename comment:
 ```
 ### [CONFIRMED | REJECTED | ESCALATE] Candidate [N.X]: [Title]
 
@@ -113,6 +121,7 @@ synthesize into one consolidated report:
 ### Confirmed Bugs
 
 #### [B1] Title — P0 | P1 | P2
+<!-- Severity: P0 = data loss / corruption | P1 = crash / unavailability | P2 = extra resync / silent wrong behaviour -->
 
 **Location**: file.cpp:line
 **Type**: ...

--- a/.claude/commands/bugs-hunt.md
+++ b/.claude/commands/bugs-hunt.md
@@ -32,13 +32,13 @@ Operate accordingly:
 
 ## Session Setup
 
-Run the following via the Bash tool to get a unique session prefix (portable):
+Run the following via the Bash tool to get a unique session prefix (ublk is Linux-only,
+so `shuf` is available; use the Python fallback in containers without util-linux):
 
 ```bash
-python3 -c "import random; print(random.randint(1000000,9999999))"
+shuf -i 1000000-9999999 -n1
+# fallback: python3 -c "import random; print(random.randint(1000000,9999999))"
 ```
-
-On Linux you can also use `shuf -i 1000000-9999999 -n1`.
 
 Use the output (e.g., `3847201`) as a prefix for **every** output file and shell command
 in this run. This prevents silent overwrites on re-runs or concurrent hunts — a timestamp
@@ -62,6 +62,13 @@ string `{PREFIX}` is passed to an agent, the sentinel check passes vacuously (no
 found) and Phase 2 will report all agents as unaudited. The announced prefix above is the
 guard — reference it explicitly when constructing each agent prompt.
 
+Also check for KFP staleness before Phase 1 by running:
+```bash
+git log --since=2026-05-31 --oneline src/raid/raid1/raid1.cpp src/raid/raid1/raid1_superblock.cpp
+```
+A non-empty result means code that KFP entries depend on has changed — re-verify the
+relevant KFP entries before trusting them.
+
 Example: prefix `3847201` → `/tmp/bh-3847201-agent1.md`, `/tmp/bh-3847201-verify-01.md`,
 `/tmp/bh-3847201-report.md`. The PREFIX is preserved in the report and escalations filenames
 — these are the only files kept after cleanup, so the PREFIX remains recoverable.
@@ -70,8 +77,9 @@ Example: prefix `3847201` → `/tmp/bh-3847201-agent1.md`, `/tmp/bh-3847201-veri
 
 ## Phase 1 — Parallel Discovery (5 agents)
 
-**Reminder**: substitute the actual prefix for `{PREFIX}` in every agent prompt and
-filename you emit in this phase — do not pass the literal string `{PREFIX}` to agents.
+**Pre-spawn verification**: before spawning agents, list the 5 output filenames you will
+tell each agent to write to and confirm none contains the literal string `{PREFIX}`. If any
+does, the substitution failed — stop and re-announce the prefix.
 
 Spawn **5 agents in parallel** using the Agent tool. Send all 5 in a single message so
 they run concurrently. Each agent is scoped to one subsystem, reads the relevant source
@@ -122,6 +130,9 @@ was interrupted mid-run and should be treated as missing (report explicitly, do 
 Candidate confidence bar but touches `__become_degraded`. Note: the XB channel is the
 **only** path for startup-path findings that straddle the Agent 2/3 boundary — Agent 3
 cannot confirm or reject such findings directly, only flag them for Agent 2 verification.
+The channel is one-directional (Agent 3 → Agent 2 only). If Agent 2 finds something in
+`__become_degraded` that needs startup-path context, it should write a High-confidence
+candidate and note the dependency in its Uncertainty field.
 
 ```
 ## Cross-Boundary Concerns (for Agent 2 verification)
@@ -136,31 +147,33 @@ cannot confirm or reject such findings directly, only flag them for Agent 2 veri
 ## Phase 2 — Independent Verification
 
 After all 5 discovery agents complete:
-1. Read **all 5 output files** (`/tmp/bh-{PREFIX}-agent1.md` through
-   `/tmp/bh-{PREFIX}-agent5.md`) and collect every candidate into a working list
-   before spawning any verification agent. For each file: verify it exists, is non-empty,
-   and ends with `<!-- END AGENT N -->`. A file that fails any check (missing, empty, or
-   no sentinel) means that subsystem is unaudited — **report it prominently and ask the
-   user** whether to rerun that agent or continue without it. Do not silently skip and do
-   not synthesize a partial report without user acknowledgement. Also collect any
-   `## Cross-Boundary Concerns` sections from `agent3.md` — **XB items are appended to
-   the candidate list before dedup, not after**.
-   After collecting all candidates, **dedup before assigning flat indices**. Two candidates
-   are the same issue if they point to the same code location AND the trigger sequence
-   produces the same harmful outcome — merge them into one rather than spawning two
-   independent verifiers. Same location but different harmful outcome = keep both.
-2. **If the working list is empty**: emit `Bug Hunt Report: 0 candidates found — no bugs
+1. Run a pre-read sentinel check before processing any file:
+   ```bash
+   grep -rL "END AGENT" /tmp/bh-{PREFIX}-agent*.md 2>/dev/null
+   ```
+   Any file listed by this command is missing its sentinel (truncated or failed). For each:
+   ask the user whether to rerun that agent (with the same output file target) or continue
+   without it. If an agent tool call failed entirely (no file at all), treat it the same way.
+   Do not proceed until all 5 files are confirmed or the user explicitly accepts a gap.
+2. Read the confirmed files and collect every candidate into a working list. Also collect any
+   `## Cross-Boundary Concerns` sections from `agent3.md` — **XB items are appended to the
+   candidate list before dedup, not after**.
+   After collecting, **dedup before assigning flat indices**. Two candidates are the same
+   issue if they point to the same code location AND the trigger sequence produces the same
+   harmful outcome — merge them. Same location but different harmful outcome = keep both.
+3. **If the working list is empty**: emit `Bug Hunt Report: 0 candidates found — no bugs
    detected in audited subsystems.` Clean up discovery files (`rm /tmp/bh-{PREFIX}-agent*.md`)
    and do not proceed to Phase 3.
-3. Sort candidates by agent number, then by candidate number within each agent, then assign
-   a flat sequential index (01, 02, 03 …). Consistent ordering ensures batching by source
-   file groups same-file Low-confidence candidates together naturally.
-4. Each candidate gets its own agent — do not batch unless the user explicitly instructs it
-   (batched agents share context, and a finding in candidate A can anchor reasoning for B).
-   Never batch High or Medium confidence candidates. Prefer **≤ 8 agents per turn** to stay
-   within the context window budget. If there are more than 8 candidates total, run them in
-   rounds of 8 — read all outputs from round N, applying the same sentinel-check
-   (`<!-- END VERIFY NN -->`) as for discovery files, before spawning round N+1.
+4. **If there are more than 20 candidates total**: escalate all Low-confidence candidates
+   directly to the report as ESCALATE (without spawning verifiers) — treat discovery-time
+   Low-confidence as insufficient evidence for a full verification pass. This caps Phase 2
+   cost when discovery floods.
+5. Sort remaining candidates by agent number, then candidate number, then assign a flat
+   sequential index (01, 02, 03 …).
+6. Each candidate gets its own agent — do not batch. Prefer **≤ 8 individual-candidate
+   agent calls per turn** to stay within the context window budget. If there are more than 8
+   candidates total, run them in rounds of 8 — read all outputs from round N, applying the
+   same sentinel-check (`<!-- END VERIFY NN -->`) as for discovery files, before round N+1.
 
 Each verification agent receives: the candidate text, the full Analysis Framework section
 (**paste verbatim**), and the million-dollar rule. It has **no knowledge of what discovery
@@ -186,7 +199,7 @@ For batched candidates, name the file after the **first** candidate's index and 
 in a header comment. Use one verdict block per candidate, referenced by flat index:
 
 ```
-<!-- Candidates: 04, 05, 07 -->
+<!-- Candidates: 04, 05, 06 -->
 
 ### [CONFIRMED] Candidate 04: [Title]
 **Verdict**: CONFIRMED
@@ -196,7 +209,7 @@ in a header comment. Use one verdict block per candidate, referenced by flat ind
 **Verdict**: REJECTED
 **Blocked by**: [specific gate that prevents it, cite the line]
 
-### [ESCALATE] Candidate 07: [Title]
+### [ESCALATE] Candidate 06: [Title]
 **Verdict**: ESCALATE
 **Scenario for user**: "Please consider: [precise, concrete sequence].
   Is this execution possible in your deployment?"

--- a/.claude/commands/bugs-hunt.md
+++ b/.claude/commands/bugs-hunt.md
@@ -28,22 +28,32 @@ Operate accordingly:
 
 ## Session Setup
 
-Run the following via the Bash tool to get a unique session prefix:
+Run the following via the Bash tool to get a unique session prefix (Linux):
 
 ```bash
 shuf -i 1000000-9999999 -n1
 ```
 
+On macOS use: `python3 -c "import random; print(random.randint(1000000,9999999))"` or
+install GNU coreutils (`brew install coreutils`) and use `gshuf`.
+
 Use the output (e.g., `3847201`) as a prefix for **every** output file and shell command
 in this run. This prevents silent overwrites on re-runs or concurrent hunts — a timestamp
 suffix is not used because two runs starting in the same second would collide.
+
+After generating the prefix, verify no prior run left files with it:
+
+```bash
+ls /tmp/bh-3847201-* 2>/dev/null && echo "conflict — regenerate prefix" || echo "prefix clear"
+```
 
 Find-and-replace `{PREFIX}` in every agent prompt and shell command before emitting — do
 not pass the literal string `{PREFIX}` to agents or the cleanup command. (The Setup section
 example shows the substitution: `{PREFIX}` → `3847201` → `/tmp/bh-3847201-agent1.md`.)
 
 Example: prefix `3847201` → `/tmp/bh-3847201-agent1.md`, `/tmp/bh-3847201-verify-01.md`,
-`/tmp/bh-3847201-report.md`.
+`/tmp/bh-3847201-report.md`. The PREFIX is preserved in the report and escalations filenames
+— these are the only files kept after cleanup, so the PREFIX remains recoverable.
 
 ---
 
@@ -111,19 +121,22 @@ After all 5 discovery agents complete:
 1. Read **all 5 output files** (`/tmp/bh-{PREFIX}-agent1.md` through
    `/tmp/bh-{PREFIX}-agent5.md`) and collect every candidate into a working list
    before spawning any verification agent. For each file: verify it exists, is non-empty,
-   and ends with `<!-- END AGENT N -->`. A file that fails any check was interrupted —
-   **report it explicitly** (e.g., "Agent 3 truncated — that subsystem is unaudited") and
-   halt. Do not synthesize a partial report. Also collect any `## Cross-Boundary Concerns`
-   sections from `agent3.md` and merge each XB entry into the working list as a candidate.
-   After collecting all candidates, **dedup by (source file, claim) before assigning flat
-   indices** — if Agent 2 and an XB entry describe the same issue, merge them into one
-   candidate rather than spawning two independent verifiers.
+   and ends with `<!-- END AGENT N -->`. A file that fails any check (missing, empty, or
+   no sentinel) means that subsystem is unaudited — **report it prominently and ask the
+   user** whether to rerun that agent or continue without it. Do not silently skip and do
+   not synthesize a partial report without user acknowledgement. Also collect any
+   `## Cross-Boundary Concerns` sections from `agent3.md` — **XB items are appended to
+   the candidate list before dedup, not after**.
+   After collecting all candidates, **dedup before assigning flat indices**. Two candidates
+   are the same issue if they point to the same code location AND the trigger sequence
+   produces the same harmful outcome — merge them into one rather than spawning two
+   independent verifiers.
 2. **If the working list is empty**: skip Phase 2 and emit `Bug Hunt Report: 0 candidates
    found.` Do not proceed to Phase 3.
 3. Assign each candidate a flat sequential index (01, 02, 03 …) regardless of which
    discovery agent produced it.
-4. Spawn verification agents in batches of **at most 8 at a time** (to stay within the
-   context window budget per turn — not a hard cap, but exceeding it degrades quality). Each candidate gets its own agent. If there are more
+4. Prefer batches of **≤ 8 agents per turn** to stay within the context window budget.
+   If you have strong reason to exceed this, proceed but note the quality risk. Each candidate gets its own agent. If there are more
    than 8 candidates total, run them in rounds of 8 — read all outputs from round N before
    spawning round N+1. Only if forced by the limit: batch **Low-confidence** candidates
    targeting the same source file into one agent (never High or Medium — batched agents share
@@ -179,8 +192,8 @@ synthesize into one consolidated report:
 2. If any escalations exist, **also write them to `/tmp/bh-{PREFIX}-escalations.md`**
    (so the user can re-read them without parsing the full report). Omit this file if there
    are no escalations.
-3. **Conditionally** clean up intermediate files — only if `/tmp/bh-{PREFIX}-report.md` is
-   non-empty and Phase 3 completed without error:
+3. **Conditionally** clean up intermediate files — only if the report file exists, is ≥ 100
+   bytes, and every verify file was read without exception:
    `rm /tmp/bh-{PREFIX}-agent*.md /tmp/bh-{PREFIX}-verify-*.md`
    Do not run if Phase 3 failed mid-synthesis (intermediates needed to retry).
    The report and escalations files are always kept.
@@ -406,5 +419,6 @@ Check each explicitly during both discovery and verification:
 
 **Persistence**
 - [ ] Destructor-assumed side effect (sync, flush, write) that may not run on pod kill
+  (but see KFP §1 — for ublkpp this is currently structurally blocked by resync drain)
 - [ ] One-sided version bounds: `version < N` with no `version > MAX` upper-bound rejection
 - [ ] Two writes that must be consistent but have no atomic boundary between them

--- a/.claude/commands/bugs-hunt.md
+++ b/.claude/commands/bugs-hunt.md
@@ -19,7 +19,7 @@ Out of scope: public API headers (`include/ublkpp/`) and interface-level contrac
 ## Mindset — The Million-Dollar Rule
 
 You are a professional C++ correctness engineer. Every real bug you find is worth
-**$1,000,000**. Every false positive you report costs you **$1,000,000**.
+**\$1,000,000**. Every false positive you report costs you **\$1,000,000**.
 
 Operate accordingly:
 - A finding is only reported if you are **100% certain** it is a real bug

--- a/.claude/commands/bugs-hunt.md
+++ b/.claude/commands/bugs-hunt.md
@@ -189,6 +189,47 @@ Before reporting a race, determine which direction it can go:
 A race that can only go in the safe direction is a TSan warning, not a correctness bug.
 Document it accurately; do not overstate the risk.
 
+### RAID1 Known False Positives — Verify Before Reporting
+
+These patterns look dangerous on first inspection but are structurally impossible. Confirm each
+applies before flagging a finding; if anything in the code path has changed, re-trace from scratch.
+
+#### 1. Destructor races with IO coroutines (phantom)
+
+`Raid1Disk::~Raid1Disk` is called **after** all IO queues are stopped.
+`_resync_task->stop()` is the first call in the destructor — it joins the resync coroutine
+and waits for all in-flight IO to drain. By the time any subsequent destructor line executes
+there are **zero active IO coroutines**. Nothing in the destructor can race with anything:
+
+- `_dirty_bitmap->sync_to(...)` — no concurrent `dirty_region` / `clean_region` / `set_bit`
+- `write_superblock(..., include_superbitmap=true)` — no concurrent `SuperBitmap::set_bit`
+- `_sb->fields.clean_unmount = 0x1` — no concurrent readers or writers
+
+**REJECT** any candidate that claims a race between the destructor and IO coroutines.
+
+#### 2. Concurrent `write_superblock` callers (phantom)
+
+Two `write_superblock` calls cannot overlap — the state machine prevents it structurally:
+
+- `__become_degraded` opens with `CAS(EITHER → DEVA/DEVB)`. It only proceeds past the CAS —
+  and only reaches `write_superblock` — when it wins from `EITHER`.
+- `__become_clean` only runs when `route != EITHER` (array already degraded).
+- After `__become_degraded`'s CAS succeeds the route is DEVA/DEVB; any concurrent caller
+  that tries `CAS(EITHER → ...)` sees a mismatch and returns before reaching `write_superblock`.
+- The same CAS argument excludes `__swap_device`.
+
+**What TSan actually detects is a different, safe-direction race:** the old code passed `_sb`
+directly as `iov_base`, causing a non-atomic read of `superbitmap_reserved` (bytes 74–4095)
+while IO coroutines call `SuperBitmap::set_bit` → `atomic_ref<uint8_t>::fetch_or` on those same
+bytes. Under the core invariant this race can only go in the safe direction — `fetch_or` only
+sets bits, so memory gets dirtier than disk, never cleaner. It is a TSan warning, not a
+correctness bug. The fix (local-copy buffer stopping at byte 74) silences TSan and is a correct
+cleanup, but the concurrent-callers framing is wrong.
+
+**REJECT** any candidate claiming two concurrent `write_superblock` callers.
+
+---
+
 ### Pattern Checklist
 
 Check each explicitly during both discovery and verification:

--- a/.claude/commands/bugs-hunt.md
+++ b/.claude/commands/bugs-hunt.md
@@ -1,3 +1,7 @@
+---
+description: Systematic 3-phase bug hunt — parallel discovery, independent verification, consolidated report
+---
+
 # Bug Hunt — ublkpp
 
 > **KFP last verified: 2026-05-31.** Re-verify Known False Positive entries before running
@@ -23,7 +27,7 @@ Operate accordingly:
   scenario and ask the user: *"Is this execution sequence possible in your deployment?"*
 - "This looks suspicious" is not a finding. "This exact sequence produces data loss:
   1. Thread A does X, 2. Thread B does Y, 3. result Z is wrong" is a finding.
-- Removing a false positive is always correct. Keeping an uncertain finding is never correct.
+- Removing a false positive from your report is always correct. Keeping an uncertain finding is never correct.
 - **"No bugs found" is a valid and valuable outcome.** If the code is correct, say so. Do
   not manufacture findings to justify the run — a clean report is the most useful output
   when the codebase is actually sound.
@@ -48,6 +52,8 @@ Send all 5 in a single message so they run concurrently.
 
 ```bash
 mkdir -p .claude/bugs-hunt
+# Clean up stale escalations from any prior run so they don't mix with new results:
+rm -f .claude/bugs-hunt/bh-escalations.md .claude/bugs-hunt/bh-report-escalations.md
 ```
 
 Each agent is scoped to one subsystem, reads the relevant source files in full, and writes
@@ -101,9 +107,10 @@ was interrupted mid-run and should be treated as missing (report explicitly, do 
 Candidate confidence bar but touches `__become_degraded`. Note: the XB channel is the
 **only** path for startup-path findings that straddle the Agent 2/3 boundary — Agent 3
 cannot confirm or reject such findings directly, only flag them for Agent 2 verification.
-The channel is one-directional (Agent 3 → Agent 2 only). If Agent 2 finds something in
-`__become_degraded` that needs startup-path context, it should write a High-confidence
-candidate and note the dependency in its Uncertainty field.
+The channel is one-directional: the orchestrator collects XB items in Phase 2 and assigns
+them to verification agents scoped to Agent 2's domain (`__become_degraded`). If Agent 2
+finds something in `__become_degraded` that needs startup-path context but doesn't meet the
+High-confidence bar, it should write it as an ESCALATE candidate (not suppress it).
 
 ```
 ## Cross-Boundary Concerns (for Agent 2 verification)
@@ -139,6 +146,9 @@ After all 5 discovery agents complete:
    to the report as ESCALATE (without spawning verifiers) — treat discovery-time
    Low-confidence as insufficient evidence when discovery is this broad. <!-- threshold rule:
    keep Phase 2 ≤ 4 rounds × 8 agents; recalibrate for larger codebases -->
+   Step 6 budget exception applies only after step 4; Low-confidence candidates escalated
+   here don't reach step 6. If High+Medium candidates after dedup exceed 32, cap at the
+   top 32 by confidence tier then agent number, and note the truncation in the report.
 5. Sort remaining candidates by agent number, then candidate number, then assign a flat
    sequential index (01, 02, 03 …).
 6. **By default, one candidate per agent.** Run **≤ 8 agents per turn** (sized for the
@@ -192,13 +202,15 @@ in a header comment. Use one verdict block per candidate, referenced by flat ind
 **Scenario for user**: "Please consider: [precise, concrete sequence].
   Is this execution possible in your deployment?"
 
-<!-- END VERIFY 04 -->
+<!-- END VERIFY 04 | batch: 3 -->
 ```
 
 The sentinel is required on every verify file. **NN = first candidate's flat index**
-(matching the filename: verify-04.md → `<!-- END VERIFY 04 -->`). Do not use the last
-candidate's index — a file truncated after the first verdict block would then pass the
-sentinel check, masking the truncation. Apply the sentinel check before the next round.
+(matching the filename: verify-04.md → `<!-- END VERIFY 04 | batch: N -->`), where N is
+the number of candidates in the file. Do not use the last candidate's index — a file
+truncated after the first verdict block would then pass the sentinel check. For batched
+files, the `batch: N` count lets the orchestrator verify all N verdicts are present.
+Apply the sentinel check before the next round.
 
 ---
 
@@ -212,12 +224,13 @@ synthesize into one consolidated report:
    (so the user can re-read them without parsing the full report). Omit this file if there
    are no escalations. This file is intentionally kept across re-runs (not cleaned up).
 3. **Conditionally** clean up intermediate files — only if `bh-report.md` ends with
-   `<!-- BUG HUNT COMPLETE -->` and every verify file was read without exception:
+   `<!-- BUG HUNT COMPLETE -->` and every file listed by
+   `ls .claude/bugs-hunt/bh-verify-*.md` was included in the synthesis:
    `rm .claude/bugs-hunt/bh-agent*.md .claude/bugs-hunt/bh-verify-*.md`
-   Note: the glob `verify-*.md` matches escalation re-verification files (`verify-ENN.md`)
-   as well — this is intentional. If the `rm` fails (permissions, already deleted), note it
-   but do not treat it as a Phase 3 failure — the report is already written. The report and
-   escalations files are always kept. Do not run if Phase 3 failed mid-synthesis.
+   Note: `verify-ENN.md` escalation re-verification files are created after Phase 3, so
+   they won't exist yet at this cleanup step — the glob will not match them here. They'll
+   be cleaned up on the next run's Phase 1 (overwritten). If the `rm` fails, note it but
+   do not treat it as a Phase 3 failure — the report is already written.
 
 ```
 ## Bug Hunt Report
@@ -425,32 +438,32 @@ correctness bug.
 Check each explicitly during both discovery and verification:
 
 **Concurrency**
-- [ ] Non-atomic compound RMW: `check + act` where another thread can act between the two
+- Non-atomic compound RMW: `check + act` where another thread can act between the two
   - `isal_zero_detect(page)` then `clear_bit` — concurrent `fetch_or` fires in the gap
   - `load()` then `fetch_sub()` — two callers both read the same value and both subtract
   - `dirty_pages() == 0` then `complete()` — new dirty page appears between the two calls
-- [ ] CAS loser acts on context captured before the CAS (stale premise)
-- [ ] Signal before check: `sem_post` / completion fires before the `if (success)` guard
-- [ ] Stale capture across `co_await`: value loaded before suspension used after resumption
+- CAS loser acts on context captured before the CAS (stale premise)
+- Signal before check: `sem_post` / completion fires before the `if (success)` guard
+- Stale capture across `co_await`: value loaded before suspension used after resumption
   without re-read — another coroutine may have mutated shared state while this one was suspended
-- [ ] Dangling reference into coroutine frame: `const T&` or pointer captured into a coroutine
+- Dangling reference into coroutine frame: `const T&` or pointer captured into a coroutine
   body may outlive the referent if the owning object is destroyed while the coroutine is suspended
-- [ ] Relaxed atomic as a branch guard: `load(relaxed)` used as a condition without a subsequent
+- Relaxed atomic as a branch guard: `load(relaxed)` used as a condition without a subsequent
   `acquire` fence — the load can be reordered past dependent loads it was intended to gate
-- [ ] Convention-only protection: field assumed single-threaded but guarded only by a
+- Convention-only protection: field assumed single-threaded but guarded only by a
   "callers must ensure X" invariant with no lock or atomic — verify the invariant holds on
   every call path (these don't appear in TSan if the convention is always honored but are fragile)
 
 **Error handling**
-- [ ] Error from device A sets `unavail` / triggers `__become_degraded` on device B
-- [ ] SB write failure ignored but CAS still fires (in-memory and on-disk states diverge)
+- Error from device A sets `unavail` / triggers `__become_degraded` on device B
+- SB write failure ignored but CAS still fires (in-memory and on-disk states diverge)
 
 **State machine**
-- [ ] Redirect stores last-used state in a way that creates a stable wrong fixed point
-- [ ] Rollback assumed to run after an error (crash between error and rollback)
+- Redirect stores last-used state in a way that creates a stable wrong fixed point
+- Rollback assumed to run after an error (crash between error and rollback)
 
 **Persistence**
-- [ ] Destructor-assumed side effect (sync, flush, write) that may not run on pod kill
+- Destructor-assumed side effect (sync, flush, write) that may not run on pod kill
   (but see KFP §1 — for ublkpp this is currently structurally blocked by resync drain)
-- [ ] One-sided version bounds: `version < N` with no `version > MAX` upper-bound rejection
-- [ ] Two writes that must be consistent but have no atomic boundary between them
+- One-sided version bounds: `version < N` with no `version > MAX` upper-bound rejection
+- Two writes that must be consistent but have no atomic boundary between them

--- a/.claude/commands/bugs-hunt.md
+++ b/.claude/commands/bugs-hunt.md
@@ -30,8 +30,8 @@ files in full, and writes its candidates to a dedicated output file.
 | Agent | Scope | Output file |
 |---|---|---|
 | 1 | `src/raid/raid1/bitmap.cpp`, `bitmap.hpp`, `super_bitmap.*` | `/tmp/bh-agent1.md` |
-| 2 | `src/raid/raid1/raid1.cpp` — state transitions (`__become_*`, `__swap_device`, `async_iov`) | `/tmp/bh-agent2.md` |
-| 3 | `src/raid/raid1/raid1_superblock.*`, startup path in `raid1.cpp` (`__init_*`, `__load_*`) | `/tmp/bh-agent3.md` |
+| 2 | `src/raid/raid1/raid1.cpp` — **runtime** state transitions only (`__become_degraded`, `__become_clean`, `__swap_device`, `async_iov`, `prepare`); `src/raid/raid1/raid1_resync_task.*` | `/tmp/bh-agent2.md` |
+| 3 | `src/raid/raid1/raid1_superblock.*`; startup path in `raid1.cpp` (`__init_*`, `__load_*`, **`__become_active`**) — pay particular attention to `__become_active` failing mid-startup and delegating to `__become_degraded` | `/tmp/bh-agent3.md` |
 | 4 | `src/target/ublkpp_tgt.cpp`, `src/lib/disk_task.*` | `/tmp/bh-agent4.md` |
 | 5 | `src/raid/raid0/raid0.cpp`, `src/driver/`, `src/metrics/` | `/tmp/bh-agent5.md` |
 
@@ -61,8 +61,13 @@ files in full, and writes its candidates to a dedicated output file.
 
 ## Phase 2 — Independent Verification
 
-After all 5 discovery agents complete, spawn **one verification agent per candidate**
-(batch Low-confidence candidates from the same file together). Each verification agent:
+After all 5 discovery agents complete:
+1. Read **all 5 output files** (`/tmp/bh-agent1.md` through `/tmp/bh-agent5.md`) and collect
+   every candidate into a working list before spawning any verification agent.
+2. Spawn **one verification agent per candidate** (batch Low-confidence candidates that target
+   the same source file into a single agent to reduce redundant reads).
+
+Each verification agent:
 
 - Has **clean context** — no memory of the discovery phase, no shared state with other agents
 - Reads the candidate verbatim from the output file
@@ -78,7 +83,8 @@ After all 5 discovery agents complete, spawn **one verification agent per candid
 5. **CONFIRM** if the sequence is definitively reachable and produces the claimed harm
 6. **ESCALATE** if uncertain after full investigation — do not guess; ask the user
 
-**Verification output per candidate:**
+**Verification output per candidate** — write to `/tmp/bh-verify-[N][X].md`
+(e.g. `/tmp/bh-verify-2a.md` for Candidate 2.A; batched candidates share one file):
 ```
 ### [CONFIRMED | REJECTED | ESCALATE] Candidate [N.X]: [Title]
 
@@ -93,7 +99,8 @@ After all 5 discovery agents complete, spawn **one verification agent per candid
 
 ## Phase 3 — Final Report
 
-After all verification agents complete, synthesize into one consolidated report:
+After all verification agents complete, read all `/tmp/bh-verify-*.md` files and
+synthesize into one consolidated report:
 
 ```
 ## Bug Hunt Report

--- a/.claude/commands/bugs-hunt.md
+++ b/.claude/commands/bugs-hunt.md
@@ -1,0 +1,215 @@
+# Bug Hunt — ublkpp
+
+Systematic correctness audit using parallel discovery agents followed by independent
+verification. Each finding must survive a separate clean-context challenge before it
+is reported as real.
+
+---
+
+## Mindset — The Million-Dollar Rule
+
+You are a professional C++ correctness engineer. Every real bug you find is worth
+**$1,000,000**. Every false positive you report costs you **$1,000,000**.
+
+Operate accordingly:
+- A finding is only reported if you are **100% certain** it is a real bug
+- If you are not certain, do NOT report it as a bug — formulate a precise, concrete
+  scenario and ask the user: *"Is this execution sequence possible in your deployment?"*
+- "This looks suspicious" is not a finding. "This exact sequence produces data loss:
+  1. Thread A does X, 2. Thread B does Y, 3. result Z is wrong" is a finding.
+- Removing a false positive is always correct. Keeping an uncertain finding is never correct.
+
+---
+
+## Phase 1 — Parallel Discovery (5 agents)
+
+Spawn **5 agents in parallel** using the Agent tool. Send all 5 in a single message so
+they run concurrently. Each agent is scoped to one subsystem, reads the relevant source
+files in full, and writes its candidates to a dedicated output file.
+
+| Agent | Scope | Output file |
+|---|---|---|
+| 1 | `src/raid/raid1/bitmap.cpp`, `bitmap.hpp`, `super_bitmap.*` | `/tmp/bh-agent1.md` |
+| 2 | `src/raid/raid1/raid1.cpp` — state transitions (`__become_*`, `__swap_device`, `async_iov`) | `/tmp/bh-agent2.md` |
+| 3 | `src/raid/raid1/raid1_superblock.*`, startup path in `raid1.cpp` (`__init_*`, `__load_*`) | `/tmp/bh-agent3.md` |
+| 4 | `src/target/ublkpp_tgt.cpp`, `src/lib/disk_task.*` | `/tmp/bh-agent4.md` |
+| 5 | `src/raid/raid0/raid0.cpp`, `src/driver/`, `src/metrics/` | `/tmp/bh-agent5.md` |
+
+**Discovery agent prompt must include:**
+- Assigned files (read them in full — do not skim)
+- The Analysis Framework section below
+- The million-dollar rule
+- This output format — write raw candidates to the output file, no filtering yet:
+
+```
+## Candidate Findings — Agent [N] — [Subsystem]
+
+### Candidate [N.X]: [Title]
+**Location**: file.cpp:line
+**Type**: race | power-loss | TOCTOU | wrong-device | sequencing | version-bounds | other
+**Claim**: [one sentence — what goes wrong and what the impact is]
+**Trigger sequence**:
+  1. [exact step]
+  2. [exact step]
+  3. Result: [concrete wrong outcome]
+**Evidence**: [CAS trace / code path / specific line numbers]
+**Confidence**: High | Medium | Low
+**Uncertainty**: [what you're not sure about, if anything]
+```
+
+---
+
+## Phase 2 — Independent Verification
+
+After all 5 discovery agents complete, spawn **one verification agent per candidate**
+(batch Low-confidence candidates from the same file together). Each verification agent:
+
+- Has **clean context** — no memory of the discovery phase, no shared state with other agents
+- Reads the candidate verbatim from the output file
+- Reads the relevant source files from scratch, following call chains as needed
+- Applies the million-dollar rule as the only criterion
+- Delivers a verdict: **CONFIRM**, **REJECT**, or **ESCALATE**
+
+**Verification protocol:**
+1. Read every file mentioned in the candidate plus any callers/callees relevant to the claim
+2. Trace the exact trigger sequence step by step through the actual code
+3. Identify every guard — CAS gate, lock, ordering constraint — that could block the sequence
+4. **REJECT** if any guard definitively prevents the sequence — name the guard, cite the line
+5. **CONFIRM** if the sequence is definitively reachable and produces the claimed harm
+6. **ESCALATE** if uncertain after full investigation — do not guess; ask the user
+
+**Verification output per candidate:**
+```
+### [CONFIRMED | REJECTED | ESCALATE] Candidate [N.X]: [Title]
+
+**Verdict**: ...
+**Evidence**: [exact code path, line numbers, CAS values]
+**REJECTED — blocked by**: [specific gate that prevents it]
+**ESCALATE — scenario for user**: "Please consider: [precise, concrete sequence].
+  Is this execution possible in your deployment?"
+```
+
+---
+
+## Phase 3 — Final Report
+
+After all verification agents complete, synthesize into one consolidated report:
+
+```
+## Bug Hunt Report
+
+**Scope**: [subsystems]
+**Candidates**: N total — Confirmed: X | Rejected: Y | Escalated: Z
+
+---
+
+### Confirmed Bugs
+
+#### [B1] Title — P0 | P1 | P2
+
+**Location**: file.cpp:line
+**Type**: ...
+**Trigger**:
+  1. ...
+  2. ...
+  3. Result: ...
+**Impact**: data loss | corruption | crash | silent failure | extra resync
+**Fix direction**: ...
+
+---
+
+### Rejected (False Positives)
+
+| ID | Title | Rejected because |
+|---|---|---|
+| N.X | ... | CAS at raid1.cpp:620 prevents concurrent entry |
+
+---
+
+### Escalations — Human Review Needed
+
+#### [E1] Title
+
+Please consider this scenario: [precise sequence]. Is this possible in your deployment?
+```
+
+---
+
+## Analysis Framework
+
+Used by both discovery and verification agents.
+
+### Power-Loss Safety
+
+Every line can be the last. The process runs in a pod and can die at any point.
+Never assume line A+1 executed because line A did.
+
+Walk every write to persistent state:
+- What is on-disk if power is lost immediately **before** this write?
+- What is on-disk if power is lost immediately **after** this write?
+- Does the startup path handle both cases without data loss?
+
+Core invariant: memory may be dirtier than disk (safe — causes extra resync).
+Memory must never be cleaner than disk — that is data loss.
+
+Danger patterns:
+- "Destructor always runs at shutdown" — pod kill / OOM, it does not
+- "Rollback will execute after the failed write" — crash between failure and rollback
+- "If flag X is set, then Y also happened" — X set, crash, Y never executes
+
+### CAS Gate Analysis
+
+Before flagging a race, trace the full CAS chain:
+1. Find every `compare_exchange` that guards entry to the code path
+2. Determine the `old_val` required to succeed
+3. Check whether any concurrent path has already advanced the atomic past that value
+
+If yes → the second caller's CAS fails and it returns before touching shared state →
+**the race is structurally impossible → REJECT**.
+
+Common false positive: two functions both eventually call the same helper. Always verify
+whether the CAS gate makes simultaneous execution impossible before writing it up.
+
+### Atomic Write Boundaries
+
+4 KiB aligned block writes are atomic at the device level — either the full write lands
+or none of it does. Fields sharing a 4 KiB page are written atomically with respect to
+each other.
+
+`clean_unmount`, `read_route`, and `superbitmap_reserved` share the superblock's 4 KiB page.
+If `clean_unmount=1` is on disk, the entire write that set it also landed — `superbitmap_reserved`
+reflects what was written in that same call and is trustworthy.
+
+### Race Direction
+
+Before reporting a race, determine which direction it can go:
+- **Set-only** (`fetch_or`, `set_bit`): memory gets dirtier than disk → **safe direction**
+- **Clear** (`fetch_and`, `clear_bit`): memory gets cleaner than disk → **data loss direction**
+
+A race that can only go in the safe direction is a TSan warning, not a correctness bug.
+Document it accurately; do not overstate the risk.
+
+### Pattern Checklist
+
+Check each explicitly during both discovery and verification:
+
+**Concurrency**
+- [ ] Non-atomic compound RMW: `check + act` where another thread can act between the two
+  - `isal_zero_detect(page)` then `clear_bit` — concurrent `fetch_or` fires in the gap
+  - `load()` then `fetch_sub()` — two callers both read the same value and both subtract
+  - `dirty_pages() == 0` then `complete()` — new dirty page appears between the two calls
+- [ ] CAS loser acts on context captured before the CAS (stale premise)
+- [ ] Signal before check: `sem_post` / completion fires before the `if (success)` guard
+
+**Error handling**
+- [ ] Error from device A sets `unavail` / triggers `__become_degraded` on device B
+- [ ] SB write failure ignored but CAS still fires (in-memory and on-disk states diverge)
+
+**State machine**
+- [ ] Redirect stores last-used state in a way that creates a stable wrong fixed point
+- [ ] Rollback assumed to run after an error (crash between error and rollback)
+
+**Persistence**
+- [ ] Destructor-assumed side effect (sync, flush, write) that may not run on pod kill
+- [ ] One-sided version bounds: `version < N` with no `version > MAX` upper-bound rejection
+- [ ] Two writes that must be consistent but have no atomic boundary between them

--- a/.claude/commands/bugs-hunt.md
+++ b/.claude/commands/bugs-hunt.md
@@ -57,17 +57,28 @@ Then verify no prior run left conflicting files:
 ls /tmp/bh-3847201-* 2>/dev/null && echo "conflict — regenerate prefix" || echo "prefix clear"
 ```
 
-**{PREFIX} substitution is LLM-enforced**: there is no mechanical check. If the literal
-string `{PREFIX}` is passed to an agent, the sentinel check passes vacuously (no files
-found) and Phase 2 will report all agents as unaudited. The announced prefix above is the
-guard — reference it explicitly when constructing each agent prompt.
+**{PREFIX} substitution is LLM-enforced**. Run this mechanical backstop after announcing
+the prefix — the escaped-brace glob only matches if the literal string `{PREFIX}` leaked:
 
-Also check for KFP staleness before Phase 1 by running:
 ```bash
-git log --since=2026-05-31 --oneline src/raid/raid1/raid1.cpp src/raid/raid1/raid1_superblock.cpp
+ls /tmp/bh-\{PREFIX\}-* 2>/dev/null && echo "LITERAL BRACE DETECTED — substitution failed" || true
 ```
-A non-empty result means code that KFP entries depend on has changed — re-verify the
-relevant KFP entries before trusting them.
+
+If the literal string is passed to an agent, the sentinel check passes vacuously (no files
+found) and Phase 2 will report all agents as unaudited. The announced prefix and this
+check together are the guards — reference the prefix explicitly in every agent prompt.
+
+Also check for KFP staleness before Phase 1. The KFP entries were last verified at
+commit `f984348`. Run:
+```bash
+# KFP §1 (destructor) and §2a (CAS gate) — anchored to raid1.cpp:
+git log f984348..HEAD --oneline src/raid/raid1/raid1.cpp
+# KFP §2b (superbitmap safe-direction race) — anchored to super_bitmap.*:
+git log f984348..HEAD --oneline src/raid/raid1/super_bitmap.cpp src/raid/raid1/super_bitmap.hpp
+```
+Non-empty output for the first command → re-verify §1 and §2a.
+Non-empty output for the second → re-verify §2b.
+If you re-verify and the entries still hold, update the anchor commit hash above.
 
 Example: prefix `3847201` → `/tmp/bh-3847201-agent1.md`, `/tmp/bh-3847201-verify-01.md`,
 `/tmp/bh-3847201-report.md`. The PREFIX is preserved in the report and escalations filenames
@@ -96,7 +107,8 @@ files in full, and writes its candidates to a dedicated output file.
 **Discovery agent prompt must include:**
 - Assigned files (read them in full — do not skim)
 - The Analysis Framework section below — **paste it verbatim, do not summarize**
-  (intentional: ~300 tokens × 15+ agents ≈ 4–5k tokens overhead per run; accepted cost
+  (intentional: ~300 tokens × (5 discovery + N verify) agents; at 10 candidates ≈ 4.5k
+   overhead; accepted cost
   for consistent reasoning)
 - The million-dollar rule
 - This output format — write raw candidates to the output file, no filtering yet:
@@ -166,14 +178,17 @@ After all 5 discovery agents complete:
    and do not proceed to Phase 3.
 4. **If there are more than 20 candidates total**: escalate all Low-confidence candidates
    directly to the report as ESCALATE (without spawning verifiers) — treat discovery-time
-   Low-confidence as insufficient evidence for a full verification pass. This caps Phase 2
-   cost when discovery floods.
+   Low-confidence as insufficient evidence for a full verification pass. The threshold of 20
+   is chosen to keep Phase 2 within roughly 4 rounds of 8 agents; adjust if the framework
+   is re-used on a larger codebase.
 5. Sort remaining candidates by agent number, then candidate number, then assign a flat
    sequential index (01, 02, 03 …).
-6. Each candidate gets its own agent — do not batch. Prefer **≤ 8 individual-candidate
-   agent calls per turn** to stay within the context window budget. If there are more than 8
-   candidates total, run them in rounds of 8 — read all outputs from round N, applying the
-   same sentinel-check (`<!-- END VERIFY NN -->`) as for discovery files, before round N+1.
+6. Prefer one candidate per agent. Run **≤ 8 agents per turn** to stay within the context
+   window budget. If there are more than 8 candidates total, run them in rounds of 8 — read
+   all outputs from round N, applying the same sentinel-check as for discovery files
+   (`<!-- END VERIFY NN -->`, where NN is the first candidate's flat index in that file),
+   before round N+1. If budget or candidate volume makes individual agents impractical, you
+   may put multiple candidates in one agent, but never mix High or Medium candidates.
 
 Each verification agent receives: the candidate text, the full Analysis Framework section
 (**paste verbatim**), and the million-dollar rule. It has **no knowledge of what discovery
@@ -217,8 +232,10 @@ in a header comment. Use one verdict block per candidate, referenced by flat ind
 <!-- END VERIFY NN -->
 ```
 
-The sentinel `<!-- END VERIFY NN -->` is required on every verify file (NN = flat index).
-Apply the same truncation check as for discovery files before proceeding to the next round.
+The sentinel `<!-- END VERIFY NN -->` is required on every verify file. NN must be the
+**first** candidate's flat index (matching the filename, e.g., verify-04.md → sentinel
+`<!-- END VERIFY 04 -->`). Using the last candidate's index would allow partial files to
+pass the truncation check. Apply the sentinel check before proceeding to the next round.
 
 ---
 
@@ -282,8 +299,11 @@ For each one, present the precise scenario question to the user. After the user 
 spawn one verification agent per scenario confirmed as possible, passing the candidate text
 plus the user's deployment context. Write each agent's output to
 `/tmp/bh-{PREFIX}-verify-ENN.md` (E prefix for escalation re-verification, NN is the
-escalation number). If confirmed, append findings to a `### Confirmed Bugs (Post-Escalation)`
-section at the bottom of the existing report file. Do not re-run Phases 1–3.
+escalation number). If confirmed, write findings to a **separate file**
+`/tmp/bh-{PREFIX}-report-escalations.md` (do not append to the existing report — appending
+requires read-modify-write which risks partial corruption if synthesis fails mid-write).
+Tell the user to read both the main report and the escalations supplement together.
+Do not re-run Phases 1–3.
 
 #### [E1] Title
 

--- a/.claude/commands/bugs-hunt.md
+++ b/.claude/commands/bugs-hunt.md
@@ -28,13 +28,19 @@ Operate accordingly:
 
 ## Session Setup
 
-Before spawning any agents, choose a session prefix (e.g., last 6 digits of the current
-epoch seconds) and use it as a prefix for **every** output file in this run. This prevents
-silent overwrites on re-runs or concurrent hunts.
+Run the following via the Bash tool to get a stable session prefix:
+
+```bash
+date +%s | tail -c 7
+```
+
+Use the output (e.g., `947312`) as a prefix for **every** output file in this run. This
+prevents silent overwrites on re-runs or concurrent hunts. Find-and-replace `{PREFIX}` in
+every agent prompt and shell command before emitting — do not pass the literal string
+`{PREFIX}` to agents or the cleanup command.
 
 Example: prefix `947312` → `/tmp/bh-947312-agent1.md`, `/tmp/bh-947312-verify-01.md`,
-`/tmp/bh-947312-report.md`. Find-and-replace `{PREFIX}` in every agent prompt you emit
-before spawning — do not pass the literal string `{PREFIX}` to agents.
+`/tmp/bh-947312-report.md`.
 
 ---
 
@@ -48,8 +54,8 @@ files in full, and writes its candidates to a dedicated output file.
 |---|---|---|
 | 1 | `src/raid/raid1/bitmap.cpp`, `src/raid/raid1/bitmap.hpp`, `src/raid/raid1/super_bitmap.cpp`, `src/raid/raid1/super_bitmap.hpp` | `/tmp/bh-{PREFIX}-agent1.md` |
 | 2 | `src/raid/raid1/raid1.cpp` — **runtime** state transitions only (`__become_degraded`, `__become_clean`, `__swap_device`, `async_iov`, `prepare`); `src/raid/raid1/raid1_resync_task.*`. **Owns `__become_degraded` — Agent 3 treats it as a black box.** | `/tmp/bh-{PREFIX}-agent2.md` |
-| 3 | `src/raid/raid1/raid1_superblock.*`; startup path in `raid1.cpp` (`__init_*`, `__load_*`, **`__become_active`**) — pay particular attention to `__become_active` failing mid-startup and delegating to `__become_degraded`. **Treat `__become_degraded` as a black box; note any concerns for Agent 2 to verify.** | `/tmp/bh-{PREFIX}-agent3.md` |
-| 4 | `src/target/ublkpp_tgt.cpp`, `src/target/ublkpp_tgt_impl.hpp` | `/tmp/bh-{PREFIX}-agent4.md` |
+| 3 | `src/raid/raid1/raid1_superblock.*`; startup path in `raid1.cpp` (`__init_*`, `__load_*`, **`__become_active`**) — pay particular attention to `__become_active` failing mid-startup and delegating to `__become_degraded`. **Treat `__become_degraded` as a black box; log cross-boundary concerns in the XB section (see output format below).** | `/tmp/bh-{PREFIX}-agent3.md` |
+| 4 | `src/target/ublkpp_tgt.cpp`, `src/target/ublkpp_tgt_impl.hpp`, `src/lib/disk_task.hpp`, `src/lib/disk_task.cpp`, `src/lib/cqe_state.hpp` | `/tmp/bh-{PREFIX}-agent4.md` |
 | 5 | `src/raid/raid0/raid0.cpp`, `src/driver/`, `src/metrics/` | `/tmp/bh-{PREFIX}-agent5.md` |
 
 **Discovery agent prompt must include:**
@@ -74,6 +80,17 @@ files in full, and writes its candidates to a dedicated output file.
 **Uncertainty**: [what you're not sure about, if anything]
 ```
 
+**Agent 3 only** — append a cross-boundary section for anything that doesn't clear the
+Candidate confidence bar but touches `__become_degraded`:
+
+```
+## Cross-Boundary Concerns (for Agent 2 verification)
+
+### XB-[N]: [Title]
+**Concern**: [what needs investigating in __become_degraded]
+**Context**: [what Agent 3 observed in __become_active that triggered this]
+```
+
 ---
 
 ## Phase 2 — Independent Verification
@@ -83,18 +100,18 @@ After all 5 discovery agents complete:
    `/tmp/bh-{PREFIX}-agent5.md`) and collect every candidate into a working list
    before spawning any verification agent. **If any file is missing or empty, report
    it explicitly** (e.g., "Agent 3 output missing — that subsystem was not audited")
-   before continuing. Do not silently skip it. If Agent 3 flagged a cross-boundary
-   concern about `__become_degraded`, merge it with Agent 2's candidates and treat
-   it as a single candidate for verification.
+   before continuing. Do not silently skip it. Also collect any `## Cross-Boundary
+   Concerns` sections from `agent3.md` — merge each XB entry with Agent 2's candidates
+   and treat it as a single candidate for verification.
 2. **If the working list is empty**: skip Phase 2 and emit `Bug Hunt Report: 0 candidates
    found.` Do not proceed to Phase 3.
 3. Assign each candidate a flat sequential index (01, 02, 03 …) regardless of which
    discovery agent produced it.
 4. Spawn verification agents in batches of **at most 8 at a time** (the per-turn concurrency
-   limit in Claude Code's Agent tool). Batch Low-confidence candidates that target the same
-   source file into a single agent (note: batched agents share agent context — a finding in
-   candidate A may anchor reasoning for candidate B; only batch when you accept this risk for
-   Low-confidence candidates).
+   limit in Claude Code's Agent tool). Each candidate gets its own agent. If there are more
+   than 8 candidates total and batching is unavoidable, batch only **Low-confidence** candidates
+   targeting the same source file — never High or Medium (batched agents share agent context:
+   a finding in candidate A may anchor reasoning for candidate B).
 
 Each verification agent receives: the candidate text, the full Analysis Framework section
 (**paste verbatim**), and the million-dollar rule. It has **no knowledge of what discovery
@@ -141,10 +158,15 @@ in a header comment. Use one verdict block per candidate, referenced by flat ind
 ## Phase 3 — Final Report
 
 After all verification agents complete, read all `/tmp/bh-{PREFIX}-verify-*.md` files and
-synthesize into one consolidated report. **Write the report to `/tmp/bh-{PREFIX}-report.md`**
-and then emit it as a response. After writing the report, clean up intermediate files:
-`rm /tmp/bh-{PREFIX}-agent*.md /tmp/bh-{PREFIX}-verify-*.md` — the report and escalations
-files are kept intentionally (report for record-keeping, escalations for user follow-up).
+synthesize into one consolidated report:
+1. **Write the report to `/tmp/bh-{PREFIX}-report.md`** and emit it as a response.
+2. If any escalations exist, **also write them to `/tmp/bh-{PREFIX}-escalations.md`**
+   (so the user can re-read them without parsing the full report). Omit this file if there
+   are no escalations.
+3. **Optionally** clean up intermediate files after confirming the report is complete:
+   `rm /tmp/bh-{PREFIX}-agent*.md /tmp/bh-{PREFIX}-verify-*.md`
+   Do not run this if Phase 3 failed mid-synthesis — the intermediates are needed to retry.
+   The report and escalations files are always kept.
 
 ```
 ## Bug Hunt Report
@@ -183,10 +205,10 @@ files are kept intentionally (report for record-keeping, escalations for user fo
 
 ### Escalations — Human Review Needed
 
-Write escalations to `/tmp/bh-{PREFIX}-escalations.md` and list them here. For each one,
-present the precise scenario question to the user. After the user responds, spawn a new
-targeted verification agent for any scenario confirmed as possible, adding the deployment
-context to the candidate prompt.
+List escalations here and in `/tmp/bh-{PREFIX}-escalations.md` (omit the file if none).
+For each one, present the precise scenario question to the user. After the user responds,
+spawn a new targeted verification agent for any scenario confirmed as possible, adding the
+deployment context to the candidate prompt.
 
 #### [E1] Title
 
@@ -340,6 +362,10 @@ Check each explicitly during both discovery and verification:
 - [ ] Signal before check: `sem_post` / completion fires before the `if (success)` guard
 - [ ] Stale capture across `co_await`: value loaded before suspension used after resumption
   without re-read — another coroutine may have mutated shared state while this one was suspended
+- [ ] Dangling reference into coroutine frame: `const T&` or pointer captured into a coroutine
+  body may outlive the referent if the owning object is destroyed while the coroutine is suspended
+- [ ] Relaxed atomic as a branch guard: `load(relaxed)` used as a condition without a subsequent
+  `acquire` fence — the load can be reordered past dependent loads it was intended to gate
 
 **Error handling**
 - [ ] Error from device A sets `unavail` / triggers `__become_degraded` on device B

--- a/.claude/commands/bugs-hunt.md
+++ b/.claude/commands/bugs-hunt.md
@@ -189,6 +189,35 @@ Before reporting a race, determine which direction it can go:
 A race that can only go in the safe direction is a TSan warning, not a correctness bug.
 Document it accurately; do not overstate the risk.
 
+### Write Acknowledgment Boundary
+
+A write scenario is a correctness bug **only if** the caller could receive a successful
+acknowledgment while the data is in an inconsistent state on disk.
+
+**If the caller received EIO (or the process crashed before ACK), the upper layer owns
+recovery — this is NOT a bug in the RAID/storage layer:**
+
+- Journaling filesystems (XFS, ext4) come up after power loss, find unfinished journal
+  entries, and replay them. They read state before trusting anything — they do not assume
+  data is consistent just because RAID didn't return EIO.
+- `USER_RECOVERY` mode resubmits outstanding I/Os after restart.
+- "I never got an ACK back from this write; I should read before I assume anything" is the
+  correct upper-layer semantic.
+
+**The dangerous pattern** (real correctness bug) requires **both**:
+1. The write was (or could be) ACK'd to the caller as successful
+2. The on-disk data is inconsistent — caller reads stale data from a replica
+
+**Common false alarm**: both-writes-in-flight + A-fails + crash-before-SB-write.
+Even if B committed new data and the SB was never updated to show degraded mode,
+the caller never got a success ACK for that write (they got EIO or no response).
+On restart, a journaling filesystem treats that region as "unknown — must verify before use."
+This is handled correctly at the filesystem layer and is not a RAID-level data-loss bug.
+
+**What to check**: trace whether the ACK path (`co_return` with success,
+`UBLK_IO_COMMIT_AND_FETCH_REQ`) can fire AFTER a write landed on only one replica with no
+record of the inconsistency. If the ack fires only on the error path (EIO returned), it is safe.
+
 ### RAID1 Known False Positives — Verify Before Reporting
 
 These patterns look dangerous on first inspection but are structurally impossible. Confirm each

--- a/.claude/commands/bugs-hunt.md
+++ b/.claude/commands/bugs-hunt.md
@@ -45,10 +45,10 @@ in recent commits, re-verify the Known False Positive entries before trusting th
 
 ---
 
-## Phase 1 — Parallel Discovery (5 agents)
+## Phase 1 — Parallel Discovery (6 agents)
 
-Create the working directory, then spawn **5 agents in parallel** using the Agent tool.
-Send all 5 in a single message so they run concurrently.
+Create the working directory, then spawn **6 agents in parallel** using the Agent tool.
+Send all 6 in a single message so they run concurrently.
 
 ```bash
 mkdir -p .claude/bugs-hunt
@@ -67,7 +67,8 @@ its candidates to a dedicated output file.
 | 2 | `src/raid/raid1/raid1.cpp` — **runtime** state transitions only (`__become_degraded`, `__become_clean`, `__swap_device`, `async_iov`, `prepare`); `src/raid/raid1/raid1_resync_task.*`. **Owns `__become_degraded` — Agent 3 treats it as a black box.** | `.claude/bugs-hunt/bh-agent2.md` |
 | 3 | `src/raid/raid1/raid1_superblock.*`; startup path in `raid1.cpp` (`__init_*`, `__load_*`, **`__become_active`**) — pay particular attention to `__become_active` failing mid-startup and delegating to `__become_degraded`. **Treat `__become_degraded` as a black box; log cross-boundary concerns in the XB section (see output format below).** | `.claude/bugs-hunt/bh-agent3.md` |
 | 4 | `src/target/ublkpp_tgt.cpp`, `src/target/ublkpp_tgt_impl.hpp`, `src/lib/ublk_disk.cpp` | `.claude/bugs-hunt/bh-agent4.md` |
-| 5 | `src/raid/raid0/raid0.cpp`, `src/driver/`, `src/metrics/` — **for every capacity/size formula in raid0.cpp, apply the Arithmetic & Geometry Invariants section: identify the alignment assumption, verify the value supplier (e.g. RAID1 leg capacity) actually guarantees it, and check for remainder amplification via multiplication** | `.claude/bugs-hunt/bh-agent5.md` |
+| 5 | `src/raid/raid0/raid0.cpp`, `src/driver/`, `src/metrics/` | `.claude/bugs-hunt/bh-agent5.md` |
+| 6 | **All `.cpp` files in `src/`** (every subsystem) — focused exclusively on arithmetic & geometry invariants: capacity formulas, size computations, stride/alignment assumptions, and cross-subsystem invariant propagation. Must read **both** the consumer (e.g. `raid0.cpp`) and the supplier (e.g. `raid1.cpp`) to verify cross-subsystem alignment guarantees hold. See dedicated brief below. | `.claude/bugs-hunt/bh-agent6.md` |
 
 **Discovery agent prompt must include:**
 - Assigned files (read them in full — do not skim)
@@ -104,6 +105,40 @@ its candidates to a dedicated output file.
 The orchestrator uses this to detect truncation — a file that exists but lacks the sentinel
 was interrupted mid-run and should be treated as missing (report explicitly, do not skip).
 
+**Agent 6 only** — dedicated arithmetic & geometry analysis. Ignore races, power-loss,
+and state-machine issues (those are covered by Agents 1–5). Focus entirely on:
+
+**1. Implicit alignment assumptions.**
+For every formula `(x - stride) * n` or `x * n / stride` — what supplies `x`? Is `x`
+guaranteed to be a multiple of `stride`? Read the supplier's implementation (not just its
+callers), check version history, and verify the guarantee holds across all config paths.
+
+**2. Remainder amplification.**
+When a per-unit value is multiplied by a count, any remainder is amplified:
+```
+wrong:  total = (x - reserved) * n       // (x % stride) * n of phantom space
+right:  floor(x, stride) first, then compute
+```
+Phantom space maps to per-unit offsets past the end of the backing device → EIO on
+top-of-device reads (GPT / partition-table scans are a common trigger).
+
+**3. Cross-subsystem invariant propagation.**
+Trace capacity values from supplier to consumer across subsystem boundaries. Example:
+RAID1 leg capacity feeds RAID0's constructor — if RAID1 drops its padding guarantee in a
+new version, RAID0 silently over-reports. The bug is in the consumer (missing floor), not
+the supplier.
+
+**4. Integer division and sector-shift arithmetic.**
+`x >> SECTOR_SHIFT` and `x / stride` truncate; verify that truncation is intentional and
+not a silently-wrong substitute for floor-to-multiple. Check for unit mismatches (bytes
+vs sectors vs chunks).
+
+Agent 6 must read **all `.cpp` files in `src/`** to find every capacity/size formula and
+every cross-subsystem value flow. Pay particular attention to constructors that compute
+`dev_sectors` or `capacity()` from child device values.
+
+---
+
 **Agent 3 only** — append a cross-boundary section for anything that doesn't clear the
 Candidate confidence bar but touches `__become_degraded`. Note: the XB channel is the
 **only** path for startup-path findings that straddle the Agent 2/3 boundary — Agent 3
@@ -125,7 +160,7 @@ High-confidence bar, it should write it as an ESCALATE candidate (not suppress i
 
 ## Phase 2 — Independent Verification
 
-After all 5 discovery agents complete:
+After all 6 discovery agents complete:
 1. Run a pre-read sentinel check before processing any file:
    ```bash
    grep -rL "END AGENT" .claude/bugs-hunt/bh-agent*.md 2>/dev/null
@@ -133,7 +168,7 @@ After all 5 discovery agents complete:
    Any file listed by this command is missing its sentinel (truncated or failed). For each:
    ask the user whether to rerun that agent (with the same output file target) or continue
    without it. If an agent tool call failed entirely (no file at all), treat it the same way.
-   Do not proceed until all 5 files are confirmed or the user explicitly accepts a gap.
+   Do not proceed until all 6 files are confirmed or the user explicitly accepts a gap.
 2. Read the confirmed files and collect every candidate into a working list. Also collect any
    `## Cross-Boundary Concerns` sections from `agent3.md` — **XB items are appended to the
    candidate list before dedup, not after**.
@@ -238,7 +273,7 @@ synthesize into one consolidated report:
 
 **Scope**: [subsystems]
 **Candidates**: N total — Confirmed: X | Rejected: Y | Escalated: Z
-**Coverage**: All 5 agents audited | *or* Agent N unaudited (truncated/missing — [reason])
+**Coverage**: All 6 agents audited | *or* Agent N unaudited (truncated/missing — [reason])
 
 ---
 
@@ -376,8 +411,8 @@ record of the inconsistency. If the ack fires only on the error path (EIO return
 
 ### RAID1 Known False Positives — Verify Before Reporting
 
-**Note for Agent 5**: the KFP entries below are RAID1-specific and do not apply to
-RAID0, driver, or metrics code. Skip this section when scoped to Agent 5.
+**Note for Agents 5 and 6**: the KFP entries below are RAID1-specific and do not apply to
+RAID0, driver, metrics, or arithmetic-geometry analysis. Skip this section.
 
 **Staleness gate**: re-audit this entire section before running after any refactor touching
 `Raid1Disk`, `__become_*`, `write_superblock`, or `SuperBitmap`. There is no automated
@@ -431,44 +466,6 @@ invariant this cannot cause data loss. The fix (local-copy buffer stopping befor
 correctness bug.
 
 **REJECT** any candidate framing this TSan report as a data-loss or corruption risk.
-
----
-
-### Arithmetic & Geometry Invariants
-
-This class of bug is distinct from races and power-loss violations. It is often **latent** —
-correct when a supplying subsystem produces aligned inputs, silently broken when that
-subsystem changes (e.g. a version bump that drops a historical alignment guarantee).
-
-For every formula that computes a capacity, offset, stride, or count:
-
-**1. Identify the implicit alignment assumption.**
-A formula `(x - stride) * n` is correct only if `x` is a multiple of `stride`. Ask:
-- What supplies `x`? Is the alignment documented and enforced at the call site?
-- Can `x` be non-aligned? Check the full range of values the supplier can produce,
-  including across version changes and configuration paths.
-
-**2. Remainder amplification via multiplication.**
-When a per-unit value is multiplied by a count, any remainder is amplified by the count:
-```
-wrong: total = (x - reserved) * n          // (x % stride) * n of phantom space
-right: total = (floor(x, stride) - reserved) * n  // floor first, then compute
-```
-This phantom tail maps to per-unit offsets past the end of the backing device → EIO.
-
-**3. Cross-subsystem invariant propagation.**
-When function B consumes a value produced by function A and assumes property P (e.g.,
-"capacity is a multiple of stripe_size"), verify:
-- Does A currently guarantee P? Read A's implementation, not just its callers.
-- Has A ever dropped P silently? Look for version fields, reserved-size formulas,
-  or alignment padding that may have changed.
-- The bug is in B (the consumer), not A — B must not silently assume what it doesn't
-  verify.
-
-**4. Phantom address space test.**
-If reported size > actual addressable space: I/O to addresses near the top of the
-device dispatches to per-unit offsets past the end of the backing device → EIO.
-This surfaces as GPT/partition-table scan failures or top-of-device read errors.
 
 ---
 

--- a/.claude/commands/bugs-hunt.md
+++ b/.claude/commands/bugs-hunt.md
@@ -32,8 +32,8 @@ Operate accordingly:
 
 ## Session Setup
 
-Run the following via the Bash tool to get a unique session prefix (ublk is Linux-only,
-so `shuf` is available; use the Python fallback in containers without util-linux):
+Run the following via the Bash tool to get a unique session prefix (use the Python fallback
+if `shuf` is absent, e.g. on macOS dev machines):
 
 ```bash
 shuf -i 1000000-9999999 -n1
@@ -79,6 +79,8 @@ git log f984348..HEAD --oneline src/raid/raid1/super_bitmap.cpp src/raid/raid1/s
 Non-empty output for the first command → re-verify §1 and §2a.
 Non-empty output for the second → re-verify §2b.
 If you re-verify and the entries still hold, update the anchor commit hash above.
+Failing to update the hash is not a correctness problem — agents will re-investigate
+already-cleared false positives unnecessarily, but won't miss real bugs.
 
 Example: prefix `3847201` → `/tmp/bh-3847201-agent1.md`, `/tmp/bh-3847201-verify-01.md`,
 `/tmp/bh-3847201-report.md`. The PREFIX is preserved in the report and escalations filenames
@@ -88,13 +90,17 @@ Example: prefix `3847201` → `/tmp/bh-3847201-agent1.md`, `/tmp/bh-3847201-veri
 
 ## Phase 1 — Parallel Discovery (5 agents)
 
-**Pre-spawn verification**: before spawning agents, list the 5 output filenames you will
-tell each agent to write to and confirm none contains the literal string `{PREFIX}`. If any
-does, the substitution failed — stop and re-announce the prefix.
+**Pre-spawn verification**: emit the 5 actual output filenames before spawning (e.g.,
+`/tmp/bh-3847201-agent1.md` through `/tmp/bh-3847201-agent5.md`), then confirm they match
+the announced SESSION PREFIX. If any contains the literal string `{PREFIX}`, substitution
+failed — stop and re-announce the prefix. This forces the LLM to demonstrate correct
+substitution before any agent is spawned.
 
 Spawn **5 agents in parallel** using the Agent tool. Send all 5 in a single message so
 they run concurrently. Each agent is scoped to one subsystem, reads the relevant source
 files in full, and writes its candidates to a dedicated output file.
+
+<!-- Scope last reviewed: 2026-05-31 / commit f984348. Update when src/ files are renamed, moved, or new subsystems added. -->
 
 | Agent | Scope | Output file |
 |---|---|---|
@@ -107,6 +113,8 @@ files in full, and writes its candidates to a dedicated output file.
 **Discovery agent prompt must include:**
 - Assigned files (read them in full — do not skim)
 - The Analysis Framework section below — **paste it verbatim, do not summarize**
+- If you encounter an unfamiliar pattern (SISL macros, coroutine idioms, etc.), check
+  `CLAUDE.md` for project conventions before flagging it as a bug candidate
   (intentional: ~300 tokens × (5 discovery + N verify) agents; at 10 candidates ≈ 4.5k
    overhead; accepted cost
   for consistent reasoning)
@@ -176,19 +184,20 @@ After all 5 discovery agents complete:
 3. **If the working list is empty**: emit `Bug Hunt Report: 0 candidates found — no bugs
    detected in audited subsystems.` Clean up discovery files (`rm /tmp/bh-{PREFIX}-agent*.md`)
    and do not proceed to Phase 3.
-4. **If there are more than 20 candidates total**: escalate all Low-confidence candidates
-   directly to the report as ESCALATE (without spawning verifiers) — treat discovery-time
-   Low-confidence as insufficient evidence for a full verification pass. The threshold of 20
-   is chosen to keep Phase 2 within roughly 4 rounds of 8 agents; adjust if the framework
-   is re-used on a larger codebase.
+4. **If there are ≥ 20 candidates total**: escalate all Low-confidence candidates directly
+   to the report as ESCALATE (without spawning verifiers) — treat discovery-time
+   Low-confidence as insufficient evidence when discovery is this broad. <!-- threshold rule:
+   keep Phase 2 ≤ 4 rounds × 8 agents; recalibrate for larger codebases -->
 5. Sort remaining candidates by agent number, then candidate number, then assign a flat
    sequential index (01, 02, 03 …).
-6. Prefer one candidate per agent. Run **≤ 8 agents per turn** to stay within the context
-   window budget. If there are more than 8 candidates total, run them in rounds of 8 — read
-   all outputs from round N, applying the same sentinel-check as for discovery files
-   (`<!-- END VERIFY NN -->`, where NN is the first candidate's flat index in that file),
-   before round N+1. If budget or candidate volume makes individual agents impractical, you
-   may put multiple candidates in one agent, but never mix High or Medium candidates.
+6. **By default, one candidate per agent.** Run **≤ 8 agents per turn** (sized for the
+   current context window; adjust if model context limits change). If there are more than 8
+   candidates total, run them in rounds of 8 — read all outputs from round N, applying the
+   sentinel-check (`<!-- END VERIFY NN -->`) before round N+1. If a discovery agent produces
+   no output after a reasonable wait, treat it as failed and apply the missing-agent protocol
+   (ask user to rerun). **Budget exception only**: if candidate volume makes individual agents
+   impractical, you may put multiple Low-confidence candidates in one agent — never High or
+   Medium.
 
 Each verification agent receives: the candidate text, the full Analysis Framework section
 (**paste verbatim**), and the million-dollar rule. It has **no knowledge of what discovery
@@ -229,13 +238,13 @@ in a header comment. Use one verdict block per candidate, referenced by flat ind
 **Scenario for user**: "Please consider: [precise, concrete sequence].
   Is this execution possible in your deployment?"
 
-<!-- END VERIFY NN -->
+<!-- END VERIFY 04 -->
 ```
 
-The sentinel `<!-- END VERIFY NN -->` is required on every verify file. NN must be the
-**first** candidate's flat index (matching the filename, e.g., verify-04.md → sentinel
-`<!-- END VERIFY 04 -->`). Using the last candidate's index would allow partial files to
-pass the truncation check. Apply the sentinel check before proceeding to the next round.
+The sentinel is required on every verify file. **NN = first candidate's flat index**
+(matching the filename: verify-04.md → `<!-- END VERIFY 04 -->`). Do not use the last
+candidate's index — a file truncated after the first verdict block would then pass the
+sentinel check, masking the truncation. Apply the sentinel check before the next round.
 
 ---
 
@@ -247,8 +256,9 @@ synthesize into one consolidated report:
 2. If any escalations exist, **also write them to `/tmp/bh-{PREFIX}-escalations.md`**
    (so the user can re-read them without parsing the full report). Omit this file if there
    are no escalations.
-3. **Conditionally** clean up intermediate files — only if the report file exists, is ≥ 100
-   bytes, and every verify file was read without exception. Substitute the actual prefix
+3. **Conditionally** clean up intermediate files — only if the report contains the
+   `### Rejected (False Positives)` section header (present in every complete report,
+   absent if synthesis was interrupted), and every verify file was read without exception. Substitute the actual prefix
    before running (same rule as Phase 1 prompts):
    `rm /tmp/bh-{PREFIX}-agent*.md /tmp/bh-{PREFIX}-verify-*.md`
    Note: the glob `verify-*.md` matches escalation re-verification files (`verify-ENN.md`)
@@ -271,7 +281,9 @@ synthesize into one consolidated report:
 <!-- Severity:
      P0 = data loss / corruption
      P1 = crash / unavailability
-     P2 = extra resync / degraded performance / unnecessary I/O — no data loss or crash path -->
+     P2 = extra resync / degraded performance / unnecessary I/O — no data loss or crash path
+     When in doubt between two severities, use the higher one. If deployment context is
+     needed to determine severity, use ESCALATE instead. -->
 
 **Location**: file.cpp:line
 **Type**: ...

--- a/.claude/commands/bugs-hunt.md
+++ b/.claude/commands/bugs-hunt.md
@@ -67,7 +67,7 @@ its candidates to a dedicated output file.
 | 2 | `src/raid/raid1/raid1.cpp` — **runtime** state transitions only (`__become_degraded`, `__become_clean`, `__swap_device`, `async_iov`, `prepare`); `src/raid/raid1/raid1_resync_task.*`. **Owns `__become_degraded` — Agent 3 treats it as a black box.** | `.claude/bugs-hunt/bh-agent2.md` |
 | 3 | `src/raid/raid1/raid1_superblock.*`; startup path in `raid1.cpp` (`__init_*`, `__load_*`, **`__become_active`**) — pay particular attention to `__become_active` failing mid-startup and delegating to `__become_degraded`. **Treat `__become_degraded` as a black box; log cross-boundary concerns in the XB section (see output format below).** | `.claude/bugs-hunt/bh-agent3.md` |
 | 4 | `src/target/ublkpp_tgt.cpp`, `src/target/ublkpp_tgt_impl.hpp`, `src/lib/ublk_disk.cpp` | `.claude/bugs-hunt/bh-agent4.md` |
-| 5 | `src/raid/raid0/raid0.cpp`, `src/driver/`, `src/metrics/` | `.claude/bugs-hunt/bh-agent5.md` |
+| 5 | `src/raid/raid0/raid0.cpp`, `src/driver/`, `src/metrics/` — **for every capacity/size formula in raid0.cpp, apply the Arithmetic & Geometry Invariants section: identify the alignment assumption, verify the value supplier (e.g. RAID1 leg capacity) actually guarantees it, and check for remainder amplification via multiplication** | `.claude/bugs-hunt/bh-agent5.md` |
 
 **Discovery agent prompt must include:**
 - Assigned files (read them in full — do not skim)
@@ -434,6 +434,44 @@ correctness bug.
 
 ---
 
+### Arithmetic & Geometry Invariants
+
+This class of bug is distinct from races and power-loss violations. It is often **latent** —
+correct when a supplying subsystem produces aligned inputs, silently broken when that
+subsystem changes (e.g. a version bump that drops a historical alignment guarantee).
+
+For every formula that computes a capacity, offset, stride, or count:
+
+**1. Identify the implicit alignment assumption.**
+A formula `(x - stride) * n` is correct only if `x` is a multiple of `stride`. Ask:
+- What supplies `x`? Is the alignment documented and enforced at the call site?
+- Can `x` be non-aligned? Check the full range of values the supplier can produce,
+  including across version changes and configuration paths.
+
+**2. Remainder amplification via multiplication.**
+When a per-unit value is multiplied by a count, any remainder is amplified by the count:
+```
+wrong: total = (x - reserved) * n          // (x % stride) * n of phantom space
+right: total = (floor(x, stride) - reserved) * n  // floor first, then compute
+```
+This phantom tail maps to per-unit offsets past the end of the backing device → EIO.
+
+**3. Cross-subsystem invariant propagation.**
+When function B consumes a value produced by function A and assumes property P (e.g.,
+"capacity is a multiple of stripe_size"), verify:
+- Does A currently guarantee P? Read A's implementation, not just its callers.
+- Has A ever dropped P silently? Look for version fields, reserved-size formulas,
+  or alignment padding that may have changed.
+- The bug is in B (the consumer), not A — B must not silently assume what it doesn't
+  verify.
+
+**4. Phantom address space test.**
+If reported size > actual addressable space: I/O to addresses near the top of the
+device dispatches to per-unit offsets past the end of the backing device → EIO.
+This surfaces as GPT/partition-table scan failures or top-of-device read errors.
+
+---
+
 ### Pattern Checklist
 
 Check each explicitly during both discovery and verification:
@@ -468,3 +506,14 @@ Check each explicitly during both discovery and verification:
   (but see KFP §1 — for ublkpp this is currently structurally blocked by resync drain)
 - One-sided version bounds: `version < N` with no `version > MAX` upper-bound rejection
 - Two writes that must be consistent but have no atomic boundary between them
+
+**Arithmetic & Geometry**
+- Implicit alignment assumption: formula `(x - stride) * n` assumes `x % stride == 0` —
+  verify the value supplier actually guarantees this, including across version changes
+- Remainder amplification: per-unit remainder carried into a multiplication by leg/stripe
+  count produces phantom capacity: `(x % stride) * n` of address space past the backing device
+- Cross-subsystem invariant not enforced at the boundary: Subsystem B assumes Subsystem A's
+  output satisfies property P — verify P holds through A's full version and config space,
+  not just the current implementation
+- Phantom address space: I/O into the over-reported tail dispatches to per-unit offsets ≥
+  backing device capacity → EIO (surfaces as top-of-device GPT / partition-table scan failures)

--- a/.claude/commands/bugs-hunt.md
+++ b/.claude/commands/bugs-hunt.md
@@ -28,14 +28,13 @@ Operate accordingly:
 
 ## Session Setup
 
-Run the following via the Bash tool to get a unique session prefix (Linux):
+Run the following via the Bash tool to get a unique session prefix (portable):
 
 ```bash
-shuf -i 1000000-9999999 -n1
+python3 -c "import random; print(random.randint(1000000,9999999))"
 ```
 
-On macOS use: `python3 -c "import random; print(random.randint(1000000,9999999))"` or
-install GNU coreutils (`brew install coreutils`) and use `gshuf`.
+On Linux you can also use `shuf -i 1000000-9999999 -n1`.
 
 Use the output (e.g., `3847201`) as a prefix for **every** output file and shell command
 in this run. This prevents silent overwrites on re-runs or concurrent hunts — a timestamp
@@ -59,6 +58,9 @@ Example: prefix `3847201` → `/tmp/bh-3847201-agent1.md`, `/tmp/bh-3847201-veri
 
 ## Phase 1 — Parallel Discovery (5 agents)
 
+**Reminder**: substitute the actual prefix for `{PREFIX}` in every agent prompt and
+filename you emit in this phase — do not pass the literal string `{PREFIX}` to agents.
+
 Spawn **5 agents in parallel** using the Agent tool. Send all 5 in a single message so
 they run concurrently. Each agent is scoped to one subsystem, reads the relevant source
 files in full, and writes its candidates to a dedicated output file.
@@ -74,6 +76,7 @@ files in full, and writes its candidates to a dedicated output file.
 **Discovery agent prompt must include:**
 - Assigned files (read them in full — do not skim)
 - The Analysis Framework section below — **paste it verbatim, do not summarize**
+  (this is intentional; the token cost buys consistent reasoning across all agents)
 - The million-dollar rule
 - This output format — write raw candidates to the output file, no filtering yet:
 
@@ -103,7 +106,9 @@ The orchestrator uses this to detect truncation — a file that exists but lacks
 was interrupted mid-run and should be treated as missing (report explicitly, do not skip).
 
 **Agent 3 only** — append a cross-boundary section for anything that doesn't clear the
-Candidate confidence bar but touches `__become_degraded`:
+Candidate confidence bar but touches `__become_degraded`. Note: the XB channel is the
+**only** path for startup-path findings that straddle the Agent 2/3 boundary — Agent 3
+cannot confirm or reject such findings directly, only flag them for Agent 2 verification.
 
 ```
 ## Cross-Boundary Concerns (for Agent 2 verification)
@@ -130,17 +135,19 @@ After all 5 discovery agents complete:
    After collecting all candidates, **dedup before assigning flat indices**. Two candidates
    are the same issue if they point to the same code location AND the trigger sequence
    produces the same harmful outcome — merge them into one rather than spawning two
-   independent verifiers.
+   independent verifiers. Same location but different harmful outcome = keep both.
 2. **If the working list is empty**: skip Phase 2 and emit `Bug Hunt Report: 0 candidates
    found.` Do not proceed to Phase 3.
 3. Assign each candidate a flat sequential index (01, 02, 03 …) regardless of which
    discovery agent produced it.
-4. Prefer batches of **≤ 8 agents per turn** to stay within the context window budget.
-   If you have strong reason to exceed this, proceed but note the quality risk. Each candidate gets its own agent. If there are more
-   than 8 candidates total, run them in rounds of 8 — read all outputs from round N before
-   spawning round N+1. Only if forced by the limit: batch **Low-confidence** candidates
-   targeting the same source file into one agent (never High or Medium — batched agents share
-   agent context, and a finding in candidate A may anchor reasoning for candidate B).
+4. Each candidate gets its own agent. Prefer batches of **≤ 8 agents per turn** to stay
+   within the context window budget; if you have strong reason to exceed this, proceed but
+   note the quality risk. If there are more than 8 candidates total, run them in rounds of
+   8 — read all outputs from round N (applying the same sentinel-check as for discovery
+   files) before spawning round N+1. Only if a single round has more than 8 **Low-confidence**
+   candidates targeting the same source file: batch those into one agent (never High or
+   Medium — batched agents share agent context, and a finding in candidate A may anchor
+   reasoning for candidate B).
 
 Each verification agent receives: the candidate text, the full Analysis Framework section
 (**paste verbatim**), and the million-dollar rule. It has **no knowledge of what discovery
@@ -193,10 +200,12 @@ synthesize into one consolidated report:
    (so the user can re-read them without parsing the full report). Omit this file if there
    are no escalations.
 3. **Conditionally** clean up intermediate files — only if the report file exists, is ≥ 100
-   bytes, and every verify file was read without exception:
+   bytes, and every verify file was read without exception. Substitute the actual prefix
+   before running (same rule as Phase 1 prompts):
    `rm /tmp/bh-{PREFIX}-agent*.md /tmp/bh-{PREFIX}-verify-*.md`
-   Do not run if Phase 3 failed mid-synthesis (intermediates needed to retry).
-   The report and escalations files are always kept.
+   If the `rm` fails (permissions, already deleted), note it but do not treat it as a
+   Phase 3 failure — the report is already written. The report and escalations files are
+   always kept. Do not run if Phase 3 failed mid-synthesis (intermediates needed to retry).
 
 ```
 ## Bug Hunt Report
@@ -335,8 +344,11 @@ record of the inconsistency. If the ack fires only on the error path (EIO return
 
 ### RAID1 Known False Positives — Verify Before Reporting
 
-<!-- Re-audit this entire section before running after any refactor touching
-     Raid1Disk, __become_*, write_superblock, or SuperBitmap. -->
+**Note for Agent 5**: the KFP entries below are RAID1-specific and do not apply to
+RAID0, driver, or metrics code. Skip this section when scoped to Agent 5.
+
+**Staleness gate**: re-audit this entire section before running after any refactor touching
+`Raid1Disk`, `__become_*`, `write_superblock`, or `SuperBitmap`.
 
 These patterns look dangerous on first inspection but are structurally impossible. Each entry
 is anchored to a specific invariant — if that invariant changes in the code, re-trace from

--- a/.claude/commands/bugs-hunt.md
+++ b/.claude/commands/bugs-hunt.md
@@ -39,17 +39,9 @@ mkdir -p /tmp/bugs-hunt
 ```
 
 All output files go in `/tmp/bugs-hunt/`. Re-running the command overwrites previous
-results — this is intentional. Check for KFP staleness before Phase 1:
-
-```bash
-# KFP §1 (destructor) and §2a (CAS gate) — anchored to raid1.cpp:
-git log f984348..HEAD --oneline src/raid/raid1/raid1.cpp
-# KFP §2b (superbitmap safe-direction race) — anchored to super_bitmap.*:
-git log f984348..HEAD --oneline src/raid/raid1/super_bitmap.cpp src/raid/raid1/super_bitmap.hpp
-```
-
-Non-empty output for the first → re-verify §1 and §2a. Second → re-verify §2b. If entries
-still hold after re-verification, update the anchor hash `f984348` above.
+results — this is intentional. Before starting, check whether KFP-relevant code has changed since you last ran this command.
+If `Raid1Disk`, `__become_*`, `write_superblock`, or `SuperBitmap` were modified in recent
+commits, re-verify the Known False Positive entries before trusting them.
 
 ---
 
@@ -59,7 +51,7 @@ Spawn **5 agents in parallel** using the Agent tool. Send all 5 in a single mess
 they run concurrently. Each agent is scoped to one subsystem, reads the relevant source
 files in full, and writes its candidates to a dedicated output file.
 
-<!-- Scope last reviewed: 2026-05-31 / commit f984348. Update when src/ files are renamed, moved, or new subsystems added. -->
+<!-- Scope last reviewed: 2026-05-31. Update when src/ files are renamed, moved, or new subsystems added. -->
 
 | Agent | Scope | Output file |
 |---|---|---|

--- a/.claude/commands/bugs-hunt.md
+++ b/.claude/commands/bugs-hunt.md
@@ -33,7 +33,8 @@ epoch seconds) and use it as a prefix for **every** output file in this run. Thi
 silent overwrites on re-runs or concurrent hunts.
 
 Example: prefix `947312` → `/tmp/bh-947312-agent1.md`, `/tmp/bh-947312-verify-01.md`,
-`/tmp/bh-947312-report.md`. Replace `{PREFIX}` with your chosen value throughout.
+`/tmp/bh-947312-report.md`. Find-and-replace `{PREFIX}` in every agent prompt you emit
+before spawning — do not pass the literal string `{PREFIX}` to agents.
 
 ---
 
@@ -45,10 +46,10 @@ files in full, and writes its candidates to a dedicated output file.
 
 | Agent | Scope | Output file |
 |---|---|---|
-| 1 | `src/raid/raid1/bitmap.cpp`, `bitmap.hpp`, `super_bitmap.*` | `/tmp/bh-{PREFIX}-agent1.md` |
+| 1 | `src/raid/raid1/bitmap.cpp`, `src/raid/raid1/bitmap.hpp`, `src/raid/raid1/super_bitmap.cpp`, `src/raid/raid1/super_bitmap.hpp` | `/tmp/bh-{PREFIX}-agent1.md` |
 | 2 | `src/raid/raid1/raid1.cpp` — **runtime** state transitions only (`__become_degraded`, `__become_clean`, `__swap_device`, `async_iov`, `prepare`); `src/raid/raid1/raid1_resync_task.*`. **Owns `__become_degraded` — Agent 3 treats it as a black box.** | `/tmp/bh-{PREFIX}-agent2.md` |
 | 3 | `src/raid/raid1/raid1_superblock.*`; startup path in `raid1.cpp` (`__init_*`, `__load_*`, **`__become_active`**) — pay particular attention to `__become_active` failing mid-startup and delegating to `__become_degraded`. **Treat `__become_degraded` as a black box; note any concerns for Agent 2 to verify.** | `/tmp/bh-{PREFIX}-agent3.md` |
-| 4 | `src/target/ublkpp_tgt.cpp`, `src/lib/disk_task.*` | `/tmp/bh-{PREFIX}-agent4.md` |
+| 4 | `src/target/ublkpp_tgt.cpp`, `src/target/ublkpp_tgt_impl.hpp` | `/tmp/bh-{PREFIX}-agent4.md` |
 | 5 | `src/raid/raid0/raid0.cpp`, `src/driver/`, `src/metrics/` | `/tmp/bh-{PREFIX}-agent5.md` |
 
 **Discovery agent prompt must include:**
@@ -82,15 +83,18 @@ After all 5 discovery agents complete:
    `/tmp/bh-{PREFIX}-agent5.md`) and collect every candidate into a working list
    before spawning any verification agent. **If any file is missing or empty, report
    it explicitly** (e.g., "Agent 3 output missing — that subsystem was not audited")
-   before continuing. Do not silently skip it.
+   before continuing. Do not silently skip it. If Agent 3 flagged a cross-boundary
+   concern about `__become_degraded`, merge it with Agent 2's candidates and treat
+   it as a single candidate for verification.
 2. **If the working list is empty**: skip Phase 2 and emit `Bug Hunt Report: 0 candidates
    found.` Do not proceed to Phase 3.
 3. Assign each candidate a flat sequential index (01, 02, 03 …) regardless of which
    discovery agent produced it.
 4. Spawn verification agents in batches of **at most 8 at a time** (the per-turn concurrency
    limit in Claude Code's Agent tool). Batch Low-confidence candidates that target the same
-   source file into a single agent (note: batched agents share file context — an acceptable
-   cost/independence tradeoff for Low-confidence candidates only).
+   source file into a single agent (note: batched agents share agent context — a finding in
+   candidate A may anchor reasoning for candidate B; only batch when you accept this risk for
+   Low-confidence candidates).
 
 Each verification agent receives: the candidate text, the full Analysis Framework section
 (**paste verbatim**), and the million-dollar rule. It has **no knowledge of what discovery
@@ -139,8 +143,8 @@ in a header comment. Use one verdict block per candidate, referenced by flat ind
 After all verification agents complete, read all `/tmp/bh-{PREFIX}-verify-*.md` files and
 synthesize into one consolidated report. **Write the report to `/tmp/bh-{PREFIX}-report.md`**
 and then emit it as a response. After writing the report, clean up intermediate files:
-`rm /tmp/bh-{PREFIX}-agent*.md /tmp/bh-{PREFIX}-verify-*.md` — keep only the report and
-escalations files.
+`rm /tmp/bh-{PREFIX}-agent*.md /tmp/bh-{PREFIX}-verify-*.md` — the report and escalations
+files are kept intentionally (report for record-keeping, escalations for user follow-up).
 
 ```
 ## Bug Hunt Report
@@ -173,7 +177,7 @@ escalations files.
 
 | ID | Title | Rejected because |
 |---|---|---|
-| 03 | ... | CAS at raid1.cpp:620 prevents concurrent entry |
+| 03 | ... | CAS in `__become_degraded` prevents concurrent entry |
 
 ---
 
@@ -296,7 +300,7 @@ there are **zero active IO coroutines**. Nothing in the destructor can race with
 
 **REJECT** any candidate that claims a race between the destructor and IO coroutines.
 
-#### 2. Concurrent `write_superblock` callers (phantom)
+#### 2a. Concurrent `write_superblock` callers (phantom)
 
 Two `write_superblock` calls cannot overlap — the state machine prevents it structurally:
 
@@ -307,15 +311,19 @@ Two `write_superblock` calls cannot overlap — the state machine prevents it st
   that tries `CAS(EITHER → ...)` sees a mismatch and returns before reaching `write_superblock`.
 - The same CAS argument excludes `__swap_device`.
 
-**What TSan actually detects is a different, safe-direction race:** the old code passed `_sb`
-directly as `iov_base`, causing a non-atomic read of the `superbitmap_reserved` field while IO
-coroutines call `SuperBitmap::set_bit` → `atomic_ref<uint8_t>::fetch_or` on those same bytes.
-Under the core invariant this race can only go in the safe direction — `fetch_or` only sets
-bits, so memory gets dirtier than disk, never cleaner. It is a TSan warning, not a correctness
-bug. The fix (local-copy buffer stopping before `superbitmap_reserved`) silences TSan and is a
-correct cleanup, but the concurrent-callers framing is wrong.
-
 **REJECT** any candidate claiming two concurrent `write_superblock` callers.
+
+#### 2b. TSan report on `superbitmap_reserved` during superblock write (safe direction)
+
+TSan may flag a race between `write_superblock` reading `_sb` as raw bytes (via `iov_base`)
+and IO coroutines calling `SuperBitmap::set_bit` → `atomic_ref<uint8_t>::fetch_or` on the
+`superbitmap_reserved` field of the same superblock page. This is a **safe-direction race**:
+`fetch_or` only sets bits, so memory gets dirtier than disk, never cleaner. Under the core
+invariant this cannot cause data loss. The fix (local-copy buffer stopping before
+`superbitmap_reserved`) silences TSan and is a correct cleanup, but the race is not a
+correctness bug.
+
+**REJECT** any candidate framing this TSan report as a data-loss or corruption risk.
 
 ---
 


### PR DESCRIPTION
Adds \`.claude/commands/bugs-hunt.md\`: a 3-phase agentic bug-hunting skill for this repo.

## How it works

**Phase 1 — Parallel discovery (5 agents)**
Five agents run concurrently, each scoped to one subsystem:

| Agent | Scope |
|---|---|
| 1 | \`src/raid/raid1/bitmap.cpp\`, \`bitmap.hpp\`, \`super_bitmap.cpp\`, \`super_bitmap.hpp\` |
| 2 | \`src/raid/raid1/raid1.cpp\` — state transitions (\`__become_*\`, \`__swap_device\`, \`async_iov\`) |
| 3 | \`src/raid/raid1/raid1_superblock.*\`, startup path (\`__init_*\`, \`__load_*\`) |
| 4 | \`src/target/ublkpp_tgt.cpp\`, \`src/target/ublkpp_tgt_impl.hpp\`, \`src/lib/ublk_disk.cpp\` |
| 5 | \`src/raid/raid0/raid0.cpp\`, \`src/driver/\`, \`src/metrics/\` |

All output files go in \`.claude/bugs-hunt/\`. Re-running overwrites previous results.

**Phase 2 — Independent verification**
One clean-context verification agent per candidate. No shared state with discovery. Each agent traces the exact trigger sequence through the code, identifies every CAS gate / lock / ordering constraint, and delivers a CONFIRM / REJECT / ESCALATE verdict.

**Phase 3 — Consolidated report**
Confirmed bugs, rejected false positives (with the specific guard that blocks them), and escalations (precise scenario questions for the user).

## Key principles

- **Million-dollar rule**: only report if 100% certain it is a real bug; uncertain findings become escalations, never bug claims. "No bugs found" is a valid and valuable outcome.
- **Power-loss safety**: every line can be the last — never assume line A+1 ran because line A did.
- **CAS gate analysis**: trace the full compare-exchange chain before flagging a race — concurrent execution is often structurally impossible.
- **Race direction**: a set-only race (\`fetch_or\`) goes in the safe direction; a clear race (\`fetch_and\`) is the data-loss direction. Classify accurately.
- **Known false positives**: RAID1-specific phantom patterns (destructor/IO-coroutine races, concurrent \`write_superblock\` callers) are pre-documented with invariant anchors so agents don't rediscover them on every run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)