### PR TITLE
fix(bitmap): fix _dirty_chunks_est TOCTOU underflow in clean_region

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.32.11] - 2026-06-06
+
+### Fixed
+
+- **RAID1 bitmap `_dirty_chunks_est` TOCTOU underflow**: two concurrent `clean_region` callers could both `load()` the same counter value, compute the same delta, and both call `fetch_sub()` — the second subtract underflowed `uint64_t` to `UINT64_MAX`, causing `replica_states().bytes_to_sync` to report a bogus enormous value. Replaced the non-atomic `load + fetch_sub` pair with a CAS loop so each subtract is conditional on the value not having changed. Impact was P2/advisory only (`bytes_to_sync` and log messages); IO routing and resync correctness use `dirty_pages()` (actual bitmap scan) and were unaffected. Self-corrects at the next `dirty_pages()` call regardless. Addresses [issue #303](https://github.com/szmyd/ublkpp/issues/303).
+
 ## [0.32.10] - 2026-06-05
 
 ### Fixed

--- a/conanfile.py
+++ b/conanfile.py
@@ -10,7 +10,7 @@ required_conan_version = ">=2.0"
 
 class UBlkPPConan(ConanFile):
     name = "ublkpp"
-    version = "0.32.10"
+    version = "0.32.11"
 
     homepage = "https://github.com/szmyd/ublkpp"
     description = "A UBlk library for CPP application"

--- a/src/raid/raid1/bitmap.cpp
+++ b/src/raid/raid1/bitmap.cpp
@@ -321,10 +321,15 @@ std::tuple< Bitmap::word_t*, uint32_t, uint32_t > Bitmap::clean_region(uint64_t 
                                                              : (((uint64_t)0b1 << bits_to_write) - 1)
                                                  << (shift_offset - (bits_to_write - 1)));
         auto old_word = std::atomic_ref< word_t >(*cur_word).fetch_and(clear_mask, std::memory_order_relaxed);
-        _dirty_chunks_est.fetch_sub(
-            std::min(_dirty_chunks_est.load(std::memory_order_relaxed),
-                     static_cast< uint64_t >(std::popcount(old_word xor (old_word & clear_mask)))),
-            std::memory_order_relaxed);
+        auto const delta = static_cast< uint64_t >(std::popcount(old_word xor (old_word & clear_mask)));
+        // CAS loop: load+fetch_sub is not jointly atomic; two concurrent callers reading the same
+        // value would both subtract, underflowing to UINT64_MAX.
+        for (auto old = _dirty_chunks_est.load(std::memory_order_relaxed); old > 0;) {
+            auto const sub = std::min(old, delta);
+            if (_dirty_chunks_est.compare_exchange_weak(old, old - sub, std::memory_order_relaxed,
+                                                        std::memory_order_relaxed))
+                break;
+        }
         ++cur_word;
         shift_offset = bits_in_word - 1; // Word offset back to the beginning
     }

--- a/src/raid/raid1/tests/bitmap/clean_region.cpp
+++ b/src/raid/raid1/tests/bitmap/clean_region.cpp
@@ -1,3 +1,5 @@
+#include <thread>
+
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
@@ -71,6 +73,28 @@ TEST(Raid1CleanRegion, DirtyCleanDirtyCyclePreservesInvariant) {
     // And clean again
     bitmap.clean_region(0, 32 * Ki);
     EXPECT_EQ(0UL, bitmap.dirty_pages());
+}
+
+// Two threads calling clean_region on different chunks of the same page concurrently must not
+// underflow _dirty_chunks_est to UINT64_MAX. The old load+fetch_sub pair was not jointly atomic:
+// both threads could read the same counter value and both subtract, wrapping to UINT64_MAX.
+TEST(Raid1CleanRegion, ConcurrentCleanDoesNotUnderflowDirtyEst) {
+    auto sb = make_test_superbitmap();
+    auto bitmap = ublkpp::raid1::Bitmap(10 * Gi, 32 * Ki, 4 * Ki, sb.get());
+
+    // Dirty two adjacent chunks so _dirty_chunks_est == 2.
+    bitmap.dirty_region(0, 32 * Ki);
+    bitmap.dirty_region(32 * Ki, 32 * Ki);
+    EXPECT_EQ(2UL * 32 * Ki, bitmap.dirty_data_est());
+
+    // Clean both chunks from separate threads simultaneously.
+    std::thread t1([&] { bitmap.clean_region(0, 32 * Ki); });
+    std::thread t2([&] { bitmap.clean_region(32 * Ki, 32 * Ki); });
+    t1.join();
+    t2.join();
+
+    // Counter must be 0, not UINT64_MAX.
+    EXPECT_EQ(0UL, bitmap.dirty_data_est());
 }
 
 // Cleaning an already-clean page (no page allocated) is a safe no-op.


### PR DESCRIPTION
## Summary

Fixes the `_dirty_chunks_est` TOCTOU underflow reported in issue #303.

`clean_region` in `bitmap.cpp` performed two separate atomic operations — `load()` then `fetch_sub()` — with no CAS or mutex making them jointly atomic. Two concurrent `clean_region` callers could both observe the same counter value N, both compute `min(N, delta)`, and both call `fetch_sub()`. The second subtract underflowed `uint64_t` to `UINT64_MAX`.

**Impact:** P2/advisory only. `_dirty_chunks_est` feeds only `replica_states().bytes_to_sync` (user-facing info API) and resync log messages. IO routing and resync correctness use `dirty_pages()` (actual bitmap scan) and are unaffected. The counter self-corrects at the next `dirty_pages()` call via the existing clamp at `bitmap.cpp:293-295`.

## Fix

Replace the non-atomic `load + fetch_sub` pair with a CAS loop:

```cpp
auto const delta = static_cast<uint64_t>(std::popcount(old_word xor (old_word & clear_mask)));
for (auto old = _dirty_chunks_est.load(std::memory_order_relaxed); old > 0;) {
    auto const sub = std::min(old, delta);
    if (_dirty_chunks_est.compare_exchange_weak(old, old - sub,
            std::memory_order_relaxed, std::memory_order_relaxed))
        break;
}
```

If two threads race, the loser's `compare_exchange_weak` reloads the updated `old` and retries with a fresh `min(new_old, delta)` — no underflow possible.

## Test plan

- [x] `ConcurrentCleanDoesNotUnderflowDirtyEst`: two threads call `clean_region` on different chunks simultaneously; asserts `dirty_data_est() == 0` (not `UINT64_MAX`) after both join
- [x] Existing `clean_region` tests pass unchanged

Closes #303.