### PR TITLE
fix(raid0): floor legs to whole stripes so capacity isn't over-reported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.32.7] - 2026-06-01
+
+### Fixed
+
+- **H3 (raid0)**: the array capacity was computed as `(min_leg_capacity - stripe_size) * leg_count`, which assumes every leg holds a whole number of stripes. When a leg's capacity is not a multiple of `stripe_size`, the partial trailing stripe (`leg_capacity % stripe_size`) was carried into the per-leg term and then multiplied by the leg count, over-reporting the device size by `(leg_capacity % stripe_size) * leg_count`. Reads into that phantom tail (e.g. backup-GPT / partition-table scans at the top of the device) mapped to a per-leg offset past the end of the backing device and returned EIO. The bug was latent because leg capacities happened to be stripe-aligned; raid1 SuperBlock v2 dropped the 512 KiB user-data alignment that had masked it, surfacing top-of-device read failures on RAID10 arrays (observed on a 50-leg array of 3 TiB legs over-reporting by ~3 MiB). Fixed by flooring the smallest leg to a whole number of stripes before reserving the head stripe and striping.
+
 ## [0.32.6] - 2026-05-26
 
 ### Fixed

--- a/conanfile.py
+++ b/conanfile.py
@@ -10,7 +10,7 @@ required_conan_version = ">=2.0"
 
 class UBlkPPConan(ConanFile):
     name = "ublkpp"
-    version = "0.32.6"
+    version = "0.32.7"
 
     homepage = "https://github.com/szmyd/ublkpp"
     description = "A UBlk library for CPP application"

--- a/src/raid/raid0/raid0.cpp
+++ b/src/raid/raid0/raid0.cpp
@@ -129,6 +129,15 @@ Raid0Disk::Raid0Disk(boost::uuids::uuid const& uuid, uint32_t const stripe_size_
 
     // H2: guard against device capacity <= stripe_size which would underflow the unsigned subtraction.
     auto const stripe_size_sectors = static_cast< uint64_t >(_stripe_size >> SECTOR_SHIFT);
+    // H3: floor the smallest leg to a whole number of stripes before striping. RAID0 can only use
+    // stripes that are fully present on EVERY leg; a partial trailing stripe (when a leg's capacity
+    // is not a multiple of stripe_size) is unusable. Without flooring, that remainder stays in the
+    // per-leg term and is then multiplied by the leg count, so the array over-reports its size by
+    // (leg_capacity % stripe_size) * leg_count. I/O into that phantom tail maps to a per-leg offset
+    // past the end of the backing device, returning EIO. This was latent for years because leg
+    // capacities happened to be stripe-aligned; raid1 SuperBlock v2 dropped the 512 KiB user-data
+    // alignment that masked it, exposing top-of-device read failures on RAID10 arrays.
+    our_params.basic.dev_sectors -= (our_params.basic.dev_sectors % stripe_size_sectors);
     if (our_params.basic.dev_sectors <= stripe_size_sectors)
         throw std::runtime_error(
             fmt::format("Raid0Disk: device capacity ({} sectors) is too small for stripe_size ({} sectors)",

--- a/src/raid/raid0/tests/device_probe.cpp
+++ b/src/raid/raid0/tests/device_probe.cpp
@@ -41,10 +41,31 @@ TEST(Raid0, PartialStripeLegNotOverReported) {
 
     auto raid_device = ublkpp::make_raid0_disk(boost::uuids::random_generator()(), stripe, std::move(disks));
 
-    // Largest size that keeps every per-leg offset within the backing device: discard the partial
-    // trailing stripe on each leg, reserve one stripe at the head for our superblock, then stripe.
+    // safe_max = leg_count * usable_stripes_per_leg * stripe, where
+    //   usable_stripes_per_leg = floor(leg_cap / stripe) - 1   (the -1 reserves the head stripe
+    //   for our superblock). This is the largest size that keeps every per-leg offset within the
+    //   backing device. The final max_sectors alignment in the ctor is 512 KiB here (capped by
+    //   DEF_BUF_SIZE at raid0.cpp:97, regardless of leg max_io or count) and both the pre- and
+    //   post-fix totals are 512 KiB-aligned, so that step is a no-op and the value is exact.
     uint64_t const safe_max = n * ((leg_cap / stripe) - 1) * stripe;
     // Pre-fix this returned n * (leg_cap - stripe) = 8,589,410,304, which is (64 KiB * 8) too large
     // and would route reads past the end of each leg.
     EXPECT_EQ(raid_device->capacity(), safe_max);
+}
+
+// Brief: A leg smaller than two stripes is rejected, never over-reported.
+//
+// The H3 floor runs before the H2 guard, so a sub-2-stripe leg is floored to zero usable stripes
+// and H2 throws. This pins the ordering: the floor must not let construction underflow the unsigned
+// dev_sectors subtraction or expose a degenerate (phantom) capacity for a too-small device.
+TEST(Raid0, LegSmallerThanTwoStripesThrows) {
+    constexpr uint64_t leg_cap = 100 * Ki; // smaller than a single 128 KiB stripe
+    constexpr uint32_t stripe = 128 * Ki;
+
+    std::vector< std::shared_ptr< ublk_disk > > disks;
+    disks.push_back(CREATE_DISK(TestParams{.capacity = leg_cap}));
+    disks.push_back(CREATE_DISK(TestParams{.capacity = leg_cap}));
+
+    EXPECT_THROW(ublkpp::make_raid0_disk(boost::uuids::random_generator()(), stripe, std::move(disks)),
+                 std::runtime_error);
 }

--- a/src/raid/raid0/tests/device_probe.cpp
+++ b/src/raid/raid0/tests/device_probe.cpp
@@ -21,3 +21,30 @@ TEST(Raid0, IdenticalDeviceProbing) {
     EXPECT_EQ(raid_device->can_discard(), true);
     EXPECT_EQ(raid_device->direct_io(), true);
 }
+
+// Brief: A leg whose capacity is not a multiple of the stripe size must not inflate the array size.
+//
+// RAID0 can only stripe across whole stripes present on every leg. The trailing partial stripe on
+// each leg (leg_capacity % stripe_size) is unusable and must be discarded BEFORE multiplying by the
+// leg count. Pre-fix the reported capacity carried (remainder * leg_count) of phantom space, so a
+// top-of-device read mapped to a per-leg offset past the end of the backing device (observed on a
+// 50-leg RAID10 of 3 TiB legs after raid1 SuperBlock v2 dropped the alignment that had masked this).
+TEST(Raid0, PartialStripeLegNotOverReported) {
+    constexpr uint64_t leg_cap = Gi + 64 * Ki; // 4 KiB-aligned, but NOT a 128 KiB stripe multiple
+    constexpr uint32_t stripe = 128 * Ki;
+    constexpr size_t n = 8;
+
+    std::vector< std::shared_ptr< ublk_disk > > disks;
+    for (size_t i = 0; i < n; ++i) {
+        disks.push_back(CREATE_DISK(TestParams{.capacity = leg_cap}));
+    }
+
+    auto raid_device = ublkpp::make_raid0_disk(boost::uuids::random_generator()(), stripe, std::move(disks));
+
+    // Largest size that keeps every per-leg offset within the backing device: discard the partial
+    // trailing stripe on each leg, reserve one stripe at the head for our superblock, then stripe.
+    uint64_t const safe_max = n * ((leg_cap / stripe) - 1) * stripe;
+    // Pre-fix this returned n * (leg_cap - stripe) = 8,589,410,304, which is (64 KiB * 8) too large
+    // and would route reads past the end of each leg.
+    EXPECT_EQ(raid_device->capacity(), safe_max);
+}


### PR DESCRIPTION
Array capacity was (min_leg_capacity - stripe_size) * leg_count, which assumes every leg holds a whole number of stripes. When a leg capacity is not a stripe multiple, the partial trailing stripe was carried into the per-leg term and then multiplied by leg_count, over-reporting the device by (leg_capacity % stripe_size) * leg_count. Reads into that phantom tail (top-of-device GPT / partition-table scans) mapped to a per-leg offset past the end of the backing device and returned EIO.

Latent until raid1 SuperBlock v2 dropped the 512 KiB user-data alignment that had kept leg capacities stripe-aligned; surfaced on a 50-leg RAID10 of 3 TiB legs over-reporting by ~3 MiB. Fixed by flooring the smallest leg to a whole number of stripes before reserving the head stripe and striping.

Adds regression test Raid0.PartialStripeLegNotOverReported; bumps 0.32.7.