### PR TITLE
fix(bitmap,target,raid0): Bitmap-B2 race, Target-B2 queue failure detection, RAID0-B5 discard propagation

### DIFF
--- a/include/ublkpp/lib/ublk_disk.hpp
+++ b/include/ublkpp/lib/ublk_disk.hpp
@@ -60,6 +60,7 @@ public:
     uint32_t max_tx() const noexcept;
     bool can_discard() const noexcept;
     uint32_t discard_granularity() const noexcept;
+    uint32_t max_discard_sectors() const noexcept;
     uint64_t capacity() const noexcept;
     bool direct_io() const noexcept { return _direct_io; }
     bool is_missing() const noexcept { return _is_missing; }

--- a/src/lib/ublk_disk.cpp
+++ b/src/lib/ublk_disk.cpp
@@ -49,6 +49,7 @@ uint32_t ublk_disk::physical_block_size() const noexcept { return 1 << _params->
 uint32_t ublk_disk::max_tx() const noexcept { return _params->basic.max_sectors << SECTOR_SHIFT; }
 bool ublk_disk::can_discard() const noexcept { return _params->types & UBLK_PARAM_TYPE_DISCARD; }
 uint32_t ublk_disk::discard_granularity() const noexcept { return _params->discard.discard_granularity; }
+uint32_t ublk_disk::max_discard_sectors() const noexcept { return _params->discard.max_discard_sectors; }
 uint64_t ublk_disk::capacity() const noexcept { return _params->basic.dev_sectors << SECTOR_SHIFT; }
 
 namespace {

--- a/src/raid/raid0/raid0.cpp
+++ b/src/raid/raid0/raid0.cpp
@@ -144,8 +144,16 @@ Raid0Disk::Raid0Disk(boost::uuids::uuid const& uuid, uint32_t const stripe_size_
     // Align size to max_sector size
     our_params.basic.dev_sectors -= (our_params.basic.dev_sectors % our_params.basic.max_sectors);
 
-    if (can_discard())
+    if (can_discard()) {
         our_params.discard.discard_granularity = std::max(our_params.discard.discard_granularity, block_size());
+        // Propagate the tightest per-stripe max_discard_sectors across all child devices, scaled
+        // by stripe count (a top-level discard of N sectors distributes ~N/stripes per child).
+        uint32_t child_min = UINT32_MAX;
+        for (auto const& s : _stripe_array)
+            child_min = std::min(child_min, s->disk->max_discard_sectors());
+        our_params.discard.max_discard_sectors = static_cast< uint32_t >(
+            std::min< uint64_t >(static_cast< uint64_t >(child_min) * _stripe_array.size(), UINT32_MAX));
+    }
 }
 
 Raid0Disk::~Raid0Disk() = default;

--- a/src/raid/raid0/tests/device_probe.cpp
+++ b/src/raid/raid0/tests/device_probe.cpp
@@ -3,8 +3,11 @@
 // max_discard_sectors is propagated from child devices (min * stripe count)
 TEST(Raid0, MaxDiscardSectorsPropagated) {
     constexpr uint32_t k_child_max_discard = 1000; // sectors
-    auto device_a = CREATE_DISK(TestParams{.capacity = Gi, .max_discard_sectors = k_child_max_discard});
-    auto device_b = CREATE_DISK(TestParams{.capacity = Gi, .max_discard_sectors = k_child_max_discard * 2});
+    // Named vars: commas in brace-init confuse the C preprocessor into splitting the macro arg.
+    TestParams p_a{.capacity = Gi, .max_discard_sectors = k_child_max_discard};
+    TestParams p_b{.capacity = Gi, .max_discard_sectors = k_child_max_discard * 2};
+    auto device_a = CREATE_DISK(p_a);
+    auto device_b = CREATE_DISK(p_b);
 
     auto raid_device = ublkpp::make_raid0_disk(boost::uuids::random_generator()(), 32 * Ki,
                                                std::vector< std::shared_ptr< ublk_disk > >{device_a, device_b});

--- a/src/raid/raid0/tests/device_probe.cpp
+++ b/src/raid/raid0/tests/device_probe.cpp
@@ -1,5 +1,18 @@
 #include "test_raid0_common.hpp"
 
+// max_discard_sectors is propagated from child devices (min * stripe count)
+TEST(Raid0, MaxDiscardSectorsPropagated) {
+    constexpr uint32_t k_child_max_discard = 1000; // sectors
+    auto device_a = CREATE_DISK(TestParams{.capacity = Gi, .max_discard_sectors = k_child_max_discard});
+    auto device_b = CREATE_DISK(TestParams{.capacity = Gi, .max_discard_sectors = k_child_max_discard * 2});
+
+    auto raid_device = ublkpp::make_raid0_disk(boost::uuids::random_generator()(), 32 * Ki,
+                                               std::vector< std::shared_ptr< ublk_disk > >{device_a, device_b});
+
+    // min child (1000) * 2 stripes = 2000 sectors
+    EXPECT_EQ(raid_device->max_discard_sectors(), k_child_max_discard * 2u);
+}
+
 // Brief: Test that RAID0 devices correctly report paramaters based on Devices A and B
 //
 // Construct a RAID0 device with 3 Identical underlying devices that match on every

--- a/src/raid/raid1/bitmap.cpp
+++ b/src/raid/raid1/bitmap.cpp
@@ -328,8 +328,17 @@ std::tuple< Bitmap::word_t*, uint32_t, uint32_t > Bitmap::clean_region(uint64_t 
 
     // Check if page became completely clean, and update superbitmap if so
     if (0 == isal_zero_detect(page, k_page_size)) {
-        // Clear superbitmap bit for this now-clean page
         _super_bitmap.clear_bit(page_offset);
+        // Race guard: dirty_region may have called fetch_or (setting bits) and then set_bit
+        // (marking superbitmap) between our isal_zero_detect and clear_bit above. The fence
+        // ensures we observe any such concurrent store before re-reading the page. If the page
+        // has new dirty bits we restore the superbitmap bit; if dirty_region's set_bit runs
+        // after our fence it wins and sets the bit itself — either way the superbitmap is correct.
+        std::atomic_thread_fence(std::memory_order_seq_cst);
+        if (0 != isal_zero_detect(page, k_page_size)) {
+            _super_bitmap.set_bit(page_offset);
+            return std::make_tuple(nullptr, page_offset, sz);
+        }
         return std::make_tuple(_clean_page.get(), page_offset, sz);
     }
     return std::make_tuple(nullptr, page_offset, sz);

--- a/src/raid/raid1/tests/bitmap/CMakeLists.txt
+++ b/src/raid/raid1/tests/bitmap/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required (VERSION 3.11)
 
 list(APPEND RAID1_TEST_SRCS
   bitmap/calc_regions.cpp
+  bitmap/clean_region.cpp
   bitmap/cross_page.cpp
   bitmap/init_bitmap.cpp
   bitmap/is_dirty.cpp

--- a/src/raid/raid1/tests/bitmap/clean_region.cpp
+++ b/src/raid/raid1/tests/bitmap/clean_region.cpp
@@ -1,0 +1,85 @@
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "raid/raid1/bitmap.hpp"
+#include "raid/raid1/tests/test_raid1_common.hpp"
+
+using ublkpp::Gi;
+using ublkpp::Ki;
+
+// When all bits on a page are cleared, clean_region must clear the superbitmap bit and
+// return the shared clean page (non-null), signalling to the caller that the page slot
+// is now empty.
+TEST(Raid1CleanRegion, FullCleanClearsSuperbitmap) {
+    auto sb = make_test_superbitmap();
+    auto bitmap = ublkpp::raid1::Bitmap(10 * Gi, 32 * Ki, 4 * Ki, sb.get());
+
+    bitmap.dirty_region(0, 32 * Ki);
+    EXPECT_EQ(1UL, bitmap.dirty_pages());
+
+    auto [page_ptr, page_off, sz] = bitmap.clean_region(0, 32 * Ki);
+
+    // Superbitmap bit must be cleared — dirty_pages() and next_dirty() use it to scan
+    EXPECT_EQ(0UL, bitmap.dirty_pages());
+    auto [next_off, next_len] = bitmap.next_dirty();
+    EXPECT_EQ(0U, next_len);
+
+    // Non-null page pointer signals the page became fully clean (caller swaps to clean_page)
+    EXPECT_NE(nullptr, page_ptr);
+}
+
+// When only part of a page is cleaned, the remaining dirty bits keep the superbitmap bit set.
+TEST(Raid1CleanRegion, PartialCleanPreservesSuperbitmap) {
+    auto sb = make_test_superbitmap();
+    auto bitmap = ublkpp::raid1::Bitmap(10 * Gi, 32 * Ki, 4 * Ki, sb.get());
+
+    // Dirty two consecutive chunks in the same bitmap page
+    bitmap.dirty_region(0, 64 * Ki);
+    EXPECT_EQ(1UL, bitmap.dirty_pages());
+
+    // Clean only the first chunk — the second remains dirty
+    auto [page_ptr, page_off, sz] = bitmap.clean_region(0, 32 * Ki);
+
+    // Superbitmap bit must stay set
+    EXPECT_EQ(1UL, bitmap.dirty_pages());
+    auto [next_off, next_len] = bitmap.next_dirty();
+    EXPECT_GT(next_len, 0U);
+
+    // Null pointer: page is not empty, caller keeps the dirty page in the slot
+    EXPECT_EQ(nullptr, page_ptr);
+}
+
+// dirty_region followed by clean_region followed by dirty_region again must leave the
+// superbitmap in the correct state at each step.  This exercises the invariant that
+// clear_bit in clean_region does not permanently suppress a subsequent set_bit from
+// dirty_region.
+TEST(Raid1CleanRegion, DirtyCleanDirtyCyclePreservesInvariant) {
+    auto sb = make_test_superbitmap();
+    auto bitmap = ublkpp::raid1::Bitmap(10 * Gi, 32 * Ki, 4 * Ki, sb.get());
+
+    // Cycle 1
+    bitmap.dirty_region(0, 32 * Ki);
+    EXPECT_EQ(1UL, bitmap.dirty_pages());
+
+    bitmap.clean_region(0, 32 * Ki);
+    EXPECT_EQ(0UL, bitmap.dirty_pages());
+
+    // Cycle 2 — superbitmap must be re-set correctly
+    bitmap.dirty_region(0, 32 * Ki);
+    EXPECT_EQ(1UL, bitmap.dirty_pages());
+
+    // And clean again
+    bitmap.clean_region(0, 32 * Ki);
+    EXPECT_EQ(0UL, bitmap.dirty_pages());
+}
+
+// Cleaning an already-clean page (no page allocated) is a safe no-op.
+TEST(Raid1CleanRegion, CleanAlreadyCleanPageIsNoOp) {
+    auto sb = make_test_superbitmap();
+    auto bitmap = ublkpp::raid1::Bitmap(10 * Gi, 32 * Ki, 4 * Ki, sb.get());
+
+    // Never dirtied — clean_region should not crash and superbitmap stays clear
+    auto [page_ptr, page_off, sz] = bitmap.clean_region(0, 32 * Ki);
+    EXPECT_EQ(0UL, bitmap.dirty_pages());
+    EXPECT_EQ(nullptr, page_ptr);
+}

--- a/src/target/ublkpp_tgt.cpp
+++ b/src/target/ublkpp_tgt.cpp
@@ -147,7 +147,8 @@ static exec::task< void > run_queue_loop(ublksrv_queue const* q, ublkpp_queue_st
     co_await qs->scope.on_empty();
 }
 
-static void* ublksrv_queue_handler(std::shared_ptr< ublkpp_tgt_impl > target, int q_id, sem_t* queue_sem) {
+static void* ublksrv_queue_handler(std::shared_ptr< ublkpp_tgt_impl > target, int q_id, sem_t* queue_sem,
+                                   std::atomic< int >* queue_failures) {
     auto qs = std::make_unique< ublkpp_queue_state >(target.get());
 
     // Initialize UBlkSrv IOUring queue and bind queue state pointer
@@ -156,7 +157,9 @@ static void* ublksrv_queue_handler(std::shared_ptr< ublkpp_tgt_impl > target, in
     auto q = ublksrv_queue_init_flags(target->ublk_dev, q_id, qs.get(),
                                       IORING_SETUP_COOP_TASKRUN | IORING_SETUP_SINGLE_ISSUER);
 
-    // Wake up ::start() thread
+    // Signal start() regardless of success/failure so it never deadlocks waiting.
+    // Report failures via queue_failures so start() can detect a partial init.
+    if (!q) queue_failures->fetch_add(1, std::memory_order_relaxed);
     sem_post(queue_sem);
     target.reset();
 
@@ -237,9 +240,10 @@ static std::expected< std::filesystem::path, std::error_condition > start(std::s
     // Setup Queues
     sem_t queue_sem;
     sem_init(&queue_sem, 0, 0);
+    std::atomic< int > queue_failures{0};
     for (auto i = 0; i < dinfo->nr_hw_queues; ++i) {
         tgt->queue_handlers.push_back(sisl::named_thread(fmt::format("q_{}_{}", tgt->dev_data->dev_id, i),
-                                                         ublksrv_queue_handler, tgt, i, &queue_sem));
+                                                         ublksrv_queue_handler, tgt, i, &queue_sem, &queue_failures));
     }
     auto const recovery = tgt->device_recovering;
     auto const dev_name = fmt::format("{}", *tgt->device);
@@ -254,6 +258,11 @@ static std::expected< std::filesystem::path, std::error_condition > start(std::s
     for (auto i = 0; i < dinfo->nr_hw_queues; ++i)
         sem_wait(&queue_sem);
     sem_destroy(&queue_sem);
+
+    if (auto const failed = queue_failures.load(std::memory_order_relaxed); failed > 0) {
+        TLOGE("dev {} failed: {} queue(s) did not initialize", dev_id, failed)
+        return std::unexpected(std::make_error_condition(std::errc::operation_not_permitted));
+    }
 
     // Start processing I/Os
     if (!recovery) {

--- a/src/tests/test_disk.hpp
+++ b/src/tests/test_disk.hpp
@@ -17,6 +17,7 @@ struct TestParams {
     uint32_t l_size{ublkpp::DEFAULT_BLOCK_SIZE};
     uint32_t p_size{ublkpp::DEFAULT_BLOCK_SIZE};
     uint32_t max_io{512 * Ki};
+    uint32_t max_discard_sectors{UINT32_MAX >> 9}; // UINT_MAX >> SECTOR_SHIFT default
     bool can_discard{true};
     bool direct_io{true};
     bool is_slot_b{false};
@@ -37,6 +38,7 @@ public:
             our_params.types &= ~UBLK_PARAM_TYPE_DISCARD;
         else
             our_params.types |= UBLK_PARAM_TYPE_DISCARD;
+        our_params.discard.max_discard_sectors = test_params.max_discard_sectors;
         _direct_io = test_params.direct_io;
     }
     std::string id() const noexcept override { return my_id; }


### PR DESCRIPTION
## Summary

Three confirmed bugs from issue #284, addressed after independent verification:

- **Bitmap-B2** (`src/raid/raid1/bitmap.cpp`): `clean_region` had a TOCTOU race between `isal_zero_detect` (non-atomic SIMD scan) and `clear_bit` (atomic). A concurrent `dirty_region` could set bits and mark the superbitmap between those two calls, then `clear_bit` would erase that mark — leaving the superbitmap inconsistent (bit cleared but page has dirty data). Fixed with a double-check pattern guarded by `std::atomic_thread_fence(seq_cst)`: after `clear_bit`, re-read the page; if it has new dirty bits, restore the superbitmap bit.

- **Target-B2** (`src/target/ublkpp_tgt.cpp`): `ublksrv_queue_handler` failures (null `q` from `ublksrv_queue_init`) were silently swallowed — `start()` would proceed as if all queues initialized successfully. Fixed by passing an `std::atomic<int>* queue_failures` counter to each queue thread; threads increment it before `sem_post` on failure; `start()` checks the counter after all semaphores are collected and returns an error if any queue failed.

- **RAID0-B5** (`src/raid/raid0/raid0.cpp`): `Raid0Disk` did not propagate `max_discard_sectors` from child devices. A top-level discard could be dispatched at a size the child device rejects. Fixed: constructor computes the minimum `max_discard_sectors` across children, then scales by stripe count (the aggregate size a RAID0 can handle is `min_child × num_stripes`). Added `max_discard_sectors()` public accessor to `ublk_disk` since the field was only reachable via the protected `params()`.

Bugs evaluated but confirmed as **false positives** (not fixed): RAID1-B1, RAID1-B6, RAID1-B9, Bitmap-B3, Bitmap-B4, RAID1-B14, SB-B9. All relied on CAS gates, type-safe invariants, or sequencing guarantees that make the "concurrent" path structurally impossible.

## Test plan

- [ ] `Raid1CleanRegion/FullCleanClearsSuperbitmap` — new: full clean clears superbitmap, returns non-null clean page
- [ ] `Raid1CleanRegion/PartialCleanPreservesSuperbitmap` — new: partial clean leaves superbitmap set, returns null
- [ ] `Raid1CleanRegion/DirtyCleanDirtyCyclePreservesInvariant` — new: multi-round dirty→clean cycle stays consistent
- [ ] `Raid1CleanRegion/CleanAlreadyCleanPageIsNoOp` — new: cleaning unallocated page is safe
- [ ] `Raid0/MaxDiscardSectorsPropagated` — new: min-child × stripe-count propagation verified
- [ ] CI TSan job covers the concurrent Bitmap-B2 race window (deterministic unit test not feasible for that path)
- [ ] CI GccAddressSanitize, GccCoverage, ClangRelease jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)