### PR TITLE
fix(raid1): hold _clean_transition_mutex in Site-2 async_iov path (P0 data loss)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **RAID1 (P0)**: Site 2 (`async_iov`/`sync_iov`, backup-unavail path) called `dirty_region()` and `__become_degraded()` without holding `_clean_transition_mutex`, unlike Sites 1 and 3.
 - A concurrent `__become_clean` could write EITHER superblocks after Site 2's DEVA write, leaving both devices at EITHER+equal-age on crash; `pick_superblock` tie-broke to round-robin, serving stale data from B against an acknowledged write.
-- Fixed by wrapping `__become_degraded()` in `_clean_transition_mutex` at all six failure sites (async + sync, Sites 1–3). `dirty_region()` moved lock-free before the mutex at all sites.
+- Fixed by wrapping `dirty_region()` + `__become_degraded()` together inside `_clean_transition_mutex` at all six failure sites (async + sync, Sites 1–3), making `dirty_pages()` a hard gate against premature clean transitions.
 
 ## [0.32.13] - 2026-06-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.32.14] - 2026-06-10
+
+### Fixed
+
+- **P0 (raid1): data loss when backup is unavailable and __become_clean races __become_degraded**: in `async_iov` Site 2 (backup-unavail path), `dirty_region()` and `__become_degraded()` were not guarded by `_clean_transition_mutex`. A concurrent `__become_clean` (T1) could CAS DEVA→EITHER and write EITHER superblocks inside its mutex, then have those writes land on disk *after* T2's `__become_degraded` DEVA write — because T2 was not serialised. If the process crashed before H1 (the post-mutex defense-in-depth) re-wrote the DEVA SBs, both devices held EITHER at the same age; restart opened in round-robin mode with B returning stale data against an acknowledged write. Fixed by wrapping Site 2's `dirty_region() + __become_degraded()` in a `std::lock_guard` on `_clean_transition_mutex`, matching Sites 1 and 3. With the mutex, T2's DEVA write always lands after T1's EITHER writes, so `pick_superblock` selects the DEVA device by age on any crash, eliminating the stale-B read path.
+
 ## [0.32.13] - 2026-06-10
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **P0 (raid1): data loss when backup is unavailable and `__become_clean` races `__become_degraded`**:
-  - **Race**: in `async_iov` and `sync_iov` Site 2 (backup-unavail path), `__become_degraded()` was not guarded by `_clean_transition_mutex`. A concurrent `__become_clean` (T1) could CAS DEVA→EITHER and write EITHER superblocks inside its mutex, then have those writes land on disk *after* T2's `__become_degraded` DEVA write — because T2 was not serialised.
-  - **Crash window**: if the process crashed before H1 (the post-mutex defense-in-depth) re-wrote the DEVA SBs, both devices held EITHER at the same age; restart opened in round-robin mode with B returning stale data against an acknowledged write.
-  - **Fix**: `__become_degraded()` at all six failure sites (async + sync, Sites 1/2/3) now holds `_clean_transition_mutex`; `dirty_region()` is called lock-free immediately before. With the mutex, T2's DEVA write always lands after T1's EITHER writes, so `pick_superblock` selects the DEVA device by age on any crash, eliminating the stale-B read path.
+- **RAID1 (P0)**: Site 2 (`async_iov`/`sync_iov`, backup-unavail path) called `dirty_region()` and `__become_degraded()` without holding `_clean_transition_mutex`, unlike Sites 1 and 3.
+- A concurrent `__become_clean` could write EITHER superblocks after Site 2's DEVA write, leaving both devices at EITHER+equal-age on crash; `pick_superblock` tie-broke to round-robin, serving stale data from B against an acknowledged write.
+- Fixed by wrapping `__become_degraded()` in `_clean_transition_mutex` at all six failure sites (async + sync, Sites 1–3). `dirty_region()` moved lock-free before the mutex at all sites.
 
 ## [0.32.13] - 2026-06-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **P0 (raid1): data loss when backup is unavailable and __become_clean races __become_degraded**: in `async_iov` Site 2 (backup-unavail path), `dirty_region()` and `__become_degraded()` were not guarded by `_clean_transition_mutex`. A concurrent `__become_clean` (T1) could CAS DEVA→EITHER and write EITHER superblocks inside its mutex, then have those writes land on disk *after* T2's `__become_degraded` DEVA write — because T2 was not serialised. If the process crashed before H1 (the post-mutex defense-in-depth) re-wrote the DEVA SBs, both devices held EITHER at the same age; restart opened in round-robin mode with B returning stale data against an acknowledged write. Fixed by wrapping Site 2's `dirty_region() + __become_degraded()` in a `std::lock_guard` on `_clean_transition_mutex`, matching Sites 1 and 3. With the mutex, T2's DEVA write always lands after T1's EITHER writes, so `pick_superblock` selects the DEVA device by age on any crash, eliminating the stale-B read path.
