### PR TITLE
fix(raid1): self-heal read-determinism after both-present unclean shutdown (issue #290 phase 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.32.9] - 2026-06-04
+
+### Fixed
+
+- **RAID1 read-determinism after unclean shutdown (both legs present)**: when both legs were present at startup with equal ages, `clean_unmount=0`, and `read_route=EITHER`, the code previously only logged a warning. Writes in-flight at crash time may have landed on one leg but not the other, so round-robin reads of the same LBA could return different bytes on alternating accesses — a violation of the block-device read-determinism contract that filesystems (XFS, etc.) depend on unconditionally. The fix detects this case and self-heals: manufactures a +16 age gap on the canonical leg (device_a), pins reads to it via `read_route::DEVA`, dirties the whole bitmap, and marks device_b stale (`unavail`) so writes skip it until `probe_mirror` confirms physical health. `__become_active` skips persisting device_b's superblock (new `unavail` guard), preserving the on-disk age gap so any crash mid-resync reassembles through the existing `new_device` path rather than back into this branch. Idempotent across repeated crashes; no new superblock field. Addresses [issue #290](https://github.com/szmyd/ublkpp/issues/290) Phase 1.
+
 ## [0.32.8] - 2026-06-01
 
 ### Fixed

--- a/conanfile.py
+++ b/conanfile.py
@@ -10,7 +10,7 @@ required_conan_version = ">=2.0"
 
 class UBlkPPConan(ConanFile):
     name = "ublkpp"
-    version = "0.32.8"
+    version = "0.32.9"
 
     homepage = "https://github.com/szmyd/ublkpp"
     description = "A UBlk library for CPP application"

--- a/src/raid/raid1/raid1.cpp
+++ b/src/raid/raid1/raid1.cpp
@@ -31,6 +31,7 @@ namespace raid1 {
 
 // Min page-resolution (how much does the smallest page cover?)
 constexpr auto k_min_page_depth = k_min_chunk_size * k_page_size * k_bits_in_byte; // 1GiB from above
+constexpr uint64_t k_age_bump = 16; // must be > 1 (pick_superblock threshold for new_device detection)
 
 // Max user-data size
 constexpr uint64_t k_max_user_data =
@@ -245,7 +246,7 @@ void Raid1Disk::__init_bitmap_and_degraded_route() {
         }
     } else if (_device_a->new_device xor _device_b->new_device) {
         // Bump the bitmap age
-        _sb->fields.bitmap.age = htobe64(be64toh(_sb->fields.bitmap.age) + 16);
+        _sb->fields.bitmap.age = htobe64(be64toh(_sb->fields.bitmap.age) + k_age_bump);
         RLOGW("Device is replacement {}, dirty all of BITMAP",
               *(_device_a->new_device ? _device_a->disk : _device_b->disk))
         _dirty_bitmap->dirty_region(0, capacity());
@@ -254,7 +255,7 @@ void Raid1Disk::__init_bitmap_and_degraded_route() {
     } else if ((read_route::EITHER != _read_route_cache.load(std::memory_order_acquire)) &&
                (0 == _sb->fields.clean_unmount)) {
         // Bump the bitmap age
-        _sb->fields.bitmap.age = htobe64(be64toh(_sb->fields.bitmap.age) + 16);
+        _sb->fields.bitmap.age = htobe64(be64toh(_sb->fields.bitmap.age) + k_age_bump);
         RLOGW("Unclean shutdown in degraded mode! Dirty all of BITMAP")
         _dirty_bitmap->dirty_region(0, capacity());
     } else if (auto const route = _read_route_cache.load(std::memory_order_acquire); read_route::EITHER != route) {
@@ -269,31 +270,20 @@ void Raid1Disk::__init_bitmap_and_degraded_route() {
             throw std::runtime_error("Invariant violated: previously degraded array has empty superbitmap");
         _dirty_bitmap->load_from(*active_dev->disk);
     } else if (0 == _sb->fields.clean_unmount) {
-        // Both legs present, equal ages, EITHER route, unclean shutdown. In-flight writes at
-        // crash time may have landed on one leg but not the other; round-robin reads would
-        // return different bytes for the same LBA, violating the block-device read-determinism
-        // contract (filesystem and application code assume a given LBA always reads the same).
-        //
-        // Self-heal by manufacturing a +16 age gap: pin reads to device_a (canonical — the
-        // choice is arbitrary since both are legal post-crash states), dirty the whole bitmap,
-        // and mark device_b stale so writes skip it until probe_mirror confirms physical health.
-        //
-        // __become_active skips persisting device_b's SB (via the unavail guard there),
-        // preserving the on-disk age gap: canonical gets age=N+16, stale keeps age=N (gap 16>1).
-        // On any crash-mid-resync reassembly, pick_superblock selects the canonical, the age
-        // difference routes through the existing one-new-device xor branch, which re-dirties the
-        // whole bitmap and resumes the full resync. Idempotent across crashes.
-        //
-        // Note: the dirty_region(0, capacity()) call below makes probe_mirror clearing unavail
-        // safe -- until the resync makes progress, every read to device_b is redirected back to
-        // device_a by the dirty-bitmap check in __select_read_devices (100% coverage guarantee).
-        _sb->fields.bitmap.age = htobe64(be64toh(_sb->fields.bitmap.age) + 16);
-        RLOGW("Unclean shutdown with both legs present [uuid:{}] -- reads pinned to {} (canonical), "
-              "full resync to {} scheduled to restore read-determinism",
-              _str_uuid, *_device_a->disk, *_device_b->disk)
+        // Both-present unclean: reads may diverge across legs. Pin to device_a (canonical),
+        // dirty all, mark device_b stale. __become_active skips device_b's SB (unavail guard)
+        // to preserve the >1 age gap for idempotent crash-mid-resync reassembly.
+        DEBUG_ASSERT(_read_route_cache.load(std::memory_order_relaxed) == read_route::EITHER,
+                     "self-heal branch reached with non-EITHER route")
+        DEBUG_ASSERT(!_device_a->new_device && !_device_b->new_device,
+                     "self-heal branch reached with new_device set")
+        _sb->fields.bitmap.age = htobe64(be64toh(_sb->fields.bitmap.age) + k_age_bump);
         _dirty_bitmap->dirty_region(0, capacity());
         _read_route_cache.store(read_route::DEVA, std::memory_order_release);
         _device_b->unavail.test_and_set(std::memory_order_release);
+        RLOGW("Unclean shutdown with both legs present [uuid:{}] -- reads pinned to {} (canonical), "
+              "full resync to {} scheduled to restore read-determinism",
+              _str_uuid, *_device_a->disk, *_device_b->disk)
     }
 }
 
@@ -311,13 +301,11 @@ void Raid1Disk::__become_active() {
         return;
     }
     if (state.backup_dev->disk->is_missing()) return;
-    // Stale-leg guard: when the backup was marked unavailable at startup (both-present unclean
-    // self-heal path in __init_bitmap_and_degraded_route), skip writing its superblock here.
-    // Canonical's SB carries the bumped age (N+16); leaving stale's on-disk SB at age N
-    // preserves the >1 age gap, so any crash-mid-resync reassembly routes through the existing
-    // new_device path (pick_superblock selects canonical, age_diff>1 sets new_device=true)
-    // rather than looping back into the both-present-unclean branch.
-    if (state.backup_dev->unavail.test(std::memory_order_acquire)) return;
+    // Preserve on-disk age gap for crash-mid-resync idempotency (see __init_bitmap_and_degraded_route).
+    if (state.backup_dev->unavail.test(std::memory_order_acquire)) {
+        TLOGD("Skipping backup SB write: device_b marked stale at startup [uuid:{}]", _str_uuid)
+        return;
+    }
     if (!write_superblock(*state.backup_dev->disk, _sb.get(), read_route::DEVB != state.route, state.route)) {
         if (!__become_degraded(false, &state, false)) {
             throw std::runtime_error(fmt::format("Could not initialize superblocks!"));

--- a/src/raid/raid1/raid1.cpp
+++ b/src/raid/raid1/raid1.cpp
@@ -31,7 +31,7 @@ namespace raid1 {
 
 // Min page-resolution (how much does the smallest page cover?)
 constexpr auto k_min_page_depth = k_min_chunk_size * k_page_size * k_bits_in_byte; // 1GiB from above
-constexpr uint64_t k_age_bump = 16; // must be > 1 (pick_superblock threshold for new_device detection)
+constexpr uint64_t k_age_bump = 16; // must be > 1 (new_device detection threshold in __load_and_select_superblock)
 
 // Max user-data size
 constexpr uint64_t k_max_user_data =
@@ -394,7 +394,7 @@ bool Raid1Disk::__swap_device(std::string const& outgoing_device_id, std::shared
     if (!_read_route_cache.compare_exchange_strong(orig_route, new_read_route)) return false;
 
     auto old_age = be64toh(_sb->fields.bitmap.age);
-    auto new_age = old_age + 16;
+    auto new_age = old_age + k_age_bump;
 
     auto& outgoing_dev = swapping_device_a ? _device_a : _device_b;
     outgoing_dev.swap(incoming_mirror);

--- a/src/raid/raid1/raid1.cpp
+++ b/src/raid/raid1/raid1.cpp
@@ -277,8 +277,10 @@ void Raid1Disk::__init_bitmap_and_degraded_route() {
         // to preserve the >1 age gap for idempotent crash-mid-resync reassembly.
         DEBUG_ASSERT(_read_route_cache.load(std::memory_order_relaxed) == read_route::EITHER,
                      "self-heal branch reached with non-EITHER route")
-        DEBUG_ASSERT(!_device_a->new_device && !_device_b->new_device,
-                     "self-heal branch reached with new_device set")
+        // The XOR branch above catches exactly one-new-device; if both new_device flags are set
+        // (both SBs corrupt or absent) the XOR is false and we fall through here. That scenario
+        // is not both-present-unclean: skip self-heal and let the caller handle the fresh array.
+        if (_device_a->new_device || _device_b->new_device) return;
         _sb->fields.bitmap.age = htobe64(be64toh(_sb->fields.bitmap.age) + k_age_bump);
         _dirty_bitmap->dirty_region(0, capacity());
         _read_route_cache.store(read_route::DEVA, std::memory_order_release);

--- a/src/raid/raid1/raid1.cpp
+++ b/src/raid/raid1/raid1.cpp
@@ -285,10 +285,10 @@ void Raid1Disk::__init_bitmap_and_degraded_route() {
         // whole bitmap and resumes the full resync. Idempotent across crashes.
         //
         // Note: the dirty_region(0, capacity()) call below makes probe_mirror clearing unavail
-        // safe — until the resync makes progress, every read to device_b is redirected back to
+        // safe -- until the resync makes progress, every read to device_b is redirected back to
         // device_a by the dirty-bitmap check in __select_read_devices (100% coverage guarantee).
         _sb->fields.bitmap.age = htobe64(be64toh(_sb->fields.bitmap.age) + 16);
-        RLOGI("Unclean shutdown with both legs present [uuid:{}] — reads pinned to {} (canonical), "
+        RLOGW("Unclean shutdown with both legs present [uuid:{}] -- reads pinned to {} (canonical), "
               "full resync to {} scheduled to restore read-determinism",
               _str_uuid, *_device_a->disk, *_device_b->disk)
         _dirty_bitmap->dirty_region(0, capacity());

--- a/src/raid/raid1/raid1.cpp
+++ b/src/raid/raid1/raid1.cpp
@@ -281,15 +281,19 @@ void Raid1Disk::__init_bitmap_and_degraded_route() {
         // __become_active skips persisting device_b's SB (via the unavail guard there),
         // preserving the on-disk age gap: canonical gets age=N+16, stale keeps age=N (gap 16>1).
         // On any crash-mid-resync reassembly, pick_superblock selects the canonical, the age
-        // difference routes through the existing new_device path (raid1.cpp:225-232), which
-        // re-dirties the whole bitmap and resumes the full resync. Idempotent across crashes.
+        // difference routes through the existing one-new-device xor branch, which re-dirties the
+        // whole bitmap and resumes the full resync. Idempotent across crashes.
+        //
+        // Note: the dirty_region(0, capacity()) call below makes probe_mirror clearing unavail
+        // safe — until the resync makes progress, every read to device_b is redirected back to
+        // device_a by the dirty-bitmap check in __select_read_devices (100% coverage guarantee).
         _sb->fields.bitmap.age = htobe64(be64toh(_sb->fields.bitmap.age) + 16);
         RLOGI("Unclean shutdown with both legs present [uuid:{}] — reads pinned to {} (canonical), "
               "full resync to {} scheduled to restore read-determinism",
               _str_uuid, *_device_a->disk, *_device_b->disk)
         _dirty_bitmap->dirty_region(0, capacity());
         _read_route_cache.store(read_route::DEVA, std::memory_order_release);
-        _device_b->unavail.test_and_set(std::memory_order_acq_rel);
+        _device_b->unavail.test_and_set(std::memory_order_release);
     }
 }
 

--- a/src/raid/raid1/raid1.cpp
+++ b/src/raid/raid1/raid1.cpp
@@ -31,7 +31,9 @@ namespace raid1 {
 
 // Min page-resolution (how much does the smallest page cover?)
 constexpr auto k_min_page_depth = k_min_chunk_size * k_page_size * k_bits_in_byte; // 1GiB from above
-constexpr uint64_t k_age_bump = 16; // must be > 1 (new_device detection threshold in __load_and_select_superblock)
+// > 1: new_device detection threshold in __load_and_select_superblock. 16: matches the bumps used
+// in __swap_device and the existing new_device / unclean-degraded paths so all sites are comparable.
+constexpr uint64_t k_age_bump = 16;
 
 // Max user-data size
 constexpr uint64_t k_max_user_data =
@@ -303,7 +305,12 @@ void Raid1Disk::__become_active() {
     if (state.backup_dev->disk->is_missing()) return;
     // Preserve on-disk age gap for crash-mid-resync idempotency (see __init_bitmap_and_degraded_route).
     if (state.backup_dev->unavail.test(std::memory_order_acquire)) {
-        TLOGD("Skipping backup SB write: device_b marked stale at startup [uuid:{}]", _str_uuid)
+        // Both the SB write and its __become_degraded fallback are intentionally skipped: the array
+        // is already in the correct degraded state from __init_bitmap_and_degraded_route, and the
+        // stale SB must not be updated so the on-disk age gap is preserved. probe_mirror cannot
+        // clear unavail before this point because the resync task only starts after construction
+        // completes and the first queue thread registers.
+        RLOGI("Skipping backup SB write: device_b marked stale at startup [uuid:{}]", _str_uuid)
         return;
     }
     if (!write_superblock(*state.backup_dev->disk, _sb.get(), read_route::DEVB != state.route, state.route)) {

--- a/src/raid/raid1/raid1.cpp
+++ b/src/raid/raid1/raid1.cpp
@@ -310,7 +310,7 @@ void Raid1Disk::__become_active() {
         // stale SB must not be updated so the on-disk age gap is preserved. probe_mirror cannot
         // clear unavail before this point because the resync task only starts after construction
         // completes and the first queue thread registers.
-        RLOGI("Skipping backup SB write: device_b marked stale at startup [uuid:{}]", _str_uuid)
+        RLOGW("Skipping backup SB write: device_b marked stale at startup [uuid:{}]", _str_uuid)
         return;
     }
     if (!write_superblock(*state.backup_dev->disk, _sb.get(), read_route::DEVB != state.route, state.route)) {

--- a/src/raid/raid1/raid1.cpp
+++ b/src/raid/raid1/raid1.cpp
@@ -269,7 +269,27 @@ void Raid1Disk::__init_bitmap_and_degraded_route() {
             throw std::runtime_error("Invariant violated: previously degraded array has empty superbitmap");
         _dirty_bitmap->load_from(*active_dev->disk);
     } else if (0 == _sb->fields.clean_unmount) {
-        RLOGW("Raid1 was not cleanly shutdown last time [uuid:{}]!", _str_uuid)
+        // Both legs present, equal ages, EITHER route, unclean shutdown. In-flight writes at
+        // crash time may have landed on one leg but not the other; round-robin reads would
+        // return different bytes for the same LBA, violating the block-device read-determinism
+        // contract (filesystem and application code assume a given LBA always reads the same).
+        //
+        // Self-heal by manufacturing a +16 age gap: pin reads to device_a (canonical — the
+        // choice is arbitrary since both are legal post-crash states), dirty the whole bitmap,
+        // and mark device_b stale so writes skip it until probe_mirror confirms physical health.
+        //
+        // __become_active skips persisting device_b's SB (via the unavail guard there),
+        // preserving the on-disk age gap: canonical gets age=N+16, stale keeps age=N (gap 16>1).
+        // On any crash-mid-resync reassembly, pick_superblock selects the canonical, the age
+        // difference routes through the existing new_device path (raid1.cpp:225-232), which
+        // re-dirties the whole bitmap and resumes the full resync. Idempotent across crashes.
+        _sb->fields.bitmap.age = htobe64(be64toh(_sb->fields.bitmap.age) + 16);
+        RLOGI("Unclean shutdown with both legs present [uuid:{}] — reads pinned to {} (canonical), "
+              "full resync to {} scheduled to restore read-determinism",
+              _str_uuid, *_device_a->disk, *_device_b->disk)
+        _dirty_bitmap->dirty_region(0, capacity());
+        _read_route_cache.store(read_route::DEVA, std::memory_order_release);
+        _device_b->unavail.test_and_set(std::memory_order_acq_rel);
     }
 }
 
@@ -287,6 +307,13 @@ void Raid1Disk::__become_active() {
         return;
     }
     if (state.backup_dev->disk->is_missing()) return;
+    // Stale-leg guard: when the backup was marked unavailable at startup (both-present unclean
+    // self-heal path in __init_bitmap_and_degraded_route), skip writing its superblock here.
+    // Canonical's SB carries the bumped age (N+16); leaving stale's on-disk SB at age N
+    // preserves the >1 age gap, so any crash-mid-resync reassembly routes through the existing
+    // new_device path (pick_superblock selects canonical, age_diff>1 sets new_device=true)
+    // rather than looping back into the both-present-unclean branch.
+    if (state.backup_dev->unavail.test(std::memory_order_acquire)) return;
     if (!write_superblock(*state.backup_dev->disk, _sb.get(), read_route::DEVB != state.route, state.route)) {
         if (!__become_degraded(false, &state, false)) {
             throw std::runtime_error(fmt::format("Could not initialize superblocks!"));

--- a/src/raid/raid1/raid1_impl.hpp
+++ b/src/raid/raid1/raid1_impl.hpp
@@ -20,6 +20,17 @@ struct MirrorDevice {
     MirrorDevice(boost::uuids::uuid const& uuid, std::shared_ptr< ublk_disk > device);
     std::shared_ptr< ublk_disk > const disk;
     std::shared_ptr< SuperBlock > sb; // Only used during load_superblock time
+    // Three distinct uses, all guarded by the same flag:
+    //   1. I/O routing — reads/writes skip this leg when unavail is set
+    //      (__select_read_devices, __backup_writable).
+    //   2. Physical health probe — probe_mirror clears unavail when the device
+    //      responds to a read, re-enabling writes and eventually reads.
+    //   3. SB persistence skip — __become_active skips writing this leg's
+    //      superblock when unavail is set at startup (both-present unclean
+    //      self-heal path), preserving the on-disk age gap for idempotent
+    //      crash-mid-resync recovery. This use is safe because unavail is set
+    //      in __init_bitmap_and_degraded_route before any queue thread starts,
+    //      so no I/O path can clear it before __become_active runs.
     std::atomic_flag unavail;
 
     bool new_device{true};

--- a/src/raid/raid1/raid1_impl.hpp
+++ b/src/raid/raid1/raid1_impl.hpp
@@ -20,17 +20,8 @@ struct MirrorDevice {
     MirrorDevice(boost::uuids::uuid const& uuid, std::shared_ptr< ublk_disk > device);
     std::shared_ptr< ublk_disk > const disk;
     std::shared_ptr< SuperBlock > sb; // Only used during load_superblock time
-    // Three distinct uses, all guarded by the same flag:
-    //   1. I/O routing — reads/writes skip this leg when unavail is set
-    //      (__select_read_devices, __backup_writable).
-    //   2. Physical health probe — probe_mirror clears unavail when the device
-    //      responds to a read, re-enabling writes and eventually reads.
-    //   3. SB persistence skip — __become_active skips writing this leg's
-    //      superblock when unavail is set at startup (both-present unclean
-    //      self-heal path), preserving the on-disk age gap for idempotent
-    //      crash-mid-resync recovery. This use is safe because unavail is set
-    //      in __init_bitmap_and_degraded_route before any queue thread starts,
-    //      so no I/O path can clear it before __become_active runs.
+    // Also used during startup self-heal to skip backup SB persistence
+    // (preserves on-disk age gap; safe because no IO threads have started yet).
     std::atomic_flag unavail;
 
     bool new_device{true};

--- a/src/raid/raid1/raid1_impl.hpp
+++ b/src/raid/raid1/raid1_impl.hpp
@@ -20,7 +20,7 @@ struct MirrorDevice {
     MirrorDevice(boost::uuids::uuid const& uuid, std::shared_ptr< ublk_disk > device);
     std::shared_ptr< ublk_disk > const disk;
     std::shared_ptr< SuperBlock > sb; // Only used during load_superblock time
-    std::atomic_flag unavail; // set during startup self-heal to skip device_b's SB write (preserves age gap)
+    std::atomic_flag unavail; // marks device not ready for normal IO; also used at startup to preserve age gap
 
     bool new_device{true};
 };

--- a/src/raid/raid1/raid1_impl.hpp
+++ b/src/raid/raid1/raid1_impl.hpp
@@ -20,9 +20,7 @@ struct MirrorDevice {
     MirrorDevice(boost::uuids::uuid const& uuid, std::shared_ptr< ublk_disk > device);
     std::shared_ptr< ublk_disk > const disk;
     std::shared_ptr< SuperBlock > sb; // Only used during load_superblock time
-    // Also used during startup self-heal to skip backup SB persistence
-    // (preserves on-disk age gap; safe because no IO threads have started yet).
-    std::atomic_flag unavail;
+    std::atomic_flag unavail; // set during startup self-heal to skip device_b's SB write (preserves age gap)
 
     bool new_device{true};
 };

--- a/src/raid/raid1/raid1_impl.hpp
+++ b/src/raid/raid1/raid1_impl.hpp
@@ -20,7 +20,8 @@ struct MirrorDevice {
     MirrorDevice(boost::uuids::uuid const& uuid, std::shared_ptr< ublk_disk > device);
     std::shared_ptr< ublk_disk > const disk;
     std::shared_ptr< SuperBlock > sb; // Only used during load_superblock time
-    std::atomic_flag unavail; // not ready for IO; also set at startup self-heal to prevent SB writes that would destroy the age gap
+    std::atomic_flag
+        unavail; // not ready for IO; also set at startup self-heal to prevent SB writes that would destroy the age gap
 
     bool new_device{true};
 };

--- a/src/raid/raid1/raid1_impl.hpp
+++ b/src/raid/raid1/raid1_impl.hpp
@@ -20,7 +20,7 @@ struct MirrorDevice {
     MirrorDevice(boost::uuids::uuid const& uuid, std::shared_ptr< ublk_disk > device);
     std::shared_ptr< ublk_disk > const disk;
     std::shared_ptr< SuperBlock > sb; // Only used during load_superblock time
-    std::atomic_flag unavail; // marks device not ready for normal IO; also used at startup to preserve age gap
+    std::atomic_flag unavail; // not ready for IO; also set at startup self-heal to prevent SB writes that would destroy the age gap
 
     bool new_device{true};
 };

--- a/src/raid/raid1/tests/misc/edge_cases.cpp
+++ b/src/raid/raid1/tests/misc/edge_cases.cpp
@@ -236,6 +236,23 @@ TEST(Raid1, UncleanShutdownBothPresentSelfHeal) {
     EXPECT_EQ(ublkpp::raid1::replica_state::CLEAN, state.device_a);
     EXPECT_EQ(ublkpp::raid1::replica_state::ERROR, state.device_b);
     EXPECT_GT(state.bytes_to_sync, 0ULL);
+
+    // Verify read routing: a sync read must dispatch to device_a only.
+    // route=DEVA + device_b->unavail means __select_read_devices never returns device_b.
+    // Run in a fresh thread to avoid contaminating the thread_local last_read state shared
+    // across tests (same pattern used by other tests that exercise __select_read_devices).
+    EXPECT_CALL(*device_b, sync_iov(UBLK_IO_OP_READ, _, _, _)).Times(0);
+    EXPECT_CALL(*device_a, sync_iov(UBLK_IO_OP_READ, _, _, _))
+        .Times(1)
+        .WillOnce([](uint8_t, iovec* iov, uint32_t, off_t) -> io_result {
+            memset(iov->iov_base, 0, iov->iov_len);
+            return static_cast< int >(iov->iov_len);
+        });
+    RUN_IN_THREAD({
+        alignas(4096) std::array< char, ublkpp::raid1::k_page_size > buf{};
+        auto iov = iovec{.iov_base = buf.data(), .iov_len = buf.size()};
+        EXPECT_TRUE(raid_device.sync_iov(UBLK_IO_OP_READ, &iov, 1, 0).has_value());
+    });
 }
 
 // Test 5b: Crash-mid-resync idempotency — reassembly after a self-heal crash uses the

--- a/src/raid/raid1/tests/misc/edge_cases.cpp
+++ b/src/raid/raid1/tests/misc/edge_cases.cpp
@@ -216,12 +216,14 @@ TEST(Raid1, UncleanShutdownBothPresentSelfHeal) {
             return ublkpp::raid1::k_page_size;
         })
         .WillOnce([](uint8_t, iovec* iovecs, uint32_t nr_vecs, off_t addr) -> io_result {
-            // destructor SB: clean_unmount=1
+            // destructor SB: clean_unmount=1, route still DEVA (array remains degraded at shutdown)
             EXPECT_EQ(1U, nr_vecs);
             EXPECT_EQ(ublkpp::raid1::k_page_size, ublkpp::iovec_len(iovecs, iovecs + nr_vecs));
             EXPECT_EQ(0UL, addr);
             auto* sb = reinterpret_cast< ublkpp::raid1::SuperBlock* >(iovecs->iov_base);
             EXPECT_EQ(1, sb->fields.clean_unmount);
+            EXPECT_EQ(ublkpp::raid1::read_route::DEVA,
+                      static_cast< ublkpp::raid1::read_route >(sb->fields.read_route));
             return ublkpp::raid1::k_page_size;
         });
     // device_b: no writes — __become_active skips (unavail guard), destructor skips (degraded backup)

--- a/src/raid/raid1/tests/misc/edge_cases.cpp
+++ b/src/raid/raid1/tests/misc/edge_cases.cpp
@@ -323,8 +323,8 @@ TEST(Raid1, UncleanBothPresentSelfHealIdempotentAfterCrash) {
     EXPECT_CALL(*device_b, sync_iov(UBLK_IO_OP_WRITE, _, _, _))
         .Times(2)
         .WillOnce([](uint8_t, iovec*, uint32_t, off_t addr) -> io_result {
-            // init_to: clean bitmap pages written to the new/stale device
-            EXPECT_GE(addr, static_cast< off_t >(ublkpp::raid1::k_page_size));
+            // init_to: first (and only, for 1 GiB) bitmap page at sizeof(SuperBlock) == k_page_size
+            EXPECT_EQ(addr, static_cast< off_t >(ublkpp::raid1::k_page_size));
             return ublkpp::raid1::k_page_size;
         })
         .WillOnce([](uint8_t, iovec* iovecs, uint32_t, off_t addr) -> io_result {

--- a/src/raid/raid1/tests/misc/edge_cases.cpp
+++ b/src/raid/raid1/tests/misc/edge_cases.cpp
@@ -154,9 +154,19 @@ TEST(Raid1, UncleanShutdownWhileDegraded) {
     auto raid_device = ublkpp::raid1::Raid1Disk(boost::uuids::string_generator()(test_uuid), device_a, device_b);
 }
 
-// Test 5: Unclean shutdown while healthy — route=EITHER, clean_unmount=0.
-// Exercises the final (clean_unmount == 0) branch: just a log warning, no bitmap changes.
-TEST(Raid1, UncleanShutdownWhileHealthy) {
+// Test 5: Unclean shutdown with both legs present and equal ages — the self-heal path.
+// Both legs have route=EITHER, clean_unmount=0, same age.  The self-heal branch must:
+//   • bump the canonical (device_a) age by +16 and pin reads to it via route=DEVA
+//   • dirty the whole bitmap so a full resync runs
+//   • mark device_b stale (unavail) so writes skip it until probe_mirror clears the flag
+//   • skip writing device_b's SB in __become_active (preserving the on-disk age gap)
+//
+// Writes observed:
+//   device_a — 3:  __become_active SB (age+16, route=DEVA)
+//                   sync_to bitmap page (shutdown, degraded path)
+//                   destructor SB (clean_unmount=1)
+//   device_b — 0:  __become_active skips (unavail guard); destructor skips (degraded backup)
+TEST(Raid1, UncleanShutdownBothPresentSelfHeal) {
     auto device_a = std::make_shared< ublkpp::TestDisk >(TestParams{.capacity = Gi});
     auto device_b = std::make_shared< ublkpp::TestDisk >(TestParams{.capacity = Gi, .is_slot_b = true});
 
@@ -183,28 +193,138 @@ TEST(Raid1, UncleanShutdownWhileHealthy) {
             return ublkpp::raid1::k_page_size;
         });
 
-    // __become_active writes SB to both (clean_unmount=0); destructor writes SB to both (clean_unmount=1).
-    // No bitmap sync — route=EITHER means not degraded, so sync_to is not called at shutdown.
+    // device_a: __become_active SB + bitmap sync_to + destructor SB  (3 writes)
     EXPECT_CALL(*device_a, sync_iov(UBLK_IO_OP_WRITE, _, _, _))
-        .Times(1)
+        .Times(3)
         .WillOnce([](uint8_t, iovec* iovecs, uint32_t nr_vecs, off_t addr) -> io_result {
+            // __become_active: age bumped +16, route=DEVA, clean_unmount=0
             EXPECT_EQ(1U, nr_vecs);
             EXPECT_EQ(ublkpp::raid1::k_page_size, ublkpp::iovec_len(iovecs, iovecs + nr_vecs));
             EXPECT_EQ(0UL, addr);
+            auto* sb = reinterpret_cast< ublkpp::raid1::SuperBlock* >(iovecs->iov_base);
+            EXPECT_EQ(ublkpp::raid1::read_route::DEVA,
+                      static_cast< ublkpp::raid1::read_route >(sb->fields.read_route));
+            EXPECT_EQ(htobe64(16), sb->fields.bitmap.age); // age 0 (normal_superblock) + 16
+            EXPECT_EQ(0, sb->fields.clean_unmount);
+            return ublkpp::raid1::k_page_size;
+        })
+        .WillOnce([](uint8_t, iovec* iovecs, uint32_t nr_vecs, off_t addr) -> io_result {
+            // sync_to: bitmap page (shutdown degraded path), not at SB offset
+            EXPECT_EQ(1U, nr_vecs);
+            EXPECT_EQ(ublkpp::raid1::k_page_size, ublkpp::iovec_len(iovecs, iovecs + nr_vecs));
+            EXPECT_GE(addr, static_cast< off_t >(ublkpp::raid1::k_page_size));
+            return ublkpp::raid1::k_page_size;
+        })
+        .WillOnce([](uint8_t, iovec* iovecs, uint32_t nr_vecs, off_t addr) -> io_result {
+            // destructor SB: clean_unmount=1
+            EXPECT_EQ(1U, nr_vecs);
+            EXPECT_EQ(ublkpp::raid1::k_page_size, ublkpp::iovec_len(iovecs, iovecs + nr_vecs));
+            EXPECT_EQ(0UL, addr);
+            auto* sb = reinterpret_cast< ublkpp::raid1::SuperBlock* >(iovecs->iov_base);
+            EXPECT_EQ(1, sb->fields.clean_unmount);
             return ublkpp::raid1::k_page_size;
         });
-    EXPECT_CALL(*device_b, sync_iov(UBLK_IO_OP_WRITE, _, _, _))
+    // device_b: no writes — __become_active skips (unavail guard), destructor skips (degraded backup)
+    EXPECT_CALL(*device_b, sync_iov(UBLK_IO_OP_WRITE, _, _, _)).Times(0);
+
+    auto raid_device = ublkpp::raid1::Raid1Disk(boost::uuids::string_generator()(test_uuid), device_a, device_b);
+
+    // Reads must be pinned to canonical (device_a): route=DEVA, device_b marked stale (ERROR).
+    auto const state = raid_device.replica_states();
+    EXPECT_EQ(ublkpp::raid1::replica_state::CLEAN, state.device_a);
+    EXPECT_EQ(ublkpp::raid1::replica_state::ERROR, state.device_b);
+    EXPECT_GT(state.bytes_to_sync, 0ULL);
+}
+
+// Test 5b: Crash-mid-resync idempotency — reassembly after a self-heal crash uses the
+// existing new_device path, not the both-present-unclean branch.
+//
+// Simulates on-disk state after __become_active on the first self-heal assembly:
+//   device_a: age=16, route=DEVA, clean_unmount=0   (canonical, bumped by self-heal)
+//   device_b: age=0,  route=EITHER, clean_unmount=0  (stale, SB write was skipped)
+//
+// pick_superblock picks device_a (higher age).  age_diff = 16 > 1 → _device_b->new_device=true.
+// __init_bitmap_and_degraded_route enters the existing one-new-device branch (not the
+// both-present-unclean branch), bumps age another +16, and sets route=DEVA.
+//
+// Writes:
+//   device_a — 3: __become_active SB (age=32, route=DEVA) + bitmap sync_to + destructor SB
+//   device_b — 2: init_to bitmap pages (new_device path) + __become_active SB (age=32, route=DEVA)
+//                 new_device path does NOT set unavail, so __become_active writes backup SB normally
+TEST(Raid1, UncleanBothPresentSelfHealIdempotentAfterCrash) {
+    auto device_a = std::make_shared< ublkpp::TestDisk >(TestParams{.capacity = Gi});
+    auto device_b = std::make_shared< ublkpp::TestDisk >(TestParams{.capacity = Gi, .is_slot_b = true});
+
+    // device_a: canonical SB from first self-heal assembly (age=16, route=DEVA)
+    EXPECT_CALL(*device_a, sync_iov(UBLK_IO_OP_READ, _, _, _))
         .Times(1)
-        .WillOnce([](uint8_t, iovec* iovecs, uint32_t nr_vecs, off_t addr) -> io_result {
-            EXPECT_EQ(1U, nr_vecs);
-            EXPECT_EQ(ublkpp::raid1::k_page_size, ublkpp::iovec_len(iovecs, iovecs + nr_vecs));
+        .WillOnce([](uint8_t, iovec* iovecs, uint32_t, off_t) -> io_result {
+            memcpy(iovecs->iov_base, &normal_superblock, ublkpp::raid1::k_page_size);
+            auto* sb = reinterpret_cast< ublkpp::raid1::SuperBlock* >(iovecs->iov_base);
+            sb->fields.device_b = 0;
+            sb->fields.read_route = static_cast< uint8_t >(ublkpp::raid1::read_route::DEVA);
+            sb->fields.clean_unmount = 0;
+            sb->fields.bitmap.age = htobe64(16);
+            return ublkpp::raid1::k_page_size;
+        });
+    // device_b: stale SB, age=0, route=EITHER (was never written during first self-heal)
+    EXPECT_CALL(*device_b, sync_iov(UBLK_IO_OP_READ, _, _, _))
+        .Times(1)
+        .WillOnce([](uint8_t, iovec* iovecs, uint32_t, off_t) -> io_result {
+            memcpy(iovecs->iov_base, &normal_superblock, ublkpp::raid1::k_page_size);
+            auto* sb = reinterpret_cast< ublkpp::raid1::SuperBlock* >(iovecs->iov_base);
+            sb->fields.device_b = 1;
+            sb->fields.read_route = static_cast< uint8_t >(ublkpp::raid1::read_route::EITHER);
+            sb->fields.clean_unmount = 0;
+            sb->fields.bitmap.age = htobe64(0);
+            return ublkpp::raid1::k_page_size;
+        });
+
+    // device_a: __become_active SB (age=32, route=DEVA) + bitmap sync_to + destructor SB
+    EXPECT_CALL(*device_a, sync_iov(UBLK_IO_OP_WRITE, _, _, _))
+        .Times(3)
+        .WillOnce([](uint8_t, iovec* iovecs, uint32_t, off_t addr) -> io_result {
             EXPECT_EQ(0UL, addr);
+            auto* sb = reinterpret_cast< ublkpp::raid1::SuperBlock* >(iovecs->iov_base);
+            EXPECT_EQ(ublkpp::raid1::read_route::DEVA,
+                      static_cast< ublkpp::raid1::read_route >(sb->fields.read_route));
+            EXPECT_EQ(htobe64(32), sb->fields.bitmap.age); // 16 + 16 bump from new_device path
+            return ublkpp::raid1::k_page_size;
+        })
+        .WillOnce([](uint8_t, iovec*, uint32_t, off_t addr) -> io_result {
+            EXPECT_GE(addr, static_cast< off_t >(ublkpp::raid1::k_page_size));
+            return ublkpp::raid1::k_page_size;
+        })
+        .WillOnce([](uint8_t, iovec* iovecs, uint32_t, off_t addr) -> io_result {
+            EXPECT_EQ(0UL, addr);
+            EXPECT_EQ(1, reinterpret_cast< ublkpp::raid1::SuperBlock* >(iovecs->iov_base)->fields.clean_unmount);
+            return ublkpp::raid1::k_page_size;
+        });
+    // device_b: init_to bitmap pages (new_device path), then __become_active SB
+    EXPECT_CALL(*device_b, sync_iov(UBLK_IO_OP_WRITE, _, _, _))
+        .Times(2)
+        .WillOnce([](uint8_t, iovec*, uint32_t, off_t addr) -> io_result {
+            // init_to: clean bitmap pages written to the new/stale device
+            EXPECT_GE(addr, static_cast< off_t >(ublkpp::raid1::k_page_size));
+            return ublkpp::raid1::k_page_size;
+        })
+        .WillOnce([](uint8_t, iovec* iovecs, uint32_t, off_t addr) -> io_result {
+            // __become_active SB: no unavail guard in new_device path, backup gets SB
+            EXPECT_EQ(0UL, addr);
+            auto* sb = reinterpret_cast< ublkpp::raid1::SuperBlock* >(iovecs->iov_base);
+            EXPECT_EQ(ublkpp::raid1::read_route::DEVA,
+                      static_cast< ublkpp::raid1::read_route >(sb->fields.read_route));
+            EXPECT_EQ(htobe64(32), sb->fields.bitmap.age);
             return ublkpp::raid1::k_page_size;
         });
 
     auto raid_device = ublkpp::raid1::Raid1Disk(boost::uuids::string_generator()(test_uuid), device_a, device_b);
-    EXPECT_TO_WRITE_SB(device_a);
-    EXPECT_TO_WRITE_SB(device_b);
+
+    // Should still be degraded (route=DEVA), resync pending
+    auto const state = raid_device.replica_states();
+    EXPECT_EQ(ublkpp::raid1::replica_state::CLEAN, state.device_a);
+    EXPECT_EQ(ublkpp::raid1::replica_state::SYNCING, state.device_b); // unavail NOT set by new_device path
+    EXPECT_GT(state.bytes_to_sync, 0ULL);
 }
 
 // Test 6: Unclean shutdown while degraded (original broken test kept for documentation)

--- a/src/raid/raid1/tests/misc/edge_cases.cpp
+++ b/src/raid/raid1/tests/misc/edge_cases.cpp
@@ -202,8 +202,7 @@ TEST(Raid1, UncleanShutdownBothPresentSelfHeal) {
             EXPECT_EQ(ublkpp::raid1::k_page_size, ublkpp::iovec_len(iovecs, iovecs + nr_vecs));
             EXPECT_EQ(0UL, addr);
             auto* sb = reinterpret_cast< ublkpp::raid1::SuperBlock* >(iovecs->iov_base);
-            EXPECT_EQ(ublkpp::raid1::read_route::DEVA,
-                      static_cast< ublkpp::raid1::read_route >(sb->fields.read_route));
+            EXPECT_EQ(ublkpp::raid1::read_route::DEVA, static_cast< ublkpp::raid1::read_route >(sb->fields.read_route));
             EXPECT_EQ(htobe64(16), sb->fields.bitmap.age); // age 0 (normal_superblock) + 16
             EXPECT_EQ(0, sb->fields.clean_unmount);
             return ublkpp::raid1::k_page_size;
@@ -222,8 +221,7 @@ TEST(Raid1, UncleanShutdownBothPresentSelfHeal) {
             EXPECT_EQ(0UL, addr);
             auto* sb = reinterpret_cast< ublkpp::raid1::SuperBlock* >(iovecs->iov_base);
             EXPECT_EQ(1, sb->fields.clean_unmount);
-            EXPECT_EQ(ublkpp::raid1::read_route::DEVA,
-                      static_cast< ublkpp::raid1::read_route >(sb->fields.read_route));
+            EXPECT_EQ(ublkpp::raid1::read_route::DEVA, static_cast< ublkpp::raid1::read_route >(sb->fields.read_route));
             return ublkpp::raid1::k_page_size;
         });
     // device_b: no writes — __become_active skips (unavail guard), destructor skips (degraded backup)
@@ -305,8 +303,7 @@ TEST(Raid1, UncleanBothPresentSelfHealIdempotentAfterCrash) {
         .WillOnce([](uint8_t, iovec* iovecs, uint32_t, off_t addr) -> io_result {
             EXPECT_EQ(0UL, addr);
             auto* sb = reinterpret_cast< ublkpp::raid1::SuperBlock* >(iovecs->iov_base);
-            EXPECT_EQ(ublkpp::raid1::read_route::DEVA,
-                      static_cast< ublkpp::raid1::read_route >(sb->fields.read_route));
+            EXPECT_EQ(ublkpp::raid1::read_route::DEVA, static_cast< ublkpp::raid1::read_route >(sb->fields.read_route));
             EXPECT_EQ(htobe64(32), sb->fields.bitmap.age); // 16 + 16 bump from new_device path
             return ublkpp::raid1::k_page_size;
         })
@@ -331,8 +328,7 @@ TEST(Raid1, UncleanBothPresentSelfHealIdempotentAfterCrash) {
             // __become_active SB: no unavail guard in new_device path, backup gets SB
             EXPECT_EQ(0UL, addr);
             auto* sb = reinterpret_cast< ublkpp::raid1::SuperBlock* >(iovecs->iov_base);
-            EXPECT_EQ(ublkpp::raid1::read_route::DEVA,
-                      static_cast< ublkpp::raid1::read_route >(sb->fields.read_route));
+            EXPECT_EQ(ublkpp::raid1::read_route::DEVA, static_cast< ublkpp::raid1::read_route >(sb->fields.read_route));
             EXPECT_EQ(htobe64(32), sb->fields.bitmap.age);
             return ublkpp::raid1::k_page_size;
         });


### PR DESCRIPTION
## Background

RAID1 makes a weaker guarantee than Linux MD-RAID1 on unclean shutdown. When both legs are present and the array crashes while healthy (both legs at `clean_unmount=0`, `read_route=EITHER`, equal ages), writes in-flight at crash time may have landed on one leg but not the other. The array previously only logged a warning and continued serving reads round-robin across both legs.

This is a **read-determinism** bug, not a durability bug. The block-device contract — a given LBA always reads back the same bytes — is broken. Filesystems (XFS, etc.) and applications depend on read-determinism unconditionally, including for LBAs they never wrote. The same LBA can flip-flop between the two versions within a single mount as reads route A→B→A→B.

Closes #290 (Phase 1). Phase 2 (unified thin-aware resync) is tracked separately.

## What this PR does

Detects the both-present + unclean + `EITHER` + equal-age assembly case in `__init_bitmap_and_degraded_route` and self-heals:

```
Detection:  both legs present, clean_unmount=0, read_route=EITHER, equal ages
             ↓
Action:     bump canonical (device_a) age +16  → manufactures >1 gap vs stale on-disk age
            dirty whole bitmap                  → full canonical→stale resync scheduled
            read_route → DEVA                  → reads pinned to canonical
            device_b->unavail = true           → writes skip stale until probe_mirror clears

__become_active: skip writing device_b's SB (unavail guard)
             → canonical on-disk: age=N+16, route=DEVA
             → stale on-disk:     age=N,    route=EITHER  (gap preserved)
```

## Crash-mid-resync idempotency

On reassembly after a crash mid-resync, `pick_superblock` selects the canonical (higher age), `age_diff=16>1` sets `_device_b->new_device=true`, and the **existing** `new_device` path re-dirties the whole bitmap and resumes the full resync. No new superblock field; no new state machine. Idempotent across any number of crashes.

| Assembly | Path taken | Result |
|---|---|---|
| 1st (unclean, equal ages) | **new branch** | reads pinned to canonical, resync spawned |
| 2nd (crash mid-resync, age gap=16) | existing `new_device` path | bitmap re-dirtied, resync resumes |
| 3rd+ (if route=DEVA persists) | existing `unclean in degraded mode` path | bitmap re-dirtied, resync resumes |

## Changes

- **`raid1.cpp:__init_bitmap_and_degraded_route`**: replace the `else if (clean_unmount==0)` warning with the self-heal logic (+16 age, dirty all, pin to DEVA, mark device_b stale).
- **`raid1.cpp:__become_active`**: add `unavail` guard after `is_missing()` — skips writing the stale leg's SB to preserve the on-disk age gap for crash idempotency.
- **Tests**:
  - `UncleanShutdownWhileHealthy` → `UncleanShutdownBothPresentSelfHeal`: 3 writes to device_a (activate SB + bitmap sync + clean SB), 0 to device_b; `replica_states()` shows `device_a=CLEAN, device_b=ERROR, bytes_to_sync>0`.
  - New `UncleanBothPresentSelfHealIdempotentAfterCrash`: simulates on-disk state after crash mid-resync (canonical age=16, stale age=0), verifies second assembly uses existing `new_device` path (age=32, device_b gets `init_to`+SB).

## Acceptance criteria (from #290 Phase 1)

- [x] Both-present + `clean_unmount=0` + `read_route=EITHER` + equal-age assembly no longer serves diverged reads; reads pin to canonical until repair completes.
- [x] Detection manufactures a +16 age gap on the canonical leg only and dirties the whole bitmap, routing the rest through the existing age-divergent path.
- [x] Recovery is idempotent across repeated crashes (interrupt mid-recovery, reassemble via the age gap, recovery resumes and completes) — no new SB bit.
- [ ] On completion the ages re-equalize, the array returns to `read_route::EITHER`, and a clean shutdown sets `clean_unmount`. *(existing `__become_clean` machinery; covered by existing clean-degraded tests)*
- [x] Array is available for IO immediately on assembly (no blocking resync).
- [x] Tests: injected divergence on equal-age unclean assembly; crash-during-recovery resume; existing missing-leg / replacement paths unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)