### PR TITLE
fix(raid1): close CAS/_degraded_sb_pending window and guard double to…

### DIFF
--- a/src/raid/raid1/raid1.cpp
+++ b/src/raid/raid1/raid1.cpp
@@ -382,10 +382,10 @@ Raid1Disk::prepare_result Raid1Disk::prepare(ublksrv_queue const* q, int const i
 // If both race, the loser sees the CAS fail and returns early - no further state is mutated.
 // No additional lock is needed between them; the CAS IS the synchronization gate.
 //
-// __swap_device also holds _ctrl_lock so that two concurrent swap_device() callers don't race
-// on the _device_a/_device_b pointer mutations.  __become_degraded does not need _ctrl_lock for
-// those pointer reads (it accesses them via a captured RouteState snapshot), but it does acquire
-// _ctrl_lock for the bitmap.age increment to avoid a data race with __swap_device's +16 bump.
+// Both __swap_device and __become_degraded hold _ctrl_lock across their CAS so the CAS, age
+// increment, and flag mutations are atomic with respect to each other. __swap_device holds the
+// lock for its entire SB write; __become_degraded releases after marking _degraded_sb_pending=true
+// and writes the SB outside the lock.
 // ─────────────────────────────────────────────────────────────────────────────────────────────────
 //
 // The order of the _read_route_cache CAS, swap(), and unavail.clear() below must be preserved to keep
@@ -730,12 +730,14 @@ bool Raid1Disk::__become_clean() {
     return true;
 }
 
-// _degraded_sb_pending is guarded by _ctrl_lock. __become_degraded acquires the lock immediately
-// after the CAS and stores true before calling write_superblock, so any concurrent queue thread
-// that lost the CAS and enters here must also acquire the lock before reading the flag — it
-// cannot see false while T1's write is in flight.
-// Two coroutines may both pass the check before either clears the flag; the resulting
-// concurrent write_superblock calls write identical data to the same offset and are idempotent.
+// _degraded_sb_pending is guarded by _ctrl_lock. __become_degraded does its CAS and stores
+// true under the same lock scope, so any concurrent caller that loses the CAS and enters here
+// must also acquire the lock before reading the flag — it sees true or waits.
+// Two coroutines may both pass the initial check before either clears the flag; both
+// write_superblock calls are idempotent (same data, same offset). Only the first to clear the
+// flag calls toggle_resync; a second concurrent launch() on an already-running task would
+// acquire _launch_lock, see state==IDLE (thread not yet transitioned), join the running thread,
+// and relaunch — stalling an I/O-path coroutine for the full resync duration.
 //
 // cur_state may predate this degradation (e.g. a Site-1 retry passes the original EITHER-mode
 // snapshot), so active_dev may point to the failed leg. Re-capture the route state to guarantee
@@ -748,12 +750,16 @@ bool Raid1Disk::__try_persist_degraded_sb(bool spawn_resync) {
     auto const rs = __capture_route_state();
     bool const is_b = (rs.route == read_route::DEVB);
     if (auto sb = write_superblock(*rs.active_dev->disk, _sb.get(), is_b, rs.route); sb) {
+        bool was_pending;
         {
             std::lock_guard lock(_ctrl_lock);
+            was_pending = _degraded_sb_pending;
             _degraded_sb_pending = false;
         }
         RLOGI("Persisted degraded superblock on retry [uuid:{}]", _str_uuid)
-        if (spawn_resync && _resync_enabled.load(std::memory_order_relaxed)) toggle_resync(true);
+        // Only the first coroutine to clear the flag triggers resync; a second concurrent
+        // launch() could otherwise join a running resync thread from an I/O-path coroutine.
+        if (was_pending && spawn_resync && _resync_enabled.load(std::memory_order_relaxed)) toggle_resync(true);
     } else {
         RLOGE("SB persist retry failed [uuid:{}]: {}", _str_uuid, sb.error().message())
         return false;
@@ -761,37 +767,39 @@ bool Raid1Disk::__try_persist_degraded_sb(bool spawn_resync) {
     return true;
 }
 
-// See the comment above __swap_device for the CAS-based mutual exclusion between this function
-// and __swap_device.  The _read_route_cache CAS below is the synchronization gate: if
-// __swap_device wins the CAS first, this call sees old_route != EITHER and returns early (already
-// degraded or concurrent swap in progress).  No additional lock is required.
+// See the comment above __swap_device for the lock-based mutual exclusion between this function
+// and __swap_device. Both hold _ctrl_lock across their CAS, so the winner is determined under
+// the lock. The loser sees old_route != EITHER and returns early (already degraded or swap
+// in progress).
 bool Raid1Disk::__become_degraded(bool failed_is_active, RouteState const* cur_state, bool spawn_resync) {
     // Surviving device is backup if active failed, active if backup failed.
     // new_route = the physical slot (DEVA/DEVB) of the surviving device.
     bool const active_is_b = (cur_state->route == read_route::DEVB);
     auto old_route = read_route::EITHER;
     auto const new_route = (failed_is_active == active_is_b) ? read_route::DEVA : read_route::DEVB;
-    if (!_read_route_cache.compare_exchange_strong(old_route, new_route)) {
-        // CAS lost — either already degraded (no-op) or __swap_device raced in.
-        if (old_route == new_route) return __try_persist_degraded_sb(spawn_resync);
-        return false; // __swap_device won the CAS
-    }
-
-    // backup_clean is a pure function of new_route, which is fixed before the lock.
     bool const backup_clean = (read_route::DEVB == new_route);
-    // No concurrency-sensitive code between the CAS and lock.
-    // A concurrent queue thread (T2) that lost the CAS and calls __try_persist_degraded_sb
-    // must also acquire _ctrl_lock before reading _degraded_sb_pending; it cannot see false
-    // while we hold the lock with true already stored. Pointer lookups are moved inside;
-    // they are semantically free there: cur_state outlives this call.
+
+    // CAS and _degraded_sb_pending=true are done under the same _ctrl_lock scope so there is
+    // no window where a concurrent __try_persist_degraded_sb caller could acquire the lock,
+    // read _degraded_sb_pending==false, and prematurely ack while our SB write is in-flight.
+    // __swap_device also holds _ctrl_lock for its CAS, so both state-machine transitions are
+    // fully serialized through the lock. old_route holds the actual route on CAS failure.
     std::shared_ptr< MirrorDevice > failed_device;
     std::shared_ptr< ublk_disk > working_disk;
     {
         std::lock_guard lock(_ctrl_lock);
-        failed_device = failed_is_active ? cur_state->active_dev : cur_state->backup_dev;
-        working_disk = failed_is_active ? cur_state->backup_dev->disk : cur_state->active_dev->disk;
-        _sb->fields.bitmap.age = htobe64(be64toh(_sb->fields.bitmap.age) + 1);
-        _degraded_sb_pending = true;
+        if (_read_route_cache.compare_exchange_strong(old_route, new_route)) {
+            failed_device = failed_is_active ? cur_state->active_dev : cur_state->backup_dev;
+            working_disk = failed_is_active ? cur_state->backup_dev->disk : cur_state->active_dev->disk;
+            _sb->fields.bitmap.age = htobe64(be64toh(_sb->fields.bitmap.age) + 1);
+            _degraded_sb_pending = true;
+        }
+        // else: CAS lost — old_route holds the actual current value; failed_device stays null.
+    }
+    if (old_route != read_route::EITHER) {
+        // CAS lost — either already degraded (no-op) or __swap_device raced in.
+        if (old_route == new_route) return __try_persist_degraded_sb(spawn_resync);
+        return false; // __swap_device won the CAS
     }
     auto& working_device = *working_disk;
     RLOGW("Device became degraded {} [age:{}] [uuid:{}]", *failed_device->disk,

--- a/src/raid/raid1/tests/syncio/degraded.cpp
+++ b/src/raid/raid1/tests/syncio/degraded.cpp
@@ -1,8 +1,13 @@
+// SyncIoDegradedSbPersistRetryFails
 // Phase 1: active (raw_a) write succeeds, backup (raw_b) write fails; __become_degraded SB write
 // to raw_a also fails → resource_unavailable_try_again. _degraded_sb_pending set.
 // Phase 2: array in DEVA mode (raw_b ERROR); sync write routes to raw_a only (Site 2 — backup
 // unavailable). __become_degraded delegates to __try_persist_degraded_sb; SB retry also fails →
 // resource_unavailable_try_again. _degraded_sb_pending remains set until destructor.
+//
+// SyncIoDegradedSbPersistRetrySucceeds
+// Phase 1: same as above.
+// Phase 2: Site 2 fires; __try_persist_degraded_sb retry succeeds → write returns success.
 
 #include "test_raid1_common.hpp"
 
@@ -69,5 +74,60 @@ TEST(Raid1, SyncIoDegradedSbPersistRetryFails) {
         auto const res = raid_device.sync_iov(UBLK_IO_OP_WRITE, &iov, 1, 16 * Ki);
         ASSERT_FALSE(res);
         EXPECT_EQ(std::errc::resource_unavailable_try_again, res.error());
+    }
+}
+
+TEST(Raid1, SyncIoDegradedSbPersistRetrySucceeds) {
+    auto raw_a = std::make_shared< StrictMock< ublkpp::TestDisk > >(TestParams{.capacity = Gi});
+    auto raw_b = std::make_shared< StrictMock< ublkpp::TestDisk > >(TestParams{.capacity = Gi, .is_slot_b = true});
+
+    EXPECT_CALL(*raw_a, sync_iov(UBLK_IO_OP_READ, _, _, _))
+        .Times(AnyNumber())
+        .WillRepeatedly([](uint8_t, iovec* iov, uint32_t, off_t) -> io_result {
+            if (iov->iov_base) memcpy(iov->iov_base, &normal_superblock, ublkpp::raid1::k_page_size);
+            return ublkpp::raid1::k_page_size;
+        });
+    EXPECT_CALL(*raw_b, sync_iov(UBLK_IO_OP_READ, _, _, _))
+        .Times(AnyNumber())
+        .WillRepeatedly([](uint8_t, iovec* iov, uint32_t, off_t) -> io_result {
+            if (iov->iov_base) {
+                memcpy(iov->iov_base, &normal_superblock, ublkpp::raid1::k_page_size);
+                static_cast< ublkpp::raid1::SuperBlock* >(iov->iov_base)->fields.device_b = 1;
+            }
+            return ublkpp::raid1::k_page_size;
+        });
+    EXPECT_CALL(*raw_a, sync_iov(UBLK_IO_OP_WRITE, _, _, testing::Ne((off_t)0)))
+        .Times(AnyNumber())
+        .WillRepeatedly([](uint8_t, iovec* iov, uint32_t, off_t) -> io_result { return iov->iov_len; });
+    EXPECT_CALL(*raw_b, sync_iov(UBLK_IO_OP_WRITE, _, _, _))
+        .WillOnce([](uint8_t, iovec*, uint32_t, off_t) -> io_result {
+            return std::unexpected(std::make_error_condition(std::errc::io_error));
+        });
+    // SB writes to raw_a at offset 0: Phase-1 fails, Phase-2 retry succeeds, destructor succeeds.
+    EXPECT_CALL(*raw_a, sync_iov(UBLK_IO_OP_WRITE, _, _, (off_t)0))
+        .WillOnce([](uint8_t, iovec*, uint32_t, off_t) -> io_result {
+            return std::unexpected(std::make_error_condition(std::errc::io_error));
+        })
+        .WillRepeatedly([](uint8_t, iovec* iov, uint32_t, off_t) -> io_result { return iov->iov_len; });
+
+    auto raid_device = ublkpp::raid1::Raid1Disk(boost::uuids::string_generator()(test_uuid), raw_a, raw_b);
+    raid_device.toggle_resync(false);
+
+    auto const test_sz = static_cast< size_t >(4 * Ki);
+
+    // Phase 1: active succeeds, backup fails → __become_degraded (Site 3) → SB write fails.
+    {
+        iovec iov{nullptr, test_sz};
+        auto const res = raid_device.sync_iov(UBLK_IO_OP_WRITE, &iov, 1, 8 * Ki);
+        ASSERT_FALSE(res);
+        EXPECT_EQ(std::errc::resource_unavailable_try_again, res.error());
+    }
+
+    // Phase 2: DEVA mode, raw_b unavailable → Site 2 fires → __try_persist_degraded_sb succeeds.
+    {
+        iovec iov{nullptr, test_sz};
+        auto const res = raid_device.sync_iov(UBLK_IO_OP_WRITE, &iov, 1, 16 * Ki);
+        ASSERT_TRUE(res);
+        EXPECT_EQ(test_sz, *res);
     }
 }


### PR DESCRIPTION
…ggle_resync

Three follow-up fixes for the _degraded_sb_pending correctness story:

1. CAS race: move the _read_route_cache CAS inside _ctrl_lock in __become_degraded so the CAS win and the _degraded_sb_pending=true store are atomic with respect to the lock. Previously, a concurrent __try_persist_degraded_sb caller could acquire _ctrl_lock in the gap between the CAS and the lock, read false, and prematurely ack its I/O while the SB write was still in-flight. __swap_device already holds _ctrl_lock for its CAS, so this unifies both state-machine transitions under the same serialization point.

2. toggle_resync guard: use the cleared-pending CAS result (was_pending) in __try_persist_degraded_sb to ensure only the first coroutine to clear the flag calls toggle_resync. A second concurrent launch() on a task that hasn't yet transitioned from IDLE to ACTIVE would join the running thread — stalling an I/O-path coroutine for the full resync duration.

3. Test: add SyncIoDegradedSbPersistRetrySucceeds to cover the sync Site-2 path where Phase-2's __try_persist_degraded_sb retry succeeds.