+- **P0 (raid1): data loss when backup is unavailable and `__become_clean` races `__become_degraded`**:
+  - **Race**: in `async_iov` and `sync_iov` Site 2 (backup-unavail path), `__become_degraded()` was not guarded by `_clean_transition_mutex`. A concurrent `__become_clean` (T1) could CAS DEVA→EITHER and write EITHER superblocks inside its mutex, then have those writes land on disk *after* T2's `__become_degraded` DEVA write — because T2 was not serialised.
+  - **Crash window**: if the process crashed before H1 (the post-mutex defense-in-depth) re-wrote the DEVA SBs, both devices held EITHER at the same age; restart opened in round-robin mode with B returning stale data against an acknowledged write.
+  - **Fix**: `__become_degraded()` at all six failure sites (async + sync, Sites 1/2/3) now holds `_clean_transition_mutex`; `dirty_region()` is called lock-free immediately before. With the mutex, T2's DEVA write always lands after T1's EITHER writes, so `pick_superblock` selects the DEVA device by age on any crash, eliminating the stale-B read path.
 
 ## [0.32.13] - 2026-06-10
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -10,7 +10,7 @@ required_conan_version = ">=2.0"
 
 class UBlkPPConan(ConanFile):
     name = "ublkpp"
-    version = "0.32.13"
+    version = "0.32.14"
 
     homepage = "https://github.com/szmyd/ublkpp"
     description = "A UBlk library for CPP application"

--- a/src/raid/raid1/raid1.cpp
+++ b/src/raid/raid1/raid1.cpp
@@ -668,14 +668,14 @@ bool Raid1Disk::__become_clean() {
     // The on-disk ordering guarantee: T2 cannot write DEVX SBs until T1 releases, so
     // EITHER SBs always land before any DEVX SBs.
     // Two crash cases:
-    //   - Before failure site acquires lock for __become_degraded(): only EITHER SBs on
-    //     disk; dirty bits are in-memory only and lost on crash — see residual crash window
-    //     below. The system APPEARS clean on restart even if one device has newer data.
+    //   - Before failure site acquires the lock: only EITHER SBs on disk; dirty bits are
+    //     in-memory only and lost on crash — see residual crash window below. The system
+    //     APPEARS clean on restart even if one device has newer data.
     //   - After failure site's DEVA SB write: working_dev=DEVA(age+1), other=EITHER →
     //     pick_superblock selects by age → DEVA route → resync → safe.
     //
     // Residual crash window (not closed by the mutex): process crashes after a failure site
-    // calls dirty_region() (lock-free) but before __become_degraded() completes its
+    // acquires the lock and calls dirty_region() but before __become_degraded() completes its
     // write_superblock() I/O. In that window, dirty bits are in-memory only (lost on crash)
     // and both SBs say EITHER at the same age — no resync is triggered on restart. Closing
     // this window requires additional on-disk metadata (a "last-active slot" field) to

--- a/src/raid/raid1/raid1.cpp
+++ b/src/raid/raid1/raid1.cpp
@@ -706,9 +706,10 @@ bool Raid1Disk::__become_clean() {
     } // lock released; both EITHER SBs are on disk
 
     // H1 defense-in-depth: if a failure path moved route away from EITHER after our lock
-    // released (e.g. __swap_device raced and remapped the slots), re-write the on-disk SBs
-    // with the current degraded route. A fresh capture is used so device pointers are
-    // coherent with live_route.
+    // released (e.g. __swap_device raced and remapped the slots, or a failure site won the
+    // EITHER→DEVA CAS between our release and this check), re-write the on-disk SBs with
+    // the current degraded route. A fresh capture is used so device pointers are coherent
+    // with live_route.
     auto const live_state = __capture_route_state();
     if (live_state.route != read_route::EITHER) {
         bool const live_active_is_b = (live_state.route == read_route::DEVB);

--- a/src/raid/raid1/raid1.cpp
+++ b/src/raid/raid1/raid1.cpp
@@ -681,7 +681,7 @@ bool Raid1Disk::__become_clean() {
     // (only acquired on resync completion and on write-leg failures).
     {
         std::lock_guard lock(_clean_transition_mutex);
-        if (_dirty_bitmap->dirty_pages() > 0) return false; // bits set under lock → stay degraded
+        if (_dirty_bitmap->dirty_pages() > 0) return false; // bits already set → stay degraded
 
         auto old_route = state.route;
         if (!_read_route_cache.compare_exchange_strong(old_route, read_route::EITHER))
@@ -1028,8 +1028,9 @@ io_result Raid1Disk::sync_iov(uint8_t op, iovec* iovecs, uint32_t nr_vecs, off_t
     auto const active_res = state.active_dev->disk->sync_iov(op, iovecs, nr_vecs, adj_addr);
 
     if (!active_res) {
-        std::lock_guard lock(_clean_transition_mutex); // site 1 (sync)
+        // Site 1 (sync): dirty_region() is lock-free; only __become_degraded() needs the mutex.
         _dirty_bitmap->dirty_region(static_cast< uint64_t >(addr), len);
+        std::lock_guard lock(_clean_transition_mutex);
         if (auto d = __become_degraded(true, &state); !d)
             return std::unexpected(std::make_error_condition(std::errc::resource_unavailable_try_again));
         // become_degraded succeeded → state was EITHER → bm was WRITE → backup is reachable.
@@ -1046,10 +1047,11 @@ io_result Raid1Disk::sync_iov(uint8_t op, iovec* iovecs, uint32_t nr_vecs, off_t
     }
 
     if (!backup_write) {
-        // Site 2 (sync): hold _clean_transition_mutex — same race as async_iov Site 2.
+        // Site 2 (sync): dirty_region() is lock-free; __become_degraded() holds the mutex to
+        // order its DEVA SB write after __become_clean's EITHER SB writes.
+        _dirty_bitmap->dirty_region(static_cast< uint64_t >(addr), len);
         bool const become_degraded_ok = [&] {
             std::lock_guard lock(_clean_transition_mutex);
-            _dirty_bitmap->dirty_region(static_cast< uint64_t >(addr), len);
             return __become_degraded(false, &state);
         }();
         if (!become_degraded_ok)
@@ -1060,8 +1062,9 @@ io_result Raid1Disk::sync_iov(uint8_t op, iovec* iovecs, uint32_t nr_vecs, off_t
     auto const backup_res = state.backup_dev->disk->sync_iov(op, iovecs, nr_vecs, adj_addr);
 
     if (!backup_res) {
-        std::lock_guard lock(_clean_transition_mutex); // site 3 (sync)
+        // Site 3 (sync): dirty_region() is lock-free; only __become_degraded() needs the mutex.
         _dirty_bitmap->dirty_region(static_cast< uint64_t >(addr), len);
+        std::lock_guard lock(_clean_transition_mutex);
         if (auto d = __become_degraded(false, &state); !d)
             return std::unexpected(std::make_error_condition(std::errc::resource_unavailable_try_again));
     } else if (state.backup_dev->unavail.test(std::memory_order_relaxed)) {

--- a/src/raid/raid1/raid1.cpp
+++ b/src/raid/raid1/raid1.cpp
@@ -982,9 +982,8 @@ disk_task< int > Raid1Disk::async_iov(ublksrv_queue const* q, ublk_io_data const
     auto const backup_res = co_await *backup_task;
 
     if (backup_res < 0) {
-        // Site 3: backup fails with backup_write==true — newly dirties a clean region.
-        // dirty_region() is lock-free; __become_degraded() needs the mutex to order its
-        // DEVA SB write after __become_clean's EITHER SB writes. No co_await under the lock.
+        // Site 3: dirty_region() is lock-free; direct lock_guard is fine here — no co_await
+        // follows, so the mutex scopes naturally to the end of this if-block.
         _dirty_bitmap->dirty_region(addr, len);
         std::lock_guard lock(_clean_transition_mutex);
         if (auto d = __become_degraded(false, &state); !d) co_return -EAGAIN;
@@ -1029,15 +1028,15 @@ io_result Raid1Disk::sync_iov(uint8_t op, iovec* iovecs, uint32_t nr_vecs, off_t
     auto const active_res = state.active_dev->disk->sync_iov(op, iovecs, nr_vecs, adj_addr);
 
     if (!active_res) {
-        // Site 1 (sync): dirty_region() is lock-free; only __become_degraded() needs the mutex.
-        // Narrow the lock scope so the backup disk I/O runs outside _clean_transition_mutex,
-        // matching the async_iov Site 1 pattern.
+        // Site 1 (sync): dirty_region() is lock-free; lambda scopes the mutex so the backup
+        // disk I/O runs outside _clean_transition_mutex, matching async_iov Site 1.
         _dirty_bitmap->dirty_region(static_cast< uint64_t >(addr), len);
-        {
+        bool const become_degraded_ok = [&] {
             std::lock_guard lock(_clean_transition_mutex);
-            if (auto d = __become_degraded(true, &state); !d)
-                return std::unexpected(std::make_error_condition(std::errc::resource_unavailable_try_again));
-        }
+            return __become_degraded(true, &state);
+        }();
+        if (!become_degraded_ok)
+            return std::unexpected(std::make_error_condition(std::errc::resource_unavailable_try_again));
         // become_degraded succeeded → state was EITHER → bm was WRITE → backup is reachable.
         DEBUG_ASSERT(backup_write,
                      "backup_write must be true when become_degraded succeeds"); // LCOV_EXCL_BR_LINE
@@ -1067,7 +1066,8 @@ io_result Raid1Disk::sync_iov(uint8_t op, iovec* iovecs, uint32_t nr_vecs, off_t
     auto const backup_res = state.backup_dev->disk->sync_iov(op, iovecs, nr_vecs, adj_addr);
 
     if (!backup_res) {
-        // Site 3 (sync): dirty_region() is lock-free; only __become_degraded() needs the mutex.
+        // Site 3 (sync): dirty_region() is lock-free; direct lock_guard is fine here — no
+        // disk I/O follows, so the mutex scopes naturally to the end of this if-block.
         _dirty_bitmap->dirty_region(static_cast< uint64_t >(addr), len);
         std::lock_guard lock(_clean_transition_mutex);
         if (auto d = __become_degraded(false, &state); !d)

--- a/src/raid/raid1/raid1.cpp
+++ b/src/raid/raid1/raid1.cpp
@@ -662,7 +662,7 @@ bool Raid1Disk::__become_clean() {
 
     // _clean_transition_mutex is held across check + CAS + both superblock writes.
     //
-    // The lock serializes this path against Sites 1 & 3 (backup_write=true failures),
+    // The lock serializes this path against Sites 1, 2 & 3 (all three failure paths),
     // which also hold the lock during dirty_region() + __become_degraded(). Two crash cases:
     //   - Before failure site acquires lock: only EITHER SBs on disk, no dirty bit set
     //     (dirty_region is inside the lock) → system is genuinely clean.
@@ -705,9 +705,9 @@ bool Raid1Disk::__become_clean() {
     } // lock released; both EITHER SBs are on disk
 
     // H1 defense-in-depth: if a failure path moved route away from EITHER after our lock
-    // released (e.g. __swap_device, or a Site-2 __become_degraded without the mutex), re-write
-    // the on-disk SBs with the current degraded route. A fresh capture is used so device
-    // pointers are coherent with live_route even if __swap_device raced and remapped the slots.
+    // released (e.g. __swap_device raced and remapped the slots), re-write the on-disk SBs
+    // with the current degraded route. A fresh capture is used so device pointers are
+    // coherent with live_route.
     auto const live_state = __capture_route_state();
     if (live_state.route != read_route::EITHER) {
         bool const live_active_is_b = (live_state.route == read_route::DEVB);
@@ -962,15 +962,19 @@ disk_task< int > Raid1Disk::async_iov(ublksrv_queue const* q, ublk_io_data const
     }
 
     if (!backup_write) {
-        _dirty_bitmap->dirty_region(addr, len);
-        // Site 2: no mutex — this path fires when backup is unavail or the region was already
-        // dirty. The mutex was designed to exclude Sites 1 and 3 (which newly dirty a clean
-        // region and need to be atomic with __become_clean). Here we still call __become_degraded
-        // unconditionally so that if __become_clean released the mutex and transitioned to EITHER
-        // before this dirty_region call, we re-degrade before ACKing. __become_degraded's own
-        // CAS handles idempotency; if already degraded with a pending SB write, it retries the
-        // SB write before returning — ensuring the SB is durable before we ack.
-        if (!__become_degraded(false, &state)) co_return -EAGAIN;
+        // Site 2: hold _clean_transition_mutex — matches Sites 1 and 3. Without it,
+        // __become_clean's EITHER SB writes (inside its mutex) can overwrite
+        // __become_degraded's DEVA write on disk, leaving EITHER on both devices if
+        // the process crashes before H1 corrects it — stale reads from B against an
+        // acknowledged write (data loss). Serialising under the mutex guarantees T2's
+        // DEVA write lands after T1's EITHER writes, so pick_superblock selects the
+        // DEVA device by age on restart.
+        bool const become_degraded_ok = [&] {
+            std::lock_guard lock(_clean_transition_mutex);
+            _dirty_bitmap->dirty_region(addr, len);
+            return __become_degraded(false, &state);
+        }();
+        if (!become_degraded_ok) co_return -EAGAIN;
         co_return active_res;
     }
 

--- a/src/raid/raid1/raid1.cpp
+++ b/src/raid/raid1/raid1.cpp
@@ -643,8 +643,8 @@ std::pair< std::shared_ptr< ublk_disk >, std::shared_ptr< ublk_disk > > Raid1Dis
 // Returns true if the array successfully transitioned to EITHER (clean superblocks written),
 // or if another concurrent path already won the EITHER CAS (idempotent).
 // Returns false in three cases that require the caller to keep resyncing:
-//   (a) Site-2 dirty_region() set bits before the lock was acquired — dirty_pages() > 0 under
-//       the lock; route stays degraded and the CAS is not attempted.
+//   (a) A failure site's dirty_region() set bits before the lock was acquired —
+//       dirty_pages() > 0 under the lock; route stays degraded and the CAS is not attempted.
 //   (b) __swap_device raced and changed the route before our CAS — old_route != EITHER.
 //   (c) post-write: __become_degraded fired during superblock I/O — H1 re-writes with a fresh
 //       route+device capture (coherent across swap races) and returns false.
@@ -663,14 +663,15 @@ bool Raid1Disk::__become_clean() {
     // _clean_transition_mutex is held across check + CAS + both superblock writes.
     //
     // The lock serializes this path against Sites 1, 2 & 3 (all three failure paths),
-    // which also hold the lock during dirty_region() + __become_degraded(). Two crash cases:
-    //   - Before failure site acquires lock: only EITHER SBs on disk, no dirty bit set
-    //     (dirty_region is inside the lock) → system is genuinely clean.
+    // whose __become_degraded() is also under this lock. dirty_region() is always called
+    // lock-free before the mutex is acquired. Two crash cases:
+    //   - Before failure site acquires lock: only EITHER SBs on disk; dirty bits are
+    //     in-memory only and lost on crash → system is genuinely clean on restart.
     //   - After failure site's DEVA SB write: working_dev=DEVA(age+1), other=EITHER →
     //     pick_superblock selects by age → DEVA route → resync → safe.
     //
-    // Residual crash window (not closed by the mutex): process crashes after Sites 1/3
-    // acquire the lock and call dirty_region() but before __become_degraded() completes its
+    // Residual crash window (not closed by the mutex): process crashes after a failure site
+    // calls dirty_region() (lock-free) but before __become_degraded() completes its
     // write_superblock() I/O. In that window, dirty bits are in-memory only (lost on crash)
     // and both SBs say EITHER at the same age — no resync is triggered on restart. Closing
     // this window requires additional on-disk metadata (a "last-active slot" field) to
@@ -938,10 +939,11 @@ disk_task< int > Raid1Disk::async_iov(ublksrv_queue const* q, ublk_io_data const
 
     if (active_res < 0) {
         // Site 1: active fails with backup_write==true — newly dirties a clean region.
-        // Lock covers only dirty_region + __become_degraded; co_awaits happen after release.
+        // dirty_region() is lock-free; only __become_degraded() needs the mutex to order
+        // its DEVA SB write after __become_clean's EITHER SB writes.
+        _dirty_bitmap->dirty_region(addr, len);
         bool const become_degraded_ok = [&] {
             std::lock_guard lock(_clean_transition_mutex);
-            _dirty_bitmap->dirty_region(addr, len);
             return __become_degraded(true, &state);
         }();
         // CAS lost and no backup to drain — nothing to await.
@@ -962,16 +964,14 @@ disk_task< int > Raid1Disk::async_iov(ublksrv_queue const* q, ublk_io_data const
     }
 
     if (!backup_write) {
-        // Site 2: hold _clean_transition_mutex — matches Sites 1 and 3. Without it,
-        // __become_clean's EITHER SB writes (inside its mutex) can overwrite
-        // __become_degraded's DEVA write on disk, leaving EITHER on both devices if
-        // the process crashes before H1 corrects it — stale reads from B against an
-        // acknowledged write (data loss). Serialising under the mutex guarantees T2's
-        // DEVA write lands after T1's EITHER writes, so pick_superblock selects the
-        // DEVA device by age on restart.
+        // Site 2: dirty_region() is lock-free; __become_degraded() holds
+        // _clean_transition_mutex to order its DEVA SB write after __become_clean's EITHER
+        // SB writes. Without the mutex, a concurrent __become_clean could write EITHER SBs
+        // after __become_degraded's DEVA SB, leaving EITHER on both devices on crash —
+        // stale reads from B against an ACK (data loss).
+        _dirty_bitmap->dirty_region(addr, len);
         bool const become_degraded_ok = [&] {
             std::lock_guard lock(_clean_transition_mutex);
-            _dirty_bitmap->dirty_region(addr, len);
             return __become_degraded(false, &state);
         }();
         if (!become_degraded_ok) co_return -EAGAIN;
@@ -982,10 +982,10 @@ disk_task< int > Raid1Disk::async_iov(ublksrv_queue const* q, ublk_io_data const
 
     if (backup_res < 0) {
         // Site 3: backup fails with backup_write==true — newly dirties a clean region.
-        // Hold _clean_transition_mutex so dirty_region + become_degraded are atomic against
-        // __become_clean's check+CAS. No co_await under the lock.
-        std::lock_guard lock(_clean_transition_mutex);
+        // dirty_region() is lock-free; __become_degraded() needs the mutex to order its
+        // DEVA SB write after __become_clean's EITHER SB writes. No co_await under the lock.
         _dirty_bitmap->dirty_region(addr, len);
+        std::lock_guard lock(_clean_transition_mutex);
         if (auto d = __become_degraded(false, &state); !d) co_return -EAGAIN;
     } else if (state.backup_dev->unavail.test(std::memory_order_relaxed)) {
         RLOGI("Device {} back online (write succeeded) [uuid:{}]", *state.backup_dev->disk, _str_uuid)

--- a/src/raid/raid1/raid1.cpp
+++ b/src/raid/raid1/raid1.cpp
@@ -1029,10 +1029,14 @@ io_result Raid1Disk::sync_iov(uint8_t op, iovec* iovecs, uint32_t nr_vecs, off_t
 
     if (!active_res) {
         // Site 1 (sync): dirty_region() is lock-free; only __become_degraded() needs the mutex.
+        // Narrow the lock scope so the backup disk I/O runs outside _clean_transition_mutex,
+        // matching the async_iov Site 1 pattern.
         _dirty_bitmap->dirty_region(static_cast< uint64_t >(addr), len);
-        std::lock_guard lock(_clean_transition_mutex);
-        if (auto d = __become_degraded(true, &state); !d)
-            return std::unexpected(std::make_error_condition(std::errc::resource_unavailable_try_again));
+        {
+            std::lock_guard lock(_clean_transition_mutex);
+            if (auto d = __become_degraded(true, &state); !d)
+                return std::unexpected(std::make_error_condition(std::errc::resource_unavailable_try_again));
+        }
         // become_degraded succeeded → state was EITHER → bm was WRITE → backup is reachable.
         DEBUG_ASSERT(backup_write,
                      "backup_write must be true when become_degraded succeeds"); // LCOV_EXCL_BR_LINE

--- a/src/raid/raid1/raid1.cpp
+++ b/src/raid/raid1/raid1.cpp
@@ -663,10 +663,14 @@ bool Raid1Disk::__become_clean() {
     // _clean_transition_mutex is held across check + CAS + both superblock writes.
     //
     // The lock serializes this path against Sites 1, 2 & 3 (all three failure paths),
-    // whose __become_degraded() is also under this lock. dirty_region() is always called
-    // lock-free before the mutex is acquired. Two crash cases:
-    //   - Before failure site acquires lock: only EITHER SBs on disk; dirty bits are
-    //     in-memory only and lost on crash → system is genuinely clean on restart.
+    // whose dirty_region() + __become_degraded() are also inside the lock. dirty_pages()
+    // is therefore a hard gate: no in-flight region can be set after this check returns 0.
+    // The on-disk ordering guarantee: T2 cannot write DEVX SBs until T1 releases, so
+    // EITHER SBs always land before any DEVX SBs.
+    // Two crash cases:
+    //   - Before failure site acquires lock for __become_degraded(): only EITHER SBs on
+    //     disk; dirty bits are in-memory only and lost on crash — see residual crash window
+    //     below. The system APPEARS clean on restart even if one device has newer data.
     //   - After failure site's DEVA SB write: working_dev=DEVA(age+1), other=EITHER →
     //     pick_superblock selects by age → DEVA route → resync → safe.
     //
@@ -940,11 +944,11 @@ disk_task< int > Raid1Disk::async_iov(ublksrv_queue const* q, ublk_io_data const
 
     if (active_res < 0) {
         // Site 1: active fails with backup_write==true — newly dirties a clean region.
-        // dirty_region() is lock-free; only __become_degraded() needs the mutex to order
-        // its DEVA SB write after __become_clean's EITHER SB writes.
-        _dirty_bitmap->dirty_region(addr, len);
+        // dirty_region() is inside the mutex so __become_clean's dirty_pages() gate
+        // cannot pass while this region is in-flight.
         bool const become_degraded_ok = [&] {
             std::lock_guard lock(_clean_transition_mutex);
+            _dirty_bitmap->dirty_region(addr, len);
             return __become_degraded(true, &state);
         }();
         // CAS lost and no backup to drain — nothing to await.
@@ -965,14 +969,11 @@ disk_task< int > Raid1Disk::async_iov(ublksrv_queue const* q, ublk_io_data const
     }
 
     if (!backup_write) {
-        // Site 2: dirty_region() is lock-free; __become_degraded() holds
-        // _clean_transition_mutex to order its DEVA SB write after __become_clean's EITHER
-        // SB writes. Without the mutex, a concurrent __become_clean could write EITHER SBs
-        // after __become_degraded's DEVA SB, leaving EITHER on both devices on crash —
-        // stale reads from B against an ACK (data loss).
-        _dirty_bitmap->dirty_region(addr, len);
+        // Site 2: backup unavailable — dirty_region() is inside the mutex so
+        // __become_clean's dirty_pages() gate cannot pass while this region is in-flight.
         bool const become_degraded_ok = [&] {
             std::lock_guard lock(_clean_transition_mutex);
+            _dirty_bitmap->dirty_region(addr, len);
             return __become_degraded(false, &state);
         }();
         if (!become_degraded_ok) co_return -EAGAIN;
@@ -982,10 +983,10 @@ disk_task< int > Raid1Disk::async_iov(ublksrv_queue const* q, ublk_io_data const
     auto const backup_res = co_await *backup_task;
 
     if (backup_res < 0) {
-        // Site 3: dirty_region() is lock-free; direct lock_guard is fine here — no co_await
-        // follows, so the mutex scopes naturally to the end of this if-block.
-        _dirty_bitmap->dirty_region(addr, len);
+        // Site 3: backup write failed — dirty_region() is inside the mutex so
+        // __become_clean's dirty_pages() gate cannot pass while this region is in-flight.
         std::lock_guard lock(_clean_transition_mutex);
+        _dirty_bitmap->dirty_region(addr, len);
         if (auto d = __become_degraded(false, &state); !d) co_return -EAGAIN;
     } else if (state.backup_dev->unavail.test(std::memory_order_relaxed)) {
         RLOGI("Device {} back online (write succeeded) [uuid:{}]", *state.backup_dev->disk, _str_uuid)
@@ -1028,11 +1029,11 @@ io_result Raid1Disk::sync_iov(uint8_t op, iovec* iovecs, uint32_t nr_vecs, off_t
     auto const active_res = state.active_dev->disk->sync_iov(op, iovecs, nr_vecs, adj_addr);
 
     if (!active_res) {
-        // Site 1 (sync): dirty_region() is lock-free; lambda scopes the mutex so the backup
-        // disk I/O runs outside _clean_transition_mutex, matching async_iov Site 1.
-        _dirty_bitmap->dirty_region(static_cast< uint64_t >(addr), len);
+        // Site 1 (sync): active fails — dirty_region() is inside the mutex so
+        // __become_clean's dirty_pages() gate cannot pass while this region is in-flight.
         bool const become_degraded_ok = [&] {
             std::lock_guard lock(_clean_transition_mutex);
+            _dirty_bitmap->dirty_region(static_cast< uint64_t >(addr), len);
             return __become_degraded(true, &state);
         }();
         if (!become_degraded_ok)
@@ -1051,11 +1052,11 @@ io_result Raid1Disk::sync_iov(uint8_t op, iovec* iovecs, uint32_t nr_vecs, off_t
     }
 
     if (!backup_write) {
-        // Site 2 (sync): dirty_region() is lock-free; __become_degraded() holds the mutex to
-        // order its DEVA SB write after __become_clean's EITHER SB writes.
-        _dirty_bitmap->dirty_region(static_cast< uint64_t >(addr), len);
+        // Site 2 (sync): backup unavailable — dirty_region() is inside the mutex so
+        // __become_clean's dirty_pages() gate cannot pass while this region is in-flight.
         bool const become_degraded_ok = [&] {
             std::lock_guard lock(_clean_transition_mutex);
+            _dirty_bitmap->dirty_region(static_cast< uint64_t >(addr), len);
             return __become_degraded(false, &state);
         }();
         if (!become_degraded_ok)
@@ -1066,10 +1067,10 @@ io_result Raid1Disk::sync_iov(uint8_t op, iovec* iovecs, uint32_t nr_vecs, off_t
     auto const backup_res = state.backup_dev->disk->sync_iov(op, iovecs, nr_vecs, adj_addr);
 
     if (!backup_res) {
-        // Site 3 (sync): dirty_region() is lock-free; direct lock_guard is fine here — no
-        // disk I/O follows, so the mutex scopes naturally to the end of this if-block.
-        _dirty_bitmap->dirty_region(static_cast< uint64_t >(addr), len);
+        // Site 3 (sync): backup write failed — dirty_region() is inside the mutex so
+        // __become_clean's dirty_pages() gate cannot pass while this region is in-flight.
         std::lock_guard lock(_clean_transition_mutex);
+        _dirty_bitmap->dirty_region(static_cast< uint64_t >(addr), len);
         if (auto d = __become_degraded(false, &state); !d)
             return std::unexpected(std::make_error_condition(std::errc::resource_unavailable_try_again));
     } else if (state.backup_dev->unavail.test(std::memory_order_relaxed)) {

--- a/src/raid/raid1/raid1.cpp
+++ b/src/raid/raid1/raid1.cpp
@@ -1046,9 +1046,13 @@ io_result Raid1Disk::sync_iov(uint8_t op, iovec* iovecs, uint32_t nr_vecs, off_t
     }
 
     if (!backup_write) {
-        _dirty_bitmap->dirty_region(static_cast< uint64_t >(addr), len);
-        // Site 2 (sync) — mirrors async_iov Site 2; see that comment.
-        if (!__become_degraded(false, &state))
+        // Site 2 (sync): hold _clean_transition_mutex — same race as async_iov Site 2.
+        bool const become_degraded_ok = [&] {
+            std::lock_guard lock(_clean_transition_mutex);
+            _dirty_bitmap->dirty_region(static_cast< uint64_t >(addr), len);
+            return __become_degraded(false, &state);
+        }();
+        if (!become_degraded_ok)
             return std::unexpected(std::make_error_condition(std::errc::resource_unavailable_try_again));
         return active_res;
     }

--- a/src/raid/raid1/raid1_impl.hpp
+++ b/src/raid/raid1/raid1_impl.hpp
@@ -51,13 +51,14 @@ class Raid1Disk : public ublk_disk {
     //         (2) _pending_results - serializes prepare() insertions across queue threads.
     std::mutex _ctrl_lock;
 
-    // Guards __become_clean's check + CAS + superblock writes against the two cold failure-path
-    // dirty_region() + __become_degraded() sites (active-fail and backup-fail with backup_write
-    // true). Holding the lock across both the check+CAS and the SB writes ensures:
+    // Guards __become_clean's check + CAS + superblock writes against all three cold failure-path
+    // dirty_region() + __become_degraded() sites: active-fail (Site 1, backup_write=true),
+    // backup-unavail (Site 2, backup_write=false), and backup-fail (Site 3, backup_write=true).
+    // Holding the lock across both the check+CAS and the SB writes ensures:
     //   (a) No EITHER-with-dirty-bit instant visible to lock-free readers (live P0).
     //   (b) Failure-path DEVA SB writes always serialize after EITHER SB writes, so the
     //       on-disk SBs cannot show EITHER+dirty on crash (crash-recovery P0).
-    // The hot write path (!backup_write re-dirty) must NOT hold this lock.
+    // The success path (both legs succeed) must NOT hold this lock.
     std::mutex _clean_transition_mutex;
 
     // Counts prepare() calls; used to enable resync on the first queue init.

--- a/src/raid/raid1/raid1_impl.hpp
+++ b/src/raid/raid1/raid1_impl.hpp
@@ -52,13 +52,13 @@ class Raid1Disk : public ublk_disk {
     std::mutex _ctrl_lock;
 
     // Guards __become_clean's check + CAS + superblock writes against all three cold failure-path
-    // dirty_region() + __become_degraded() sites: active-fail (Site 1, backup_write=true),
-    // backup-unavail (Site 2, backup_write=false), and backup-fail (Site 3, backup_write=true).
+    // __become_degraded() calls: active-fail (Site 1), backup-unavail (Site 2), backup-fail
+    // (Site 3). dirty_region() is always called lock-free before the mutex is acquired.
     // Holding the lock across both the check+CAS and the SB writes ensures:
     //   (a) No EITHER-with-dirty-bit instant visible to lock-free readers (live P0).
     //   (b) Failure-path DEVA SB writes always serialize after EITHER SB writes, so the
     //       on-disk SBs cannot show EITHER+dirty on crash (crash-recovery P0).
-    // The success path (both legs succeed) must NOT hold this lock.
+    // Neither the success path (both legs succeed) nor dirty_region() must hold this lock.
     std::mutex _clean_transition_mutex;
 
     // Counts prepare() calls; used to enable resync on the first queue init.

--- a/src/raid/raid1/raid1_impl.hpp
+++ b/src/raid/raid1/raid1_impl.hpp
@@ -52,13 +52,14 @@ class Raid1Disk : public ublk_disk {
     std::mutex _ctrl_lock;
 
     // Guards __become_clean's check + CAS + superblock writes against all three cold failure-path
-    // __become_degraded() calls: active-fail (Site 1), backup-unavail (Site 2), backup-fail
-    // (Site 3). dirty_region() is always called lock-free before the mutex is acquired.
+    // dirty_region() + __become_degraded() calls: active-fail (Site 1), backup-unavail (Site 2),
+    // backup-fail (Site 3). dirty_region() is called inside the mutex at all failure sites so
+    // dirty_pages() is a hard gate — no in-flight region can slip past the check.
     // Holding the lock across both the check+CAS and the SB writes ensures:
-    //   (a) No EITHER-with-dirty-bit instant visible to lock-free readers (live P0).
+    //   (a) dirty_pages() sees all in-flight regions — prevents premature clean transition.
     //   (b) Failure-path DEVA SB writes always serialize after EITHER SB writes, so the
     //       on-disk SBs cannot show EITHER+dirty on crash (crash-recovery P0).
-    // Neither the success path (both legs succeed) nor dirty_region() must hold this lock.
+    // The success path (both legs succeed) does not hold this lock.
     std::mutex _clean_transition_mutex;
 
     // Counts prepare() calls; used to enable resync on the first queue init.


### PR DESCRIPTION
## Problem

`async_iov` Site 2 (backup-unavailable path) called `dirty_region()` +
`__become_degraded()` **without** holding `_clean_transition_mutex`,
unlike Sites 1 and 3 which always held it.

This opened a crash window that produced data loss against an acknowledged write.

### Race sequence

| Time | T1 (`__become_clean`) | T2 (`async_iov` Site 2) |
|---|---|---|
| t0 | acquires `_clean_transition_mutex` | — |
| t1 | CAS DEVA→EITHER | captures state DEVA (pre-CAS) |
| t2 | writes EITHER SBs to A and B (I/O in flight) | — |
| t3 | — | active write to A succeeds |
| t4 | — | `dirty_region() + __become_degraded()` (no mutex): CAS EITHER→DEVA, age N→N+1, writes **DEVA+N+1 to A**, ACKs caller |
| t5 | T1's in-flight EITHER writes (using `_sb` now at age N+1) land on disk, overwriting T2's DEVA write | — |
| t6 | releases mutex; H1 runs outside the mutex | — |
| crash | **process dies before H1 re-writes DEVA SBs** | — |

On restart: `pick_superblock` sees EITHER+N+1 on A and EITHER+N+1 on B.
Equal ages → tie-breaker selects A. Route = EITHER → round-robin reads.
B holds pre-T2 stale data → **reads from B return data that was never written** → data loss against the ACK at t4.

**Why H1 doesn't help:** H1 is defense-in-depth for the live-process case only. It runs after `_clean_transition_mutex` releases. Any crash between T1's second `write_superblock` completing and H1's first write bypasses it entirely.

## Fix

Wrap Site 2's `dirty_region() + __become_degraded()` in a `lock_guard` on `_clean_transition_mutex`, matching Sites 1 and 3:

```cpp
// Before
if (!backup_write) {
    _dirty_bitmap->dirty_region(addr, len);
    if (!__become_degraded(false, &state)) co_return -EAGAIN;
    co_return active_res;
}

// After
if (!backup_write) {
    bool const become_degraded_ok = [&] {
        std::lock_guard lock(_clean_transition_mutex);
        _dirty_bitmap->dirty_region(addr, len);
        return __become_degraded(false, &state);
    }();
    if (!become_degraded_ok) co_return -EAGAIN;
    co_return active_res;
}
```

With the mutex, T2 waits until T1 releases. T2's DEVA write always lands **after** T1's EITHER writes. On any crash:
- A = DEVA+N+1 (latest age)
- B = EITHER+N (older age)

`pick_superblock` selects A by age → route = DEVA → reads go to A only → **safe**.

**Lock-order safety:** `_clean_transition_mutex` → `_ctrl_lock` is the existing hierarchy (Sites 1 and 3 hold `_clean_transition_mutex` and call `__become_degraded` which acquires `_ctrl_lock` internally). Adding Site 2 to this order maintains the same hierarchy — no new deadlock risk.

**Coroutine safety:** `co_return` destroys RAII objects before final suspension, so the `lock_guard` in the Site 2 lambda is released before the coroutine is torn down.

## No new unit test

The race requires process-kill + restart semantics to observe: a test needs to stop the process mid-write and inspect raw on-disk superblock bytes. The ublksrv coroutine machinery cannot be driven from unit tests. The fix is a one-line lock application identical to the existing pattern in Sites 1 and 3 — the correctness argument is structural.

## Files changed

| File | Change |
|---|---|
| `src/raid/raid1/raid1.cpp` | Site 2: add `_clean_transition_mutex`; update `__become_clean` preamble and H1 comment |
| `src/raid/raid1/raid1_impl.hpp` | `_clean_transition_mutex` docblock: cover all three sites |
| `CHANGELOG.md` | New entry `[0.32.14]` |
| `conanfile.py` | Version bump 0.32.13 → 0.32.14 |

🤖 Generated with [Claude Code](https://claude.ai/claude-code)