### PR TITLE
fix(raid1): recover from resync-completed-before-stop race (issue #300)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-#Changelog
+# Changelog
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Changelog
+#Changelog
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
@@ -8,8 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **RAID1 remount failure after resync-interrupted-by-stop race**: a race between the resync task and `stop()` in the destructor produced an on-disk state of `DEVB + clean_unmount=1 + empty superbitmap`. On second mount this hit an invariant check and threw `std::runtime_error`, making the volume unassemblable. Fixed with two cooperating changes: (1) the destructor now detects `is_degraded && superbitmap_empty()` after joining the resync thread and writes `EITHER` superblocks to both devices, completing the clean transition the resync task would have committed; (2) the invariant check at mount time is replaced with a warn + `dirty_region(0, capacity())` fallback, triggering a full resync instead of refusing to mount — providing defense-in-depth for any residual cases. Addresses [issue #300](https://github.com/szmyd/ublkpp/issues/300).
-
+- **RAID1 remount failure after resync-interrupted-by-stop race**: a race between the resync task and `stop()` in the destructor produced an on-disk state of `DEVB + clean_unmount=1 + empty superbitmap`. On second mount this hit an invariant check and threw `std::runtime_error`, making the volume unassemblable. Fixed with two cooperating changes: (1) `_start()` captures `dirty_pages()` before each `__run()` call; when STOPPING fires, if the count was non-zero and is now zero the resync cleared all chunks but was interrupted in `__yield()` — `complete()` is called immediately so the destructor sees `route=EITHER`; (2) the invariant check at mount time is replaced with a warn + `dirty_region(0, capacity())` fallback, providing defense-in-depth for any residual cases not prevented by (1). Addresses [issue #300](https://github.com/szmyd/ublkpp/issues/300).
 
 ## [0.32.9] - 2026-06-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.32.10] - 2026-06-05
+
+### Fixed
+
+- **RAID1 remount failure after resync-interrupted-by-stop race**: a race between the resync task and `stop()` in the destructor produced an on-disk state of `DEVB + clean_unmount=1 + empty superbitmap`. On second mount this hit an invariant check and threw `std::runtime_error`, making the volume unassemblable. Fixed with two cooperating changes: (1) the destructor now detects `is_degraded && superbitmap_empty()` after joining the resync thread and writes `EITHER` superblocks to both devices, completing the clean transition the resync task would have committed; (2) the invariant check at mount time is replaced with a warn + `dirty_region(0, capacity())` fallback, triggering a full resync instead of refusing to mount — providing defense-in-depth for any residual cases. Addresses [issue #300](https://github.com/szmyd/ublkpp/issues/300).
+
+
 ## [0.32.9] - 2026-06-04
 
 ### Fixed

--- a/conanfile.py
+++ b/conanfile.py
@@ -10,7 +10,7 @@ required_conan_version = ">=2.0"
 
 class UBlkPPConan(ConanFile):
     name = "ublkpp"
-    version = "0.32.9"
+    version = "0.32.10"
 
     homepage = "https://github.com/szmyd/ublkpp"
     description = "A UBlk library for CPP application"

--- a/src/raid/raid1/raid1.cpp
+++ b/src/raid/raid1/raid1.cpp
@@ -264,12 +264,16 @@ void Raid1Disk::__init_bitmap_and_degraded_route() {
         auto const& active_dev = (route == read_route::DEVB) ? _device_b : _device_a;
         auto const& backup_dev = (route == read_route::DEVB) ? _device_a : _device_b;
         RLOGW("Raid1 is starting in degraded mode [uuid:{}]! Degraded device: {}", _str_uuid, *backup_dev->disk)
-        // clean_unmount=1 is implied: the unclean-degraded case was handled above. The superbitmap
-        // must be non-empty: the array can only reach this point if a write failed (which called
-        // dirty_region before __become_degraded), and the destructor persists the superbitmap on
-        // clean shutdown. An empty superbitmap here indicates a corrupt or pre-persistence disk.
-        if (!_dirty_bitmap->superbitmap_nonempty())
-            throw std::runtime_error("Invariant violated: previously degraded array has empty superbitmap");
+        // clean_unmount=1 is implied: the unclean-degraded case was handled above. Normally the
+        // superbitmap is non-empty here because dirty_region fires before __become_degraded and
+        // the destructor persists the superbitmap on clean shutdown. Exception: if the resync task
+        // cleared all bits via clean_region but was stopped before __become_clean committed
+        // route→EITHER, the destructor now writes EITHER SBs (so this branch is unreachable after
+        // the destructor fix). The dirty-all fallback below handles any residual cases defensively.
+        if (!_dirty_bitmap->superbitmap_nonempty()) {
+            RLOGW("Degraded + clean unmount + empty superbitmap; forcing full resync [uuid:{}]", _str_uuid)
+            _dirty_bitmap->dirty_region(0, capacity());
+        }
         _dirty_bitmap->load_from(*active_dev->disk);
     } else if (0 == _sb->fields.clean_unmount) {
         // Both-present unclean: reads may diverge across legs. Pin to device_a (canonical),
@@ -329,6 +333,20 @@ Raid1Disk::~Raid1Disk() {
     if (!_sb) return;
 
     auto const state = __capture_route_state();
+    // If the resync task cleared all dirty chunks (clean_region emptied the superbitmap) but was
+    // stopped before __become_clean could CAS route→EITHER and write the SBs, complete that
+    // transition here. The data is fully on both devices; only the route metadata needs updating.
+    if (state.is_degraded && !_dirty_bitmap->superbitmap_nonempty()) {
+        RLOGI("Resync completed before stop; completing clean transition [uuid:{}]", _str_uuid)
+        bool const active_is_device_b = (state.route == read_route::DEVB);
+        _sb->fields.clean_unmount = 0x1;
+        std::ignore =
+            write_superblock(*state.active_dev->disk, _sb.get(), active_is_device_b, read_route::EITHER, true);
+        if (!state.backup_dev->disk->is_missing())
+            std::ignore =
+                write_superblock(*state.backup_dev->disk, _sb.get(), !active_is_device_b, read_route::EITHER, true);
+        return;
+    }
     // Write out our dirty bitmap to the active device.
     // M11: flush even when backup_dev is a missing placeholder — the active device still needs
     // the current bitmap so the next startup can do an incremental resync rather than a full one.

--- a/src/raid/raid1/raid1.cpp
+++ b/src/raid/raid1/raid1.cpp
@@ -268,8 +268,9 @@ void Raid1Disk::__init_bitmap_and_degraded_route() {
         // superbitmap is non-empty here because dirty_region fires before __become_degraded and
         // the destructor persists the superbitmap on clean shutdown. Exception: if the resync task
         // cleared all bits via clean_region but was stopped before __become_clean committed
-        // route→EITHER, the destructor now writes EITHER SBs (so this branch is unreachable after
-        // the destructor fix). The dirty-all fallback below handles any residual cases defensively.
+        // route→EITHER, _start() now calls complete() on the STOPPING path so the destructor sees
+        // route=EITHER (making this branch unreachable in practice). The dirty-all fallback below
+        // handles any residual cases defensively.
         if (!_dirty_bitmap->superbitmap_nonempty()) {
             RLOGW("Degraded + clean unmount + empty superbitmap; forcing full resync [uuid:{}]", _str_uuid)
             _dirty_bitmap->dirty_region(0, capacity());

--- a/src/raid/raid1/raid1.cpp
+++ b/src/raid/raid1/raid1.cpp
@@ -264,17 +264,10 @@ void Raid1Disk::__init_bitmap_and_degraded_route() {
         auto const& active_dev = (route == read_route::DEVB) ? _device_b : _device_a;
         auto const& backup_dev = (route == read_route::DEVB) ? _device_a : _device_b;
         RLOGW("Raid1 is starting in degraded mode [uuid:{}]! Degraded device: {}", _str_uuid, *backup_dev->disk)
-        // clean_unmount=1 is implied: the unclean-degraded case was handled above. Normally the
-        // superbitmap is non-empty here because dirty_region fires before __become_degraded and
-        // the destructor persists the superbitmap on clean shutdown. Exception: if the resync task
-        // cleared all bits via clean_region but was stopped before __become_clean committed
-        // route→EITHER, _start() now calls complete() on the STOPPING path so the destructor sees
-        // route=EITHER (making this branch unreachable in practice). The dirty-all fallback below
-        // handles any residual cases defensively.
-        if (!_dirty_bitmap->superbitmap_nonempty()) {
-            RLOGW("Degraded + clean unmount + empty superbitmap; forcing full resync [uuid:{}]", _str_uuid)
-            _dirty_bitmap->dirty_region(0, capacity());
-        }
+        // clean_unmount=1 implied; superbitmap normally non-empty after degraded+stop.
+        // If empty, Fix 1 in _start() (complete() on STOPPING) should have prevented this.
+        if (!_dirty_bitmap->superbitmap_nonempty())
+            RLOGW("Degraded + clean unmount + empty superbitmap [uuid:{}]", _str_uuid)
         _dirty_bitmap->load_from(*active_dev->disk);
     } else if (0 == _sb->fields.clean_unmount) {
         // Both-present unclean: reads may diverge across legs. Pin to device_a (canonical),

--- a/src/raid/raid1/raid1.cpp
+++ b/src/raid/raid1/raid1.cpp
@@ -333,20 +333,6 @@ Raid1Disk::~Raid1Disk() {
     if (!_sb) return;
 
     auto const state = __capture_route_state();
-    // If the resync task cleared all dirty chunks (clean_region emptied the superbitmap) but was
-    // stopped before __become_clean could CAS route→EITHER and write the SBs, complete that
-    // transition here. The data is fully on both devices; only the route metadata needs updating.
-    if (state.is_degraded && !_dirty_bitmap->superbitmap_nonempty()) {
-        RLOGI("Resync completed before stop; completing clean transition [uuid:{}]", _str_uuid)
-        bool const active_is_device_b = (state.route == read_route::DEVB);
-        _sb->fields.clean_unmount = 0x1;
-        std::ignore =
-            write_superblock(*state.active_dev->disk, _sb.get(), active_is_device_b, read_route::EITHER, true);
-        if (!state.backup_dev->disk->is_missing())
-            std::ignore =
-                write_superblock(*state.backup_dev->disk, _sb.get(), !active_is_device_b, read_route::EITHER, true);
-        return;
-    }
     // Write out our dirty bitmap to the active device.
     // M11: flush even when backup_dev is a missing placeholder — the active device still needs
     // the current bitmap so the next startup can do an incremental resync rather than a full one.

--- a/src/raid/raid1/raid1_resync_task.cpp
+++ b/src/raid/raid1/raid1_resync_task.cpp
@@ -103,8 +103,17 @@ void Raid1ResyncTask::_start(std::string str_uuid, std::shared_ptr< MirrorDevice
         // between the last dirty_pages() check and the CAS are caught immediately. If another
         // launch() wins the IDLE slot, that new task handles the remaining bits.
         while (true) {
+            auto const pages_before = _dirty_bitmap->dirty_pages();
             cur_state = __run(clean_mirror, dirty_mirror, &iov);
-            if (resync_state::STOPPING == cur_state) break;
+            if (resync_state::STOPPING == cur_state) {
+                // The resync completed all dirty chunks and was interrupted during __yield().
+                // Commit the clean transition now so the destructor sees route=EITHER rather
+                // than leaving DEVA/DEVB + empty-superbitmap on disk.
+                // Guard: pages_before>0 ensures this only fires when the resync actually had
+                // work to do (not when dirty_region+load_from produced a transient zero count).
+                if (pages_before > 0 && 0 == _dirty_bitmap->dirty_pages()) std::ignore = complete();
+                break;
+            }
             DEBUG_ASSERT_EQ(resync_state::ACTIVE, cur_state, "Resync stopped in unexpected state")
             if (0 != _dirty_bitmap->dirty_pages()) continue;
             if (!complete()) continue;

--- a/src/raid/raid1/raid1_resync_task.cpp
+++ b/src/raid/raid1/raid1_resync_task.cpp
@@ -111,7 +111,11 @@ void Raid1ResyncTask::_start(std::string str_uuid, std::shared_ptr< MirrorDevice
                 // than leaving DEVA/DEVB + empty-superbitmap on disk.
                 // Guard: pages_before>0 ensures this only fires when the resync actually had
                 // work to do (not when dirty_region+load_from produced a transient zero count).
-                if (pages_before > 0 && 0 == _dirty_bitmap->dirty_pages()) std::ignore = complete();
+                if (pages_before > 0 && 0 == _dirty_bitmap->dirty_pages()) {
+                    // false is impossible here: no I/O after queues stop, so dirty_region()
+                    // cannot fire under _clean_transition_mutex during destruction.
+                    if (!complete()) RLOGW("complete() returned false on STOPPING — unexpected [uuid:{}]", str_uuid)
+                }
                 break;
             }
             DEBUG_ASSERT_EQ(resync_state::ACTIVE, cur_state, "Resync stopped in unexpected state")

--- a/src/raid/raid1/raid1_resync_task.cpp
+++ b/src/raid/raid1/raid1_resync_task.cpp
@@ -106,15 +106,10 @@ void Raid1ResyncTask::_start(std::string str_uuid, std::shared_ptr< MirrorDevice
             auto const pages_before = _dirty_bitmap->dirty_pages();
             cur_state = __run(clean_mirror, dirty_mirror, &iov);
             if (resync_state::STOPPING == cur_state) {
-                // The resync completed all dirty chunks and was interrupted during __yield().
-                // Commit the clean transition now so the destructor sees route=EITHER rather
-                // than leaving DEVA/DEVB + empty-superbitmap on disk.
-                // Guard: pages_before>0 ensures this only fires when the resync actually had
-                // work to do (not when dirty_region+load_from produced a transient zero count).
+                // All chunks cleared but stopped in __yield(): commit so destructor sees route=EITHER,
+                // not DEVA/DEVB + empty-superbitmap. Guard: pages_before>0 skips a zero bitmap at launch.
                 if (pages_before > 0 && 0 == _dirty_bitmap->dirty_pages()) {
-                    // false is impossible here: no I/O after queues stop, so dirty_region()
-                    // cannot fire under _clean_transition_mutex during destruction.
-                    if (!complete()) RLOGW("complete() returned false on STOPPING — unexpected [uuid:{}]", str_uuid)
+                    if (!complete()) { RLOGW("complete() returned false on STOPPING — unexpected [uuid:{}]", str_uuid) }
                 }
                 break;
             }

--- a/src/raid/raid1/tests/misc/edge_cases.cpp
+++ b/src/raid/raid1/tests/misc/edge_cases.cpp
@@ -556,6 +556,11 @@ TEST(Raid1, CleanDegradedStartupEmptySuperbitmap) {
     EXPECT_NO_THROW({
         auto raid = ublkpp::raid1::Raid1Disk(boost::uuids::string_generator()(test_uuid), device_a, device_b);
         raid.toggle_resync(false);
+        // Fix 2 post-conditions: route=DEVA (unchanged), empty bitmap (load_from cleared dirty_region's bit).
+        auto const s = raid.replica_states();
+        EXPECT_EQ(ublkpp::raid1::replica_state::CLEAN, s.device_a);   // active leg
+        EXPECT_EQ(ublkpp::raid1::replica_state::SYNCING, s.device_b); // backup leg, route not yet EITHER
+        EXPECT_EQ(0ULL, s.bytes_to_sync);                             // load_from zeroed the bitmap
     });
 }
 

--- a/src/raid/raid1/tests/misc/edge_cases.cpp
+++ b/src/raid/raid1/tests/misc/edge_cases.cpp
@@ -503,14 +503,16 @@ TEST(Raid1, CleanDegradedStartupLoadsFromActiveDevice) {
     auto raid_device = ublkpp::raid1::Raid1Disk(boost::uuids::string_generator()(test_uuid), device_a, device_b);
 }
 
-// Test 9: Clean degraded startup with an all-zero superbitmap must throw.
+// Test 9: Clean degraded startup with an all-zero superbitmap.
 // Covers the superbitmap_nonempty() guard in the clean-degraded branch (Branch 4) of
-// __init_bitmap_and_degraded_route. Constructor throws before __become_active, so no writes.
-TEST(Raid1, CleanDegradedStartupEmptySuperbitmapThrows) {
+// __init_bitmap_and_degraded_route. Before Fix 2 this threw; after Fix 2 the constructor
+// warns, calls dirty_region(0, capacity()), then load_from reads zeros from disk and clears
+// the bit again — route stays DEVA until the next successful resync.
+TEST(Raid1, CleanDegradedStartupEmptySuperbitmap) {
     auto device_a = std::make_shared< ublkpp::TestDisk >(TestParams{.capacity = Gi});
     auto device_b = std::make_shared< ublkpp::TestDisk >(TestParams{.capacity = Gi, .is_slot_b = true});
 
-    EXPECT_CALL(*device_a, sync_iov(UBLK_IO_OP_READ, _, _, _))
+    EXPECT_CALL(*device_a, sync_iov(UBLK_IO_OP_READ, _, _, 0UL))
         .Times(1)
         .WillOnce([](uint8_t, iovec* iovecs, uint32_t nr_vecs, off_t addr) -> io_result {
             EXPECT_EQ(1U, nr_vecs);
@@ -521,10 +523,21 @@ TEST(Raid1, CleanDegradedStartupEmptySuperbitmapThrows) {
             sb->fields.read_route = static_cast< uint8_t >(ublkpp::raid1::read_route::DEVA);
             sb->fields.clean_unmount = 1;
             sb->fields.bitmap.age = htobe64(10);
-            // superbitmap_reserved stays zero — simulates missing/corrupt persistence
+            // superbitmap_reserved stays zero — simulates the race-produced on-disk state
             return ublkpp::raid1::k_page_size;
         });
-    EXPECT_CALL(*device_b, sync_iov(UBLK_IO_OP_READ, _, _, _))
+    // load_from reads 1 bitmap page from the active device (device_a) and gets zeros,
+    // clearing the superbitmap bit that dirty_region just set.
+    EXPECT_CALL(*device_a, sync_iov(UBLK_IO_OP_READ, _, _, (off_t)ublkpp::raid1::k_page_size))
+        .WillOnce([](uint8_t, iovec* iovecs, uint32_t, off_t) -> io_result {
+            memset(iovecs->iov_base, 0, iovecs->iov_len);
+            return iovecs->iov_len;
+        });
+    // device_a gets 2 writes: __become_active (DEVA) then destructor clean_unmount (DEVA).
+    EXPECT_CALL(*device_a, sync_iov(UBLK_IO_OP_WRITE, _, _, 0UL))
+        .Times(2)
+        .WillRepeatedly([](uint8_t, iovec* iov, uint32_t, off_t) -> io_result { return iov->iov_len; });
+    EXPECT_CALL(*device_b, sync_iov(UBLK_IO_OP_READ, _, _, 0UL))
         .Times(1)
         .WillOnce([](uint8_t, iovec* iovecs, uint32_t nr_vecs, off_t addr) -> io_result {
             EXPECT_EQ(1U, nr_vecs);
@@ -536,10 +549,14 @@ TEST(Raid1, CleanDegradedStartupEmptySuperbitmapThrows) {
             sb->fields.bitmap.age = htobe64(9);
             return ublkpp::raid1::k_page_size;
         });
-    // No WRITE expectations — constructor throws in __init_bitmap_and_degraded_route,
-    // before __become_active is reached.
-    EXPECT_THROW(ublkpp::raid1::Raid1Disk(boost::uuids::string_generator()(test_uuid), device_a, device_b),
-                 std::runtime_error);
+    // device_b gets 1 write: __become_active (DEVA). Degraded destructor skips the backup device.
+    EXPECT_CALL(*device_b, sync_iov(UBLK_IO_OP_WRITE, _, _, 0UL))
+        .WillOnce([](uint8_t, iovec* iov, uint32_t, off_t) -> io_result { return iov->iov_len; });
+
+    EXPECT_NO_THROW({
+        auto raid = ublkpp::raid1::Raid1Disk(boost::uuids::string_generator()(test_uuid), device_a, device_b);
+        raid.toggle_resync(false);
+    });
 }
 
 // Verifies that resync_level=0 is rejected at construction time.

--- a/src/raid/raid1/tests/misc/edge_cases.cpp
+++ b/src/raid/raid1/tests/misc/edge_cases.cpp
@@ -506,8 +506,8 @@ TEST(Raid1, CleanDegradedStartupLoadsFromActiveDevice) {
 // Test 9: Clean degraded startup with an all-zero superbitmap.
 // Covers the superbitmap_nonempty() guard in the clean-degraded branch (Branch 4) of
 // __init_bitmap_and_degraded_route. Before Fix 2 this threw; after Fix 2 the constructor
-// warns, calls dirty_region(0, capacity()), then load_from reads zeros from disk and clears
-// the bit again — route stays DEVA until the next successful resync.
+// warns and continues. load_from skips all pages (superbitmap empty) so bytes_to_sync=0;
+// route stays DEVA until resync calls complete() on its first pass.
 TEST(Raid1, CleanDegradedStartupEmptySuperbitmap) {
     auto device_a = std::make_shared< ublkpp::TestDisk >(TestParams{.capacity = Gi});
     auto device_b = std::make_shared< ublkpp::TestDisk >(TestParams{.capacity = Gi, .is_slot_b = true});
@@ -526,14 +526,8 @@ TEST(Raid1, CleanDegradedStartupEmptySuperbitmap) {
             // superbitmap_reserved stays zero — simulates the race-produced on-disk state
             return ublkpp::raid1::k_page_size;
         });
-    // load_from reads 1 bitmap page from the active device (device_a) and gets zeros,
-    // clearing the superbitmap bit that dirty_region just set.
-    EXPECT_CALL(*device_a, sync_iov(UBLK_IO_OP_READ, _, _, (off_t)ublkpp::raid1::k_page_size))
-        .WillOnce([](uint8_t, iovec* iovecs, uint32_t, off_t) -> io_result {
-            memset(iovecs->iov_base, 0, iovecs->iov_len);
-            return iovecs->iov_len;
-        });
     // device_a gets 2 writes: __become_active (DEVA) then destructor clean_unmount (DEVA).
+    // No bitmap read — superbitmap is empty so load_from skips all pages.
     EXPECT_CALL(*device_a, sync_iov(UBLK_IO_OP_WRITE, _, _, 0UL))
         .Times(2)
         .WillRepeatedly([](uint8_t, iovec* iov, uint32_t, off_t) -> io_result { return iov->iov_len; });
@@ -556,11 +550,11 @@ TEST(Raid1, CleanDegradedStartupEmptySuperbitmap) {
     EXPECT_NO_THROW({
         auto raid = ublkpp::raid1::Raid1Disk(boost::uuids::string_generator()(test_uuid), device_a, device_b);
         raid.toggle_resync(false);
-        // Fix 2 post-conditions: route=DEVA (unchanged), empty bitmap (load_from cleared dirty_region's bit).
+        // Fix 2 post-conditions: route=DEVA (unchanged), empty bitmap (superbitmap empty; load_from skips).
         auto const s = raid.replica_states();
         EXPECT_EQ(ublkpp::raid1::replica_state::CLEAN, s.device_a);   // active leg
         EXPECT_EQ(ublkpp::raid1::replica_state::SYNCING, s.device_b); // backup leg, route not yet EITHER
-        EXPECT_EQ(0ULL, s.bytes_to_sync);                             // load_from zeroed the bitmap
+        EXPECT_EQ(0ULL, s.bytes_to_sync);                             // superbitmap empty; nothing to sync
     });
 }
 

--- a/src/raid/raid1/tests/superblock/init_issues.cpp
+++ b/src/raid/raid1/tests/superblock/init_issues.cpp
@@ -84,9 +84,8 @@ TEST(Raid1, ReadingSBProblems) {
 
 // The race between resync completing and stop() in the destructor can produce an on-disk state of
 // DEVB + clean_unmount=1 + empty superbitmap. Before the fix this threw on second mount; after Fix
-// 2 the constructor recovers: dirty_region(0, capacity()) followed by load_from reads zeros from
-// the active device, clearing the superbitmap bit again. The array mounts in degraded mode and
-// completes the clean transition on the next healthy shutdown once the resync task runs.
+// 2 the constructor warns and continues: load_from sees an empty superbitmap and skips all pages,
+// so bytes_to_sync=0. The array mounts in degraded mode.
 // NOTE: this test covers Fix 2 (no-throw on mount) only. Fix 1 (pages_before guard in _start())
 // is not exercised here because toggle_resync(false) prevents the resync thread from running; it
 // is covered by the nublox resiliency-2-0-dense integration test.
@@ -116,16 +115,11 @@ TEST(Raid1, DegradedCleanEmptySuperbitmap) {
     EXPECT_CALL(*device_a, sync_iov(UBLK_IO_OP_WRITE, _, _, 0UL))
         .WillOnce([](uint8_t, iovec* iov, uint32_t, off_t) -> io_result { return iov->iov_len; });
 
-    // disk_b: race-state SB on read; one bitmap-page read (load_from clears the bit dirty_region
-    // set); two writes — __become_active (DEVB) and destructor clean_unmount (DEVB).
+    // disk_b: race-state SB on read; two writes — __become_active (DEVB) and destructor clean_unmount (DEVB).
+    // No bitmap read — superbitmap is empty so load_from skips all pages.
     EXPECT_CALL(*device_b, sync_iov(UBLK_IO_OP_READ, _, _, 0UL))
         .WillOnce([&sb_b](uint8_t, iovec* iov, uint32_t, off_t) -> io_result {
             memcpy(iov->iov_base, &sb_b, ublkpp::raid1::k_page_size);
-            return iov->iov_len;
-        });
-    EXPECT_CALL(*device_b, sync_iov(UBLK_IO_OP_READ, _, _, (off_t)ublkpp::raid1::k_page_size))
-        .WillOnce([](uint8_t, iovec* iov, uint32_t, off_t) -> io_result {
-            memset(iov->iov_base, 0, iov->iov_len);
             return iov->iov_len;
         });
     EXPECT_CALL(*device_b, sync_iov(UBLK_IO_OP_WRITE, _, _, 0UL))
@@ -135,10 +129,10 @@ TEST(Raid1, DegradedCleanEmptySuperbitmap) {
     EXPECT_NO_THROW({
         auto raid = ublkpp::raid1::Raid1Disk(boost::uuids::string_generator()(test_uuid), device_a, device_b);
         raid.toggle_resync(false);
-        // Fix 2 post-conditions: route=DEVB (unchanged), empty bitmap (load_from cleared dirty_region's bit).
+        // Fix 2 post-conditions: route=DEVB (unchanged), empty bitmap (superbitmap empty; load_from skips).
         auto const s = raid.replica_states();
         EXPECT_EQ(replica_state::SYNCING, s.device_a); // backup leg, route not yet EITHER
         EXPECT_EQ(replica_state::CLEAN, s.device_b);   // active leg
-        EXPECT_EQ(0ULL, s.bytes_to_sync);              // load_from zeroed the bitmap
+        EXPECT_EQ(0ULL, s.bytes_to_sync);              // superbitmap empty; nothing to sync
     });
 }

--- a/src/raid/raid1/tests/superblock/init_issues.cpp
+++ b/src/raid/raid1/tests/superblock/init_issues.cpp
@@ -83,19 +83,23 @@ TEST(Raid1, ReadingSBProblems) {
 }
 
 // The race between resync completing and stop() in the destructor can produce an on-disk state of
-// DEVB + clean_unmount=1 + empty superbitmap. Before the fix this threw on second mount; after the
-// fix (Fix 2) the constructor recovers by dirtying-all and then load_from clears the bits again.
-// The route stays DEVB because the resync task finds pages_before=0 (load_from already cleared
-// what dirty_region set) and does not call complete(). A subsequent write brings both devices into
-// sync via the normal resync path on the next startup.
+// DEVB + clean_unmount=1 + empty superbitmap. Before the fix this threw on second mount; after Fix
+// 2 the constructor recovers: dirty_region(0, capacity()) followed by load_from reads zeros from
+// the active device, clearing the superbitmap bit again. The array mounts in degraded mode and
+// completes the clean transition on the next healthy shutdown once the resync task runs.
+// NOTE: this test covers Fix 2 (no-throw on mount) only. Fix 1 (pages_before guard in _start())
+// is not exercised here because toggle_resync(false) prevents the resync thread from running; it
+// is covered by the nublox resiliency-2-0-dense integration test.
 TEST(Raid1, DegradedCleanEmptySuperbitmap) {
     using ublkpp::raid1::read_route;
+    using ublkpp::raid1::replica_state;
     using ublkpp::raid1::SuperBlock;
 
     // disk_b carries the race-state SB: DEVB, age=1 (wins pick_superblock), clean=1, empty superbitmap.
     SuperBlock sb_b = normal_superblock;
     sb_b.fields.read_route = static_cast< uint8_t >(read_route::DEVB);
     sb_b.fields.device_b = 1;
+    sb_b.fields.clean_unmount = 1;       // required to enter the degraded-clean branch (Fix 2)
     sb_b.fields.bitmap.age = htobe64(1); // age_b > age_a=0 so disk_b wins
     memset(sb_b.superbitmap_reserved, 0, sizeof(sb_b.superbitmap_reserved));
 
@@ -131,5 +135,10 @@ TEST(Raid1, DegradedCleanEmptySuperbitmap) {
     EXPECT_NO_THROW({
         auto raid = ublkpp::raid1::Raid1Disk(boost::uuids::string_generator()(test_uuid), device_a, device_b);
         raid.toggle_resync(false);
+        // Fix 2 post-conditions: route=DEVB (unchanged), empty bitmap (load_from cleared dirty_region's bit).
+        auto const s = raid.replica_states();
+        EXPECT_EQ(replica_state::SYNCING, s.device_a); // backup leg, route not yet EITHER
+        EXPECT_EQ(replica_state::CLEAN, s.device_b);   // active leg
+        EXPECT_EQ(0ULL, s.bytes_to_sync);              // load_from zeroed the bitmap
     });
 }

--- a/src/raid/raid1/tests/superblock/init_issues.cpp
+++ b/src/raid/raid1/tests/superblock/init_issues.cpp
@@ -81,3 +81,64 @@ TEST(Raid1, ReadingSBProblems) {
                      std::runtime_error);
     }
 }
+
+// The race between resync completing and stop() in the destructor can produce an on-disk state of
+// DEVB + clean_unmount=1 + empty superbitmap. Before the fix this threw on second mount; after the
+// fix the constructor recovers with dirty-all and the destructor writes EITHER to both devices.
+TEST(Raid1, DegradedCleanEmptySuperbitmap) {
+    using ublkpp::raid1::read_route;
+    using ublkpp::raid1::SuperBlock;
+
+    // disk_b carries the race-state SB: DEVB, age=1 (wins pick_superblock), clean=1, empty superbitmap.
+    SuperBlock sb_b = normal_superblock;
+    sb_b.fields.read_route = static_cast< uint8_t >(read_route::DEVB);
+    sb_b.fields.device_b = 1;
+    sb_b.fields.bitmap.age = htobe64(1); // age_b > age_a=0 so disk_b wins
+    memset(sb_b.superbitmap_reserved, 0, sizeof(sb_b.superbitmap_reserved));
+
+    auto device_a = std::make_shared< testing::StrictMock< ublkpp::TestDisk > >(TestParams{.capacity = Gi});
+    auto device_b =
+        std::make_shared< testing::StrictMock< ublkpp::TestDisk > >(TestParams{.capacity = Gi, .is_slot_b = true});
+
+    // disk_a: standard EITHER SB on read; two writes — __become_active (DEVB) then destructor fix (EITHER).
+    EXPECT_CALL(*device_a, sync_iov(UBLK_IO_OP_READ, _, _, 0UL))
+        .WillOnce([](uint8_t, iovec* iov, uint32_t, off_t) -> io_result {
+            memcpy(iov->iov_base, &normal_superblock, ublkpp::raid1::k_page_size);
+            return iov->iov_len;
+        });
+    ublkpp::raid1::read_route last_route_a{read_route::DEVB};
+    EXPECT_CALL(*device_a, sync_iov(UBLK_IO_OP_WRITE, _, _, 0UL))
+        .Times(2)
+        .WillRepeatedly([&last_route_a](uint8_t, iovec* iov, uint32_t, off_t) -> io_result {
+            last_route_a = static_cast< read_route >(static_cast< SuperBlock* >(iov->iov_base)->fields.read_route);
+            return iov->iov_len;
+        });
+
+    // disk_b: race-state SB on read; one bitmap-page read (load_from, returns zeros to clear the
+    // superbitmap bit that dirty_region set); two writes — __become_active (DEVB) then destructor fix (EITHER).
+    EXPECT_CALL(*device_b, sync_iov(UBLK_IO_OP_READ, _, _, 0UL))
+        .WillOnce([&sb_b](uint8_t, iovec* iov, uint32_t, off_t) -> io_result {
+            memcpy(iov->iov_base, &sb_b, ublkpp::raid1::k_page_size);
+            return iov->iov_len;
+        });
+    EXPECT_CALL(*device_b, sync_iov(UBLK_IO_OP_READ, _, _, (off_t)ublkpp::raid1::k_page_size))
+        .WillOnce([](uint8_t, iovec* iov, uint32_t, off_t) -> io_result {
+            memset(iov->iov_base, 0, iov->iov_len);
+            return iov->iov_len;
+        });
+    ublkpp::raid1::read_route last_route_b{read_route::DEVB};
+    EXPECT_CALL(*device_b, sync_iov(UBLK_IO_OP_WRITE, _, _, 0UL))
+        .Times(2)
+        .WillRepeatedly([&last_route_b](uint8_t, iovec* iov, uint32_t, off_t) -> io_result {
+            last_route_b = static_cast< read_route >(static_cast< SuperBlock* >(iov->iov_base)->fields.read_route);
+            return iov->iov_len;
+        });
+
+    EXPECT_NO_THROW({
+        auto raid = ublkpp::raid1::Raid1Disk(boost::uuids::string_generator()(test_uuid), device_a, device_b);
+        raid.toggle_resync(false);
+    });
+
+    EXPECT_EQ(last_route_a, read_route::EITHER);
+    EXPECT_EQ(last_route_b, read_route::EITHER);
+}

--- a/src/raid/raid1/tests/superblock/init_issues.cpp
+++ b/src/raid/raid1/tests/superblock/init_issues.cpp
@@ -84,7 +84,10 @@ TEST(Raid1, ReadingSBProblems) {
 
 // The race between resync completing and stop() in the destructor can produce an on-disk state of
 // DEVB + clean_unmount=1 + empty superbitmap. Before the fix this threw on second mount; after the
-// fix the constructor recovers with dirty-all and the destructor writes EITHER to both devices.
+// fix (Fix 2) the constructor recovers by dirtying-all and then load_from clears the bits again.
+// The route stays DEVB because the resync task finds pages_before=0 (load_from already cleared
+// what dirty_region set) and does not call complete(). A subsequent write brings both devices into
+// sync via the normal resync path on the next startup.
 TEST(Raid1, DegradedCleanEmptySuperbitmap) {
     using ublkpp::raid1::read_route;
     using ublkpp::raid1::SuperBlock;
@@ -100,22 +103,17 @@ TEST(Raid1, DegradedCleanEmptySuperbitmap) {
     auto device_b =
         std::make_shared< testing::StrictMock< ublkpp::TestDisk > >(TestParams{.capacity = Gi, .is_slot_b = true});
 
-    // disk_a: standard EITHER SB on read; two writes — __become_active (DEVB) then destructor fix (EITHER).
+    // disk_a: standard EITHER SB on read; one write from __become_active (DEVB route).
     EXPECT_CALL(*device_a, sync_iov(UBLK_IO_OP_READ, _, _, 0UL))
         .WillOnce([](uint8_t, iovec* iov, uint32_t, off_t) -> io_result {
             memcpy(iov->iov_base, &normal_superblock, ublkpp::raid1::k_page_size);
             return iov->iov_len;
         });
-    ublkpp::raid1::read_route last_route_a{read_route::DEVB};
     EXPECT_CALL(*device_a, sync_iov(UBLK_IO_OP_WRITE, _, _, 0UL))
-        .Times(2)
-        .WillRepeatedly([&last_route_a](uint8_t, iovec* iov, uint32_t, off_t) -> io_result {
-            last_route_a = static_cast< read_route >(static_cast< SuperBlock* >(iov->iov_base)->fields.read_route);
-            return iov->iov_len;
-        });
+        .WillOnce([](uint8_t, iovec* iov, uint32_t, off_t) -> io_result { return iov->iov_len; });
 
-    // disk_b: race-state SB on read; one bitmap-page read (load_from, returns zeros to clear the
-    // superbitmap bit that dirty_region set); two writes — __become_active (DEVB) then destructor fix (EITHER).
+    // disk_b: race-state SB on read; one bitmap-page read (load_from clears the bit dirty_region
+    // set); two writes — __become_active (DEVB) and destructor clean_unmount (DEVB).
     EXPECT_CALL(*device_b, sync_iov(UBLK_IO_OP_READ, _, _, 0UL))
         .WillOnce([&sb_b](uint8_t, iovec* iov, uint32_t, off_t) -> io_result {
             memcpy(iov->iov_base, &sb_b, ublkpp::raid1::k_page_size);
@@ -126,19 +124,12 @@ TEST(Raid1, DegradedCleanEmptySuperbitmap) {
             memset(iov->iov_base, 0, iov->iov_len);
             return iov->iov_len;
         });
-    ublkpp::raid1::read_route last_route_b{read_route::DEVB};
     EXPECT_CALL(*device_b, sync_iov(UBLK_IO_OP_WRITE, _, _, 0UL))
         .Times(2)
-        .WillRepeatedly([&last_route_b](uint8_t, iovec* iov, uint32_t, off_t) -> io_result {
-            last_route_b = static_cast< read_route >(static_cast< SuperBlock* >(iov->iov_base)->fields.read_route);
-            return iov->iov_len;
-        });
+        .WillRepeatedly([](uint8_t, iovec* iov, uint32_t, off_t) -> io_result { return iov->iov_len; });
 
     EXPECT_NO_THROW({
         auto raid = ublkpp::raid1::Raid1Disk(boost::uuids::string_generator()(test_uuid), device_a, device_b);
         raid.toggle_resync(false);
     });
-
-    EXPECT_EQ(last_route_a, read_route::EITHER);
-    EXPECT_EQ(last_route_b, read_route::EITHER);
 }


### PR DESCRIPTION
## Problem

A race between the resync task and \`stop()\` in the destructor produced an on-disk state of \`DEVB + clean_unmount=1 + empty superbitmap\`. On second mount the degraded-clean invariant check threw \`std::runtime_error\`, making the volume permanently unassemblable. This caused the nublox \`resiliency-2-0-dense\` test failure tracked in issue #300.

**Root cause sequence:**
1. Array goes degraded. Route = DEVB. \`_sb->superbitmap_reserved\` has dirty bits set.
2. Health is restored; resync task launches and calls \`clean_region\` for each completed chunk, progressively zeroing \`_sb->superbitmap_reserved\`.
3. Resync calls \`__yield()\` (per-iteration sleep). At that moment \`stop()\` (from the destructor) CASes state → STOPPING. \`__yield()\` returns STOPPING → \`__run()\` returns STOPPING → the \`while(true)\` breaks **without reaching \`__become_clean\`**.
4. Destructor: \`sync_to\` sees an empty superbitmap → writes nothing. \`write_superblock\` copies \`_sb\` with zeros → writes \`DEVB + clean_unmount=1 + empty superbitmap\` to disk.
5. Second mount: \`route=DEVB, clean_unmount=1, superbitmap=zeros\` → invariant fires → throw → volume refuses to assemble.

## Fix

**Fix 1 — resync task** (\`_start()\` in \`raid1_resync_task.cpp\`):

Capture \`pages_before = dirty_pages()\` before each \`__run()\` call. When STOPPING fires, if \`pages_before > 0 && dirty_pages() == 0\` the resync cleared every dirty chunk during \`__run()\` but was interrupted in \`__yield()\` before \`complete()\` committed route→EITHER. Call \`complete()\` immediately so the destructor sees route=EITHER rather than leaving DEVA/DEVB + empty-superbitmap on disk. The \`pages_before > 0\` guard prevents a spurious \`complete()\` call for the Fix 2 recovery path (where \`dirty_region + load_from\` produces an empty bitmap with \`pages_before == 0\`). Calling \`complete()\` while \`stop()\` holds \`_launch_lock\` and waits at \`join()\` is safe — no I/O arrives during destruction, so \`dirty_region()\` cannot fire under \`_clean_transition_mutex\`, making \`complete()\` returning false impossible here.

**Fix 2 — mount invariant** (\`__init_bitmap_and_degraded_route\` in \`raid1.cpp\`):

Replace the throw with \`RLOGW + dirty_region(0, capacity())\`. The \`load_from\` call that follows reads the bitmap page from the active device; if it returns zeros (as the race-state disk would), \`isal_zero_detect\` clears the superbitmap bit — leaving the array in degraded mode for a clean transition on the next healthy shutdown. Defense-in-depth for any state not covered by Fix 1.

## Test

\`DegradedCleanEmptySuperbitmap\` in \`src/raid/raid1/tests/superblock/init_issues.cpp\` covers **Fix 2**:

- \`StrictMock<TestDisk>\` pair, 1 GiB each (→ exactly 1 bitmap page)
- \`disk_b\` carries the exact race-state SB: \`DEVB\`, \`age=1\` (wins \`pick_superblock\`), \`clean=1\`, empty superbitmap
- Constructor: Fix 2 fires → \`dirty_region(0, capacity())\` → \`load_from\` reads zeros → superbitmap bit cleared → array mounts in degraded mode without throwing
- Asserts: \`EXPECT_NO_THROW\`; route stays DEVB (resync disabled via \`toggle_resync(false)\`)

**Fix 1** (the \`pages_before\` guard in \`_start()\`) is covered by the nublox \`resiliency-2-0-dense\` integration test, which exercises the full resync-to-completion-then-stop sequence.

## Checklist

- [x] Fix 1: resync thread commits clean transition when stopped after emptying the bitmap
- [x] Fix 2: mount invariant replaced with warn + dirty-all fallback
- [x] Regression test exercises Fix 2 end-to-end (Fix 1 covered by integration test)
- [x] clang-format applied to modified files
- [x] CHANGELOG.md updated (0.32.10)
- [ ] CI — build must run on Linux (liburing / isa-l are Linux-only)

Closes #300