### PR TITLE
perf(raid0): memset only active stripe slots in sub_cmds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.32.14] - 2026-06-12
+
+### Improved
+
+- (raid0): Only init parts of StripeAccumulator that i/o will actually touch.
+
 ## [0.32.13] - 2026-06-10
 
 ### Fixed

--- a/conanfile.py
+++ b/conanfile.py
@@ -10,7 +10,7 @@ required_conan_version = ">=2.0"
 
 class UBlkPPConan(ConanFile):
     name = "ublkpp"
-    version = "0.32.13"
+    version = "0.32.14"
 
     homepage = "https://github.com/szmyd/ublkpp"
     description = "A UBlk library for CPP application"

--- a/src/raid/raid0/raid0.cpp
+++ b/src/raid/raid0/raid0.cpp
@@ -17,9 +17,9 @@ constexpr uint32_t _max_stripe_cnt{64};
 constexpr uint32_t k_max_iovecs_per_stripe{16};
 
 struct StripeAccum {
-    uint64_t io_addr{0};
-    uint32_t nr_vecs{0};
-    std::array< iovec, k_max_iovecs_per_stripe > io_array{};
+    uint64_t io_addr;
+    uint32_t nr_vecs;
+    std::array< iovec, k_max_iovecs_per_stripe > io_array; // filled before read; no zero-init needed
 };
 
 class StripeDevice {
@@ -257,7 +257,8 @@ io_result Raid0Disk::sync_iov(uint8_t op, iovec* iovecs, uint32_t nr_vecs, off_t
     // Adjust the address for our superblock area, do not use _addr_ beyond this.
     addr += _stride_width;
 
-    std::array< StripeAccum, _max_stripe_cnt > sub_cmds{};
+    std::array< StripeAccum, _max_stripe_cnt > sub_cmds;
+    memset(sub_cmds.data(), 0, _stripe_array.size() * sizeof(StripeAccum));
     return __distribute(sub_cmds, iovecs, addr,
                         [op, this](uint32_t stripe_off, iovec* iov, uint32_t nr_iovs, uint64_t logical_off) {
                             RLOGT("Perform {}: ublk sync_io -> "
@@ -286,8 +287,10 @@ disk_task< int > Raid0Disk::async_iov(ublksrv_queue const* q, ublk_io_data const
 
     // sub_cmds is declared at function scope (not inside the else block) so its lifetime extends
     // past the if/else and covers the co_await loop below; iovec pointers into io_array remain
-    // valid for the lifetime of all child tasks.
-    std::array< StripeAccum, _max_stripe_cnt > sub_cmds{};
+    // valid for the lifetime of all child tasks. Only the [0, _stripe_array.size()) slots are
+    // ever indexed by __distribute, so only those are initialized.
+    std::array< StripeAccum, _max_stripe_cnt > sub_cmds;
+    memset(sub_cmds.data(), 0, _stripe_array.size() * sizeof(StripeAccum));
 
     if (op == UBLK_IO_OP_DISCARD || op == UBLK_IO_OP_WRITE_ZEROES) {
         uint32_t const len = (nr_vecs > 0) ? static_cast< uint32_t >(iovecs[0].iov_len) : 0;


### PR DESCRIPTION
Replace full zero-initialization of std::array<StripeAccum, 64> (17 KiB) with memset bounded to _stripe_array.size() * sizeof(StripeAccum). For a 2-device RAID0 (e.g. 2x2 RAID10) this drops per-IO initialization from 17,408 bytes to 544 bytes -- a 32x reduction. Also remove the redundant io_array{} in-class initializer since __distribute always writes each iovec slot before reading it.

Identified as the primary cause of 25-44% IOPS regression introduced in 66f65ea when sub_cmds moved from thread_local (amortized, DirtyGuard reset only touched entries) into the coroutine frame (fresh zero-init every IO).