### PR TITLE
fix(raid0,raid1): DISCARD pool crash + RAID1 superblock version guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.32.13] - 2026-06-10
+
+### Fixed
+
+- **P1 (raid0): DISCARD/WRITE_ZEROES crashes file-backed arrays with more disks than the read/write stripe count**: `prepare()` sized the CQE pool using the read/write fan-out formula `stripes_for_io(max_tx, stripe_size, N)`, which caps at `k = min(ceil(max_tx/stripe_size)+1, N)`. The DISCARD path in `async_iov` always fans out to all N disks via `merged_subcmds`, consuming one pool slot per disk. For N > k (e.g., 10 disks, stripe_size=128 KiB, max_tx=512 KiB → k=5), `RELEASE_ASSERT_LT(_pool.size(), _pool.capacity())` fired on the (k+1)th disk's `next_state()` call — process crash. Fixed by removing the k-bound from `prepare()`: all N children contribute to `max_sqes_per_io`. Over-allocation by (N-k) slots in the read/write path is harmless.
+- **Latent (raid1): superblock with version > current not rejected at open**: `load_superblock` had no upper-bound version check, silently accepting a disk formatted by a future binary. `__init_params`'s one-sided `if (sb_version < 2)` branch would compute `_reserved_size` using the v2 formula, placing all I/O at the wrong on-disk offset on a hypothetical v3 disk. Fixed by adding the M3 guard (mirrors RAID0's existing check): any superblock with `version > k_sb_version` is now rejected with `errc::not_supported`. Also exports `k_sb_version` from `raid1_superblock.hpp` so tests can reference it.
+
 ## [0.32.12] - 2026-06-06
 
 ### Fixed

--- a/conanfile.py
+++ b/conanfile.py
@@ -10,7 +10,7 @@ required_conan_version = ">=2.0"
 
 class UBlkPPConan(ConanFile):
     name = "ublkpp"
-    version = "0.32.12"
+    version = "0.32.13"
 
     homepage = "https://github.com/szmyd/ublkpp"
     description = "A UBlk library for CPP application"

--- a/src/raid/raid0/raid0.cpp
+++ b/src/raid/raid0/raid0.cpp
@@ -195,16 +195,14 @@ static inline size_t stripes_for_io(size_t io_size, size_t stripe_size, size_t n
 
 Raid0Disk::prepare_result Raid0Disk::prepare(ublksrv_queue const* q, int const iouring_device_start) {
     prepare_result result;
-    result.max_sqes_per_io = 0;
-    // At most k stripes are active concurrently per max-size I/O. Each active stripe dispatches
-    // one child async_iov that submits child.max_sqes_per_io SQEs into the shared pool. Sum the
-    // first k contributions (homogeneous arrays: all equal, so order is irrelevant).
-    auto const k = stripes_for_io(max_tx(), _stripe_size, _stripe_array.size());
-    size_t counted = 0;
+    // Sum all N children: DISCARD/WRITE_ZEROES always fans out to every disk via merged_subcmds,
+    // consuming one pool slot per disk regardless of I/O size. The READ/WRITE path caps fan-out
+    // at k = stripes_for_io(max_tx) ≤ N, so the pool is over-allocated by at most (N-k) slots
+    // in the read/write case — harmless; under-allocation on DISCARD is a P1 crash.
     for (auto& stripe : _stripe_array) {
         auto child = stripe->disk->prepare(q, iouring_device_start + static_cast< int >(result.fds.size()));
         result.fds.insert(result.fds.end(), child.fds.begin(), child.fds.end());
-        if (counted++ < k) result.max_sqes_per_io += child.max_sqes_per_io;
+        result.max_sqes_per_io += child.max_sqes_per_io;
     }
     return result;
 }

--- a/src/raid/raid0/raid0.cpp
+++ b/src/raid/raid0/raid0.cpp
@@ -195,6 +195,7 @@ static inline size_t stripes_for_io(size_t io_size, size_t stripe_size, size_t n
 
 Raid0Disk::prepare_result Raid0Disk::prepare(ublksrv_queue const* q, int const iouring_device_start) {
     prepare_result result;
+    result.max_sqes_per_io = 0;
     // Sum all N children: DISCARD/WRITE_ZEROES always fans out to every disk via merged_subcmds,
     // consuming one pool slot per disk regardless of I/O size. The READ/WRITE path caps fan-out
     // at k = stripes_for_io(max_tx) ≤ N, so the pool is over-allocated by at most (N-k) slots

--- a/src/raid/raid0/tests/simple/CMakeLists.txt
+++ b/src/raid/raid0/tests/simple/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required (VERSION 3.11)
 
 list(APPEND RAID0_TEST_SRCS
+  simple/discard.cpp
   simple/get_device.cpp
   simple/syncio.cpp
 )

--- a/src/raid/raid0/tests/simple/discard.cpp
+++ b/src/raid/raid0/tests/simple/discard.cpp
@@ -1,0 +1,22 @@
+#include "test_raid0_common.hpp"
+
+// Verifies that Raid0Disk::prepare() sizes the CQE pool for the DISCARD fan-out of N disks,
+// not the read/write fan-out k = stripes_for_io(max_tx, stripe_size, N).
+//
+// With stripe_size=128 KiB and max_tx=512 KiB, k = min((512/128)+1, N) = min(5, N).
+// For N=10: k=5 < N=10. Before the fix, prepare() accumulated only 5 children's
+// max_sqes_per_io; a full-stride DISCARD consuming all 10 pool slots hit RELEASE_ASSERT.
+TEST(Raid0PreparePoolSize, DiscardFanoutRequiresAllChildren) {
+    constexpr uint32_t kN = 10;
+    std::vector< std::shared_ptr< ublk_disk > > disks;
+    for (uint32_t i = 0; i < kN; ++i) {
+        auto d = CREATE_DISK(TestParams{.capacity = Gi});
+        EXPECT_CALL(*d, prepare(_, _))
+            .Times(::testing::AnyNumber())
+            .WillRepeatedly(Return(ublk_disk::prepare_result{.max_sqes_per_io = 1}));
+        disks.push_back(std::move(d));
+    }
+    auto raid = ublkpp::make_raid0_disk(boost::uuids::string_generator{}(test_uuid), 128 * Ki, std::move(disks));
+    auto result = raid->prepare(nullptr, 0);
+    EXPECT_EQ(result.max_sqes_per_io, kN);
+}

--- a/src/raid/raid1/raid1_superblock.cpp
+++ b/src/raid/raid1/raid1_superblock.cpp
@@ -49,8 +49,6 @@ raid1::SuperBlock* pick_superblock(raid1::SuperBlock* dev_a, raid1::SuperBlock* 
 static const uint8_t magic_bytes[16] = {0123, 045, 0377, 012, 064,  0231, 076, 0305,
                                         0147, 072, 0310, 027, 0111, 0256, 033, 0144};
 
-constexpr auto SB_VERSION = 2;
-
 static raid1::SuperBlock* read_superblock(ublk_disk& device) {
     auto const sb_size = sizeof(raid1::SuperBlock);
     DEBUG_ASSERT_EQ(0, sb_size % device.block_size(), "Device {} blocksize does not support alignment of [{}B]", device,
@@ -128,6 +126,11 @@ load_superblock(ublk_disk& device, boost::uuids::uuid const& uuid, uint32_t cons
         RLOGE("Superblock did not have a matching UUID expected: {} read: {}", to_string(uuid), to_string(read_uuid))
         return std::unexpected(std::make_error_condition(std::errc::invalid_argument));
     }
+    if (be16toh(sb->header.version) > k_sb_version) {
+        RLOGE("Superblock version {:#0x} is newer than supported {:#0x} — refusing to open",
+              be16toh(sb->header.version), k_sb_version)
+        return std::unexpected(std::make_error_condition(std::errc::not_supported));
+    }
     if (chunk_size != be32toh(sb->fields.bitmap.chunk_size)) {
         RLOGW("Superblock was created with different chunk_size: [{}B] will not use runtime config of [{}B] "
               "[uuid:{}] ",
@@ -136,7 +139,7 @@ load_superblock(ublk_disk& device, boost::uuids::uuid const& uuid, uint32_t cons
 
     if (was_new) {
         // Fresh device — stamp with current version.
-        sb->header.version = htobe16(SB_VERSION);
+        sb->header.version = htobe16(k_sb_version);
     }
     // Existing disks keep their on-disk version. __init_params branches on version to reconstruct
     // the original _reserved_size formula (v1: capacity-proportional, v2+: fixed k_superbitmap_bits).

--- a/src/raid/raid1/raid1_superblock.hpp
+++ b/src/raid/raid1/raid1_superblock.hpp
@@ -16,6 +16,7 @@ namespace ublkpp {
 
 namespace raid1 {
 constexpr auto const k_bits_in_byte = 8UL;
+constexpr uint16_t k_sb_version = 2;
 //  Cap some array parameters so we can make simple assumptions later
 constexpr auto k_min_chunk_size = 32 * Ki;
 // Use a single bit to represent each chunk

--- a/src/raid/raid1/tests/superblock/version_check.cpp
+++ b/src/raid/raid1/tests/superblock/version_check.cpp
@@ -101,3 +101,22 @@ TEST(Raid1, NewArrayWritesV2Superblock) {
     EXPECT_TO_WRITE_SB(device_a);
     EXPECT_TO_WRITE_SB(device_b);
 }
+
+// A superblock with version > k_sb_version must be rejected — mirrors RAID0's M3 guard.
+// device_b is StrictMock: the constructor must throw before ever reaching it.
+TEST(Raid1, FutureSuperblockVersionThrows) {
+    auto future_sb = normal_superblock;
+    future_sb.header.version = htobe16(ublkpp::raid1::k_sb_version + 1);
+
+    auto device_a = std::make_shared< ublkpp::TestDisk >(TestParams{.capacity = Gi});
+    EXPECT_CALL(*device_a, sync_iov(UBLK_IO_OP_READ, _, _, _))
+        .Times(1)
+        .WillOnce([&future_sb](uint8_t, iovec* iovecs, uint32_t, off_t) -> io_result {
+            memcpy(iovecs->iov_base, &future_sb, ublkpp::raid1::k_page_size);
+            return ublkpp::raid1::k_page_size;
+        });
+    auto device_b = std::make_shared< ::testing::StrictMock< ublkpp::TestDisk > >(TestParams{.capacity = Gi});
+
+    EXPECT_THROW(ublkpp::raid1::Raid1Disk(boost::uuids::string_generator()(test_uuid), device_a, device_b),
+                 std::runtime_error);
+}


### PR DESCRIPTION
## Summary

- **B1 (P1 crash) — RAID0 DISCARD pool exhaustion**: `prepare()` sized the CQE pool using the read/write fan-out formula `stripes_for_io(max_tx, stripe_size, N)` = `min(k, N)`. The DISCARD/WRITE_ZEROES path in `async_iov` always fans out to all N disks via `merged_subcmds`, consuming one `next_state()` pool slot per disk. For N > k (e.g., 10 disks, stripe_size=128 KiB, max_tx=512 KiB → k=5), `RELEASE_ASSERT_LT(_pool.size(), _pool.capacity())` fired on the (k+1)th disk's call — process crash on any file-backed RAID0 DISCARD.
- **E1 (latent) — RAID1 missing superblock version upper bound**: `load_superblock` had no guard against `version > SB_VERSION`, unlike RAID0's M3 check. A disk written by a future binary would be silently accepted; `__init_params`'s one-sided `if (sb_version < 2)` branch would compute `_reserved_size` using the v2 formula, placing all I/O at the wrong on-disk offset. Also exports `k_sb_version` from `raid1_superblock.hpp` (previously a file-local `SB_VERSION`).

## Changes

### B1 — `src/raid/raid0/raid0.cpp`
- `prepare()`: remove the `stripes_for_io` k-bound; always accumulate `max_sqes_per_io` across all N children. `stripes_for_io` is still used in `async_iov` for `stripe_tasks.reserve()` — unaffected.
- New test: `Raid0PreparePoolSize.DiscardFanoutRequiresAllChildren` in `simple/discard.cpp` — asserts `prepare()` returns `max_sqes_per_io == N` for 10 mocked children each returning 1. Pre-fix this returned 5 (k-bounded); post-fix it returns 10.

### E1 — `src/raid/raid1/raid1_superblock.*`
- `raid1_superblock.hpp`: export `constexpr uint16_t k_sb_version = 2` in `ublkpp::raid1` namespace.
- `raid1_superblock.cpp`: remove file-local `SB_VERSION`; add version upper-bound guard in `load_superblock` after the UUID check — returns `errc::not_supported` for any `version > k_sb_version`. New devices have `version=0` (memset), so the guard is safe to place unconditionally.
- New test: `Raid1.FutureSuperblockVersionThrows` in `version_check.cpp` — mirrors the RAID0 `FutureSuperblockVersionThrows` pattern.

## Test plan

- [ ] CI: `GccAddressSanitize`, `GccThreadSanitize`, `GccCoverage`, `ClangRelease` all green
- [ ] `Raid0PreparePoolSize.DiscardFanoutRequiresAllChildren` passes — pool sized to N=10, not k=5
- [ ] `Raid1.FutureSuperblockVersionThrows` passes — constructor throws on version=3 superblock
- [ ] Existing RAID0 and RAID1 tests unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)