### PR TITLE
perf(target): run queue handler threads under SCHED_FIFO at max priority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.33.1] - 2026-06-17
+
+### Improved
+
+- **Queue handler threads now run under `SCHED_FIFO` at max priority (99)**: each queue thread calls `pthread_setschedparam(SCHED_FIFO, 99)` on startup, placing it in the real-time scheduling class. This eliminates CFS jitter on the I/O hot path and ensures queue threads preempt all `SCHED_OTHER` work (including management and gRPC threads) whenever they are runnable.
+
 ## [0.33.0] - 2026-06-14
 
 ### Breaking

--- a/conanfile.py
+++ b/conanfile.py
@@ -10,7 +10,7 @@ required_conan_version = ">=2.0"
 
 class UBlkPPConan(ConanFile):
     name = "ublkpp"
-    version = "0.33.0"
+    version = "0.33.1"
 
     homepage = "https://github.com/szmyd/ublkpp"
     description = "A UBlk library for CPP application"

--- a/src/target/ublkpp_tgt.cpp
+++ b/src/target/ublkpp_tgt.cpp
@@ -37,7 +37,9 @@ SISL_OPTION_GROUP(ublkpp_tgt,
                    cxxopts::value< std::uint16_t >()->default_value("1"), "<queue_cnt>"),
                   (qdepth, "", "qdepth", "I/O Queue Depth per target",
                    cxxopts::value< std::uint16_t >()->default_value("128"), "<qd>"),
-                  (feature_zero_copy, "", "feature_zero_copy", "Enable ZeroCopy Feature", cxxopts::value< bool >(), ""))
+                  (feature_zero_copy, "", "feature_zero_copy", "Enable ZeroCopy Feature", cxxopts::value< bool >(), ""),
+                  (sched, "", "sched", "Queue thread scheduler policy (other, fifo)",
+                   cxxopts::value< std::string >()->default_value("fifo"), "<policy>"))
 
 using namespace std::chrono_literals;
 
@@ -161,9 +163,11 @@ static exec::task< void > run_queue_loop(ublksrv_queue const* q, ublkpp_queue_st
 
 static void* ublksrv_queue_handler(std::shared_ptr< ublkpp_tgt_impl > target, int q_id, sem_t* queue_sem,
                                    int* queue_ok) {
-    sched_param sp{.sched_priority = sched_get_priority_max(SCHED_FIFO)};
-    if (int rc = pthread_setschedparam(pthread_self(), SCHED_FIFO, &sp); rc != 0)
-        TLOGE("queue {}: failed to set SCHED_FIFO: {}", q_id, strerror(rc))
+    if (SISL_OPTIONS["sched"].as< std::string >() == "fifo") {
+        sched_param sp{.sched_priority = sched_get_priority_max(SCHED_FIFO)};
+        if (int rc = pthread_setschedparam(pthread_self(), SCHED_FIFO, &sp); rc != 0)
+            TLOGE("queue {}: failed to set SCHED_FIFO: {}", q_id, strerror(rc))
+    }
     auto qs = std::make_unique< ublkpp_queue_state >(target);
 
     // Initialize UBlkSrv IOUring queue and bind queue state pointer

--- a/src/target/ublkpp_tgt.cpp
+++ b/src/target/ublkpp_tgt.cpp
@@ -1,7 +1,9 @@
 #include "ublkpp/target.hpp"
 #include "ublkpp/target_testing.hpp"
 
+#include <pthread.h>
 #include <ranges>
+#include <sched.h>
 #include <semaphore.h>
 #include <exec/async_scope.hpp>
 #include <exec/inline_scheduler.hpp>
@@ -159,6 +161,8 @@ static exec::task< void > run_queue_loop(ublksrv_queue const* q, ublkpp_queue_st
 
 static void* ublksrv_queue_handler(std::shared_ptr< ublkpp_tgt_impl > target, int q_id, sem_t* queue_sem,
                                    int* queue_ok) {
+    sched_param sp{.sched_priority = sched_get_priority_max(SCHED_FIFO)};
+    pthread_setschedparam(pthread_self(), SCHED_FIFO, &sp);
     auto qs = std::make_unique< ublkpp_queue_state >(target);
 
     // Initialize UBlkSrv IOUring queue and bind queue state pointer

--- a/src/target/ublkpp_tgt.cpp
+++ b/src/target/ublkpp_tgt.cpp
@@ -162,7 +162,8 @@ static exec::task< void > run_queue_loop(ublksrv_queue const* q, ublkpp_queue_st
 static void* ublksrv_queue_handler(std::shared_ptr< ublkpp_tgt_impl > target, int q_id, sem_t* queue_sem,
                                    int* queue_ok) {
     sched_param sp{.sched_priority = sched_get_priority_max(SCHED_FIFO)};
-    pthread_setschedparam(pthread_self(), SCHED_FIFO, &sp);
+    if (int rc = pthread_setschedparam(pthread_self(), SCHED_FIFO, &sp); rc != 0)
+        TLOGE("queue {}: failed to set SCHED_FIFO: {}", q_id, strerror(rc))
     auto qs = std::make_unique< ublkpp_queue_state >(target);
 
     // Initialize UBlkSrv IOUring queue and bind queue state pointer


### PR DESCRIPTION
Queue threads call pthread_setschedparam(SCHED_FIFO, 99) on startup, placing them in the RT scheduling class and eliminating CFS jitter on the I/O hot path.