### PR TITLE
refactor(raid1): Site-1 SB retry, fix active_dev in no-op branch, RLOGW

### DIFF
--- a/src/raid/raid1/raid1.cpp
+++ b/src/raid/raid1/raid1.cpp
@@ -741,11 +741,35 @@ bool Raid1Disk::__become_degraded(bool failed_is_active, RouteState const* cur_s
     auto old_route = read_route::EITHER;
     auto const new_route = (failed_is_active == active_is_b) ? read_route::DEVA : read_route::DEVB;
     if (!_read_route_cache.compare_exchange_strong(old_route, new_route)) {
-        // CAS lost — either already degraded (idempotent) or __swap_device raced in.
-        // Either branch returns without touching _degraded_sb_pending, so any pending Site-2 retry
-        // in __try_persist_degraded_sb remains valid and will fire on the next I/O.
-        if (old_route == new_route) return true;
-        return false;
+        // CAS lost — either already degraded (no-op) or __swap_device raced in.
+        if (old_route == new_route) {
+            // Already degraded. If the initial SB write failed, retry it now so the caller can
+            // safely ack without forcing a client round-trip.
+            //
+            // Concurrent retry safety: _sb->fields is stable here — the original
+            // __become_degraded returned before toggle_resync(), so _degraded_sb_pending is
+            // only set when no resync task is running, and __become_clean cannot race without
+            // one. Two coroutines may both pass the load check before either clears the flag;
+            // the resulting concurrent write_superblock calls write identical data to the same
+            // offset and are therefore idempotent.
+            //
+            // cur_state may predate this degradation (e.g. a Site-1 retry passes the original
+            // EITHER-mode snapshot), so active_dev may point to the failed leg. Re-capture
+            // the route state to guarantee we write to the surviving device.
+            if (_degraded_sb_pending.load(std::memory_order_acquire)) {
+                auto const rs = __capture_route_state();
+                bool const is_b = (rs.route == read_route::DEVB);
+                if (auto sb = write_superblock(*rs.active_dev->disk, _sb.get(), is_b, rs.route); sb) {
+                    _degraded_sb_pending.store(false, std::memory_order_release);
+                    RLOGW("Persisted degraded superblock on retry [uuid:{}]", _str_uuid)
+                } else {
+                    RLOGE("SB persist retry failed [uuid:{}]: {}", _str_uuid, sb.error().message())
+                    return false;
+                }
+            }
+            return true;
+        }
+        return false; // __swap_device won the CAS
     }
 
     auto const backup_clean = (read_route::DEVB == new_route);
@@ -777,8 +801,8 @@ bool Raid1Disk::__become_degraded(bool failed_is_active, RouteState const* cur_s
         //
         // The age increment is NOT reverted: any subsequent SB write must carry a higher age than
         // the stale on-disk SB so pick_superblock selects the surviving device on restart.
-        // _degraded_sb_pending signals that the SB write is still outstanding; the next Site-2 I/O
-        // will retry it via __try_persist_degraded_sb before acking, closing the crash window.
+        // _degraded_sb_pending signals that the SB write is still outstanding; the next I/O
+        // that reaches the already-degraded path will retry it before acking.
         _degraded_sb_pending.store(true, std::memory_order_release);
         failed_device->unavail.test_and_set(std::memory_order_acq_rel);
         RLOGE("Could not persist degradation [uuid:{}]: {}", _str_uuid, sync_res.error().message())
@@ -787,31 +811,6 @@ bool Raid1Disk::__become_degraded(bool failed_is_active, RouteState const* cur_s
     failed_device->unavail.test_and_set(std::memory_order_acq_rel);
     if (spawn_resync && _resync_enabled.load(std::memory_order_relaxed)) toggle_resync(true); // Launch a Resync Task
     return true;
-}
-
-bool Raid1Disk::__try_persist_degraded_sb() {
-    // With nr_hw_queues > 1, two coroutines can both pass this check before either stores false.
-    // The resulting concurrent write_superblock calls write identical data to the same address and
-    // are therefore idempotent — the race is benign.
-    if (!_degraded_sb_pending.load(std::memory_order_acquire)) return true;
-
-    auto const rs = __capture_route_state();
-    if (rs.route == read_route::EITHER) {
-        // __become_clean already wrote clean SBs under the lock; the pending degradation SB no
-        // longer needs to be written (the resync task has already reconciled both devices).
-        _degraded_sb_pending.store(false, std::memory_order_release);
-        return true;
-    }
-
-    bool const is_device_b = (rs.route == read_route::DEVB);
-    if (auto sb = write_superblock(*rs.active_dev->disk, _sb.get(), is_device_b, rs.route); sb) {
-        _degraded_sb_pending.store(false, std::memory_order_release);
-        RLOGI("Persisted degraded superblock on retry [uuid:{}]", _str_uuid)
-        return true;
-    } else {
-        RLOGE("SB persist retry failed [uuid:{}]: {}", _str_uuid, sb.error().message())
-        return false;
-    }
 }
 
 disk_task< int > Raid1Disk::__failover_read_async(ublksrv_queue const* q, ublk_io_data const* data, iovec* iovecs,
@@ -928,9 +927,12 @@ disk_task< int > Raid1Disk::async_iov(ublksrv_queue const* q, ublk_io_data const
         DEBUG_ASSERT(!become_degraded_ok || backup_task.has_value(),
                      "backup_task must exist when become_degraded succeeds"); // LCOV_EXCL_BR_LINE
         auto const backup_res = co_await *backup_task;
-        // Degradation not persisted on disk: a crash here would self-heal from the stale active
-        // device, overwriting whatever the backup wrote. Return EAGAIN — the client must retry.
-        if (!become_degraded_ok) co_return -EAGAIN;
+        if (!become_degraded_ok) {
+            // Backup write landed but SB wasn't persisted. Attempt one retry before returning
+            // EAGAIN — avoids an unnecessary client round-trip for a transient SB write failure.
+            // __become_degraded sees the already-degraded route and fires the pending-retry path.
+            if (!__become_degraded(true, &state)) co_return -EAGAIN;
+        }
         co_return backup_res >= 0 ? backup_res
                                   : -EAGAIN; // -EAGAIN: degradation is durable; retry routes to sole device
     }
@@ -947,15 +949,9 @@ disk_task< int > Raid1Disk::async_iov(ublksrv_queue const* q, ublk_io_data const
         // region and need to be atomic with __become_clean). Here we still call __become_degraded
         // unconditionally so that if __become_clean released the mutex and transitioned to EITHER
         // before this dirty_region call, we re-degrade before ACKing. __become_degraded's own
-        // CAS(EITHER→DEVA) is the synchronization; no mutex needed because we're already past the
-        // transition window (the lock was already released before this point).
-        // Error intentionally discarded: the CAS already degraded the in-memory route;
-        // any SB write failure is logged inside __become_degraded.
-        std::ignore = __become_degraded(false, &state);
-        // If the initial __become_degraded SB write failed (Site 1 or 3), retry it now before
-        // acking. Without this, a crash leaves both on-disk SBs at EITHER while in-memory is
-        // DEVX, causing self-heal to resync stale data over the surviving device on restart.
-        if (!__try_persist_degraded_sb()) co_return -EAGAIN;
+        // CAS handles idempotency; if already degraded with a pending SB write, it retries the
+        // SB write before returning — ensuring the SB is durable before we ack.
+        if (!__become_degraded(false, &state)) co_return -EAGAIN;
         co_return active_res;
     }
 
@@ -1028,10 +1024,8 @@ io_result Raid1Disk::sync_iov(uint8_t op, iovec* iovecs, uint32_t nr_vecs, off_t
 
     if (!backup_write) {
         _dirty_bitmap->dirty_region(static_cast< uint64_t >(addr), len);
-        // Site 2 (sync) — see async_iov Site 2 comment; error intentionally discarded.
-        std::ignore = __become_degraded(false, &state);
-        // Retry SB persist before acking (mirrors async Site 2 — see that comment).
-        if (!__try_persist_degraded_sb())
+        // Site 2 (sync) — mirrors async_iov Site 2; see that comment.
+        if (!__become_degraded(false, &state))
             return std::unexpected(std::make_error_condition(std::errc::resource_unavailable_try_again));
         return active_res;
     }

--- a/src/raid/raid1/raid1_impl.hpp
+++ b/src/raid/raid1/raid1_impl.hpp
@@ -66,8 +66,8 @@ class Raid1Disk : public ublk_disk {
     // Set when __become_degraded updates the in-memory route but fails to persist the new route to
     // disk (transient SB write failure). The age increment is kept so any eventual SB write carries
     // a higher age than the stale on-disk SB, ensuring pick_superblock selects the correct device on
-    // restart. Cleared by __try_persist_degraded_sb once the SB write succeeds. If set at shutdown,
-    // the destructor's SB write naturally persists the correct route (it re-reads _read_route_cache).
+    // restart. Cleared by __become_degraded's already-degraded path on the next I/O. If set at
+    // shutdown, the destructor's SB write naturally persists the correct route.
     std::atomic< bool > _degraded_sb_pending{false};
 
     // Shared read/write routing helpers used by both async_iov and sync_iov.
@@ -84,11 +84,11 @@ class Raid1Disk : public ublk_disk {
 
     // Internal routines
     bool __become_clean();
+    // Transitions in-memory route from EITHER→DEVA/DEVB and persists the superblock. Returns true
+    // if the array is durably degraded (ack is safe); false if the SB write failed (caller must
+    // return -EAGAIN — a crash before the SB is written would corrupt self-heal direction).
+    // Idempotent when already degraded: retries a pending SB write if _degraded_sb_pending is set.
     bool __become_degraded(bool failed_is_active, RouteState const* state, bool spawn_resync = true);
-    // Retries the SB write when _degraded_sb_pending is set. Returns true if the SB was persisted
-    // (or no retry was needed); returns false if the write failed again, meaning the caller must
-    // not ack the current I/O (client retries on the next request).
-    bool __try_persist_degraded_sb();
     disk_task< int > __failover_read_async(ublksrv_queue const* q, ublk_io_data const* data, iovec* iovecs,
                                            uint32_t nr_vecs, uint64_t addr, uint32_t len);
     bool __swap_device(std::string const& outgoing_device_id, std::shared_ptr< MirrorDevice >& incoming_mirror,

--- a/src/raid/raid1/tests/asyncio/degraded.cpp
+++ b/src/raid/raid1/tests/asyncio/degraded.cpp
@@ -12,11 +12,14 @@ TEST_F(AsyncRaid1Fixture, BecomeDegradedSbFail) {
         .Times(AnyNumber())
         .WillRepeatedly([](uint8_t, iovec* iov, uint32_t, off_t) -> io_result { return iov->iov_len; });
 
-    // Intercept the superblock WRITE at addr=0 that __become_degraded issues to disk_b.
-    // Second WillOnce covers the clean-shutdown SB write after the test.
+    // Intercept the superblock WRITE at addr=0. Site 1's retry also fails, so three calls total:
+    // initial __become_degraded, Site-1 retry, clean-shutdown SB write after the test.
     EXPECT_CALL(*disk_b, sync_iov(UBLK_IO_OP_WRITE, _, _, 0))
-        .Times(2)
+        .Times(3)
         .WillOnce([](uint8_t, iovec*, uint32_t, off_t) -> io_result {
+            return std::unexpected(std::make_error_condition(std::errc::io_error));
+        })
+        .WillOnce([](uint8_t, iovec*, uint32_t, off_t) -> io_result { // Site-1 retry also fails
             return std::unexpected(std::make_error_condition(std::errc::io_error));
         })
         .WillOnce([](uint8_t, iovec* iov, uint32_t, off_t) -> io_result { return iov->iov_len; });
@@ -27,12 +30,44 @@ TEST_F(AsyncRaid1Fixture, BecomeDegradedSbFail) {
 
     // Active (disk_a) fails → __become_degraded fires, SB write to disk_b fails.
     EXPECT_TRUE(mock->inject_cqe(0, -EIO).empty());
-    // Backup (disk_b) succeeded, but degradation is not on disk → caller gets -EAGAIN.
+    // Backup (disk_b) succeeded; Site 1 retries SB but it fails again → caller gets -EAGAIN.
     auto completions = mock->inject_cqe(0, 4 * Ki);
     ASSERT_EQ(completions.size(), 1u);
     EXPECT_EQ(completions[0].result, -EAGAIN);
 
     // disk_a is ERROR in-memory; disk_b is the sole active device.
+    auto const states = raid->replica_states();
+    EXPECT_EQ(states.device_a, ublkpp::raid1::replica_state::ERROR);
+    EXPECT_EQ(states.device_b, ublkpp::raid1::replica_state::CLEAN);
+    EXPECT_GT(states.bytes_to_sync, 0u);
+}
+
+// Like BecomeDegradedSbFail, but the Site-1 SB retry succeeds: the backup result is acked
+// directly without forcing the client to retry.
+TEST_F(AsyncRaid1Fixture, BecomeDegradedSbFailRetrySucceeds) {
+    EXPECT_CALL(*disk_b, sync_iov(UBLK_IO_OP_WRITE, _, _, testing::Gt((off_t)0)))
+        .Times(AnyNumber())
+        .WillRepeatedly([](uint8_t, iovec* iov, uint32_t, off_t) -> io_result { return iov->iov_len; });
+
+    // SB writes at addr=0: initial __become_degraded fails, Site-1 retry succeeds, destructor.
+    EXPECT_CALL(*disk_b, sync_iov(UBLK_IO_OP_WRITE, _, _, 0))
+        .Times(3)
+        .WillOnce([](uint8_t, iovec*, uint32_t, off_t) -> io_result {
+            return std::unexpected(std::make_error_condition(std::errc::io_error));
+        })
+        .WillRepeatedly([](uint8_t, iovec* iov, uint32_t, off_t) -> io_result { return iov->iov_len; });
+
+    auto res = mock->submit_io(0, UBLK_IO_OP_WRITE, 0, 4 * Ki / 512, nullptr);
+    ASSERT_TRUE(res);
+    EXPECT_EQ(res.value(), 2u);
+
+    // Active (disk_a) fails → __become_degraded fires, SB write to disk_b fails.
+    EXPECT_TRUE(mock->inject_cqe(0, -EIO).empty());
+    // Backup (disk_b) succeeded; Site-1 retries the SB write and succeeds → ack backup result.
+    auto completions = mock->inject_cqe(0, 4 * Ki);
+    ASSERT_EQ(completions.size(), 1u);
+    EXPECT_EQ(completions[0].result, 4 * Ki);
+
     auto const states = raid->replica_states();
     EXPECT_EQ(states.device_a, ublkpp::raid1::replica_state::ERROR);
     EXPECT_EQ(states.device_b, ublkpp::raid1::replica_state::CLEAN);
@@ -66,15 +101,19 @@ TEST_F(AsyncRaid1Fixture, WriteAndSbUpdateBothFail) {
         .Times(AnyNumber())
         .WillRepeatedly([](uint8_t, iovec* iov, uint32_t, off_t) -> io_result { return iov->iov_len; });
 
-    // SB writes to disk_b at addr=0: Phase-1 fails, Phase-2 retry succeeds, destructor succeeds.
+    // SB writes to disk_b at addr=0: Phase-1 fails, Phase-1 retry fails, Phase-2 retry succeeds,
+    // destructor succeeds.
     EXPECT_CALL(*disk_b, sync_iov(UBLK_IO_OP_WRITE, _, _, (off_t)0))
-        .Times(3)
+        .Times(4)
         .WillOnce([](uint8_t, iovec*, uint32_t, off_t) -> io_result {
+            return std::unexpected(std::make_error_condition(std::errc::io_error));
+        })
+        .WillOnce([](uint8_t, iovec*, uint32_t, off_t) -> io_result { // Site-1 retry also fails
             return std::unexpected(std::make_error_condition(std::errc::io_error));
         })
         .WillRepeatedly([](uint8_t, iovec* iov, uint32_t, off_t) -> io_result { return iov->iov_len; });
 
-    // Phase 1: active -EIO → SB write fails → disk_a ERROR in-memory; backup result returned.
+    // Phase 1: active -EIO → SB write fails → Site-1 retry also fails → disk_a ERROR in-memory.
     {
         auto res = mock->submit_io(0, UBLK_IO_OP_WRITE, 0, 4 * Ki / 512, nullptr);
         ASSERT_TRUE(res);
@@ -140,23 +179,27 @@ TEST_F(AsyncRaid1Fixture, ReadAfterReplicaFail) {
 }
 
 // Phase 1: active (disk_a) fails; __become_degraded SB write to disk_b fails → _degraded_sb_pending set.
-// Phase 2: degraded write to disk_b succeeds; __try_persist_degraded_sb retries and succeeds → write
-//          is acked with the normal data result (no EIO). _degraded_sb_pending is cleared.
+// Phase 2: degraded write to disk_b succeeds; __become_degraded retries the SB write and succeeds →
+//          write is acked with the normal data result. _degraded_sb_pending is cleared.
 TEST_F(AsyncRaid1Fixture, DegradedSbPersistRetrySucceeds) {
     EXPECT_CALL(*disk_b, sync_iov(UBLK_IO_OP_WRITE, _, _, testing::Gt((off_t)0)))
         .Times(AnyNumber())
         .WillRepeatedly([](uint8_t, iovec* iov, uint32_t, off_t) -> io_result { return iov->iov_len; });
 
-    // SB writes to disk_b at addr=0: Phase-1 fails; Phase-2 retry and destructor succeed.
+    // SB writes to disk_b at addr=0: Phase-1 fails, Phase-1 retry fails, Phase-2 retry succeeds,
+    // destructor succeeds.
     EXPECT_CALL(*disk_b, sync_iov(UBLK_IO_OP_WRITE, _, _, (off_t)0))
-        .Times(3)
+        .Times(4)
         .WillOnce([](uint8_t, iovec*, uint32_t, off_t) -> io_result {
+            return std::unexpected(std::make_error_condition(std::errc::io_error));
+        })
+        .WillOnce([](uint8_t, iovec*, uint32_t, off_t) -> io_result { // Site-1 retry also fails
             return std::unexpected(std::make_error_condition(std::errc::io_error));
         })
         .WillRepeatedly([](uint8_t, iovec* iov, uint32_t, off_t) -> io_result { return iov->iov_len; });
 
-    // Phase 1: disk_a fails → SB write fails → _degraded_sb_pending set. Site 1 returns -EAGAIN
-    //          because the degradation is not yet on disk (client must retry).
+    // Phase 1: disk_a fails → SB write fails → Site-1 retry also fails → _degraded_sb_pending set.
+    //          Returns -EAGAIN because the degradation is not yet on disk (client must retry).
     {
         auto res = mock->submit_io(0, UBLK_IO_OP_WRITE, 0, 4 * Ki / 512, nullptr);
         ASSERT_TRUE(res);
@@ -185,17 +228,21 @@ TEST_F(AsyncRaid1Fixture, DegradedSbPersistRetrySucceeds) {
 }
 
 // Phase 1: active (disk_a) fails; __become_degraded SB write to disk_b fails → _degraded_sb_pending set.
-// Phase 2: degraded write to disk_b succeeds; __try_persist_degraded_sb retries but fails again →
+// Phase 2: degraded write to disk_b succeeds; __become_degraded retries the SB write but fails again →
 //          write is NOT acked (EAGAIN returned). _degraded_sb_pending remains set until destructor.
 TEST_F(AsyncRaid1Fixture, DegradedSbPersistRetryFails) {
     EXPECT_CALL(*disk_b, sync_iov(UBLK_IO_OP_WRITE, _, _, testing::Gt((off_t)0)))
         .Times(AnyNumber())
         .WillRepeatedly([](uint8_t, iovec* iov, uint32_t, off_t) -> io_result { return iov->iov_len; });
 
-    // SB writes to disk_b at addr=0: Phase-1 fails, Phase-2 retry fails, destructor succeeds.
+    // SB writes to disk_b at addr=0: Phase-1 fails, Phase-1 retry fails, Phase-2 retry fails,
+    // destructor succeeds.
     EXPECT_CALL(*disk_b, sync_iov(UBLK_IO_OP_WRITE, _, _, (off_t)0))
-        .Times(3)
+        .Times(4)
         .WillOnce([](uint8_t, iovec*, uint32_t, off_t) -> io_result {
+            return std::unexpected(std::make_error_condition(std::errc::io_error));
+        })
+        .WillOnce([](uint8_t, iovec*, uint32_t, off_t) -> io_result { // Site-1 retry also fails
             return std::unexpected(std::make_error_condition(std::errc::io_error));
         })
         .WillOnce([](uint8_t, iovec*, uint32_t, off_t) -> io_result {
@@ -203,8 +250,8 @@ TEST_F(AsyncRaid1Fixture, DegradedSbPersistRetryFails) {
         })
         .WillOnce([](uint8_t, iovec* iov, uint32_t, off_t) -> io_result { return iov->iov_len; });
 
-    // Phase 1: disk_a fails → SB write fails → _degraded_sb_pending set. Site 1 returns -EAGAIN
-    //          because the degradation is not yet on disk (client must retry).
+    // Phase 1: disk_a fails → SB write fails → Site-1 retry also fails → _degraded_sb_pending set.
+    //          Returns -EAGAIN because the degradation is not yet on disk (client must retry).
     {
         auto res = mock->submit_io(0, UBLK_IO_OP_WRITE, 0, 4 * Ki / 512, nullptr);
         ASSERT_TRUE(res);


### PR DESCRIPTION
## Summary

Follow-up to #305 addressing three items from reviewer feedback:

- **Site-1 SB retry**: after the backup write drains and `!become_degraded_ok`, call `__become_degraded` once more before returning `-EAGAIN`. The CAS sees the already-degraded route and fires the `_degraded_sb_pending` retry path. A transient SB failure no longer forces a guaranteed extra client round-trip when the retry succeeds.

- **Fix `active_dev` in CAS no-op branch**: previously used `cur_state->active_dev->disk` for the retry write, which is wrong when the caller passes a pre-degradation (`EITHER`-mode) snapshot — `active_dev` then points to the failed leg. Switch to `__capture_route_state()` to always name the surviving device correctly.

- **`RLOGI` → `RLOGW`** on the retry-success log; expand the concurrent-retry safety comment to explain the deeper invariant (`_sb->fields` is stable because no resync task runs and `__become_clean` cannot race).

## Test plan

- [ ] `BecomeDegradedSbFail`: `Times(2→3)` — Site-1 retry also fails → still `-EAGAIN`
- [ ] `BecomeDegradedSbFailRetrySucceeds`: new test — Site-1 retry succeeds → `backup_res` acked directly
- [ ] `WriteAndSbUpdateBothFail`, `DegradedSbPersistRetrySucceeds`, `DegradedSbPersistRetryFails`: each gain one `WillOnce` for the Site-1 retry (`Times(3→4)`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)