### PR TITLE
fix(metrics): key t_disk_io_timings on (instance, tag) to fix RAID fan-out aliasing

### DIFF
--- a/src/metrics/ublk_fsdisk_metrics.cpp
+++ b/src/metrics/ublk_fsdisk_metrics.cpp
@@ -21,13 +21,13 @@ UblkFSDiskMetrics::~UblkFSDiskMetrics() { deregister_me_from_farm(); }
 void UblkFSDiskMetrics::record_io_start(ublk_io_data const* data) {
     if (!data) return;
 
-    t_disk_io_timings[static_cast< uint16_t >(data->tag)] = io_timing{std::chrono::steady_clock::now()};
+    t_disk_io_timings[{this, static_cast< uint16_t >(data->tag)}] = io_timing{std::chrono::steady_clock::now()};
 }
 
 void UblkFSDiskMetrics::record_io_complete(ublk_io_data const* data) {
     if (!data) return;
 
-    if (auto it = t_disk_io_timings.find(static_cast< uint16_t >(data->tag)); it != t_disk_io_timings.end()) {
+    if (auto it = t_disk_io_timings.find({this, static_cast< uint16_t >(data->tag)}); it != t_disk_io_timings.end()) {
         auto const& timing = it->second;
         auto const end_time = std::chrono::steady_clock::now();
         auto const latency_us =

--- a/src/metrics/ublk_fsdisk_metrics.hpp
+++ b/src/metrics/ublk_fsdisk_metrics.hpp
@@ -27,7 +27,9 @@ struct UblkFSDiskMetrics : public sisl::MetricsGroup {
     UblkFSDiskMetrics(std::string const& parent_id, std::string const& disk_path);
     ~UblkFSDiskMetrics();
 
-    static inline thread_local std::map< uint16_t, io_timing > t_disk_io_timings;
+    // Keyed on (instance, tag) so fan-out I/O delivering the same tag to multiple FSDisk
+    // instances on the same queue thread does not alias entries.
+    static inline thread_local std::map< std::pair< const UblkFSDiskMetrics*, uint16_t >, io_timing > t_disk_io_timings;
 
     void record_io_start(ublk_io_data const* data);
     void record_io_complete(ublk_io_data const* data);


### PR DESCRIPTION
## Summary

Fixes #292.

`t_disk_io_timings` was keyed on `tag` alone.  In RAID1/RAID0 fan-out,
the same `data->tag` reaches multiple `FSDisk` instances on the same
queue thread, so each `record_io_start` silently clobbered the previous
instance's entry via `map::operator[]`.  Result: ~50% of latency samples
dropped, surviving samples using the wrong start time.

**Fix:** change the map key to `std::pair<const UblkFSDiskMetrics*, uint16_t>`.  
Each `FSDisk` instance now has its own slot in the shared thread-local
map, eliminating the aliasing while preserving the lock-free, per-queue-thread
design.

```diff
-static inline thread_local std::map< uint16_t, io_timing > t_disk_io_timings;
+static inline thread_local std::map< std::pair< const UblkFSDiskMetrics*, uint16_t >, io_timing > t_disk_io_timings;
```

The thread-local layout is kept (not replaced with per-instance maps)
because `FSDisk` instances are shared across queue threads — a single
`FSDisk` is reachable from every queue thread via `Raid1Disk::_device_a/b`.
A per-instance `std::map` member would require a mutex; the thread-local
map avoids it by giving each queue thread its own copy of the map.

## Test plan

- [ ] Existing unit tests pass (metrics are excluded from unit tests via `LCOV_EXCL_*` guards, but surrounding RAID1 logic is covered)
- [ ] Manual RAID1 write workload: verify no latency histogram drops and start times are monotonically sane

🤖 Generated with [Claude Code](https://claude.com/claude-code)