### PR TITLE
perf(target,raid1): add --sched flag; reset resync thread to SCHED_OTHER

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.33.2] - 2026-06-17
+### De-prioritize Resync threads to SCHED_OTHER
+
+- **RAID1**: Resync threads just do sync_io; so move them off the real-time scheduler.
+
 ## [0.33.1] - 2026-06-17
 
 ### Improved

--- a/conanfile.py
+++ b/conanfile.py
@@ -10,7 +10,7 @@ required_conan_version = ">=2.0"
 
 class UBlkPPConan(ConanFile):
     name = "ublkpp"
-    version = "0.33.1"
+    version = "0.33.2"
 
     homepage = "https://github.com/szmyd/ublkpp"
     description = "A UBlk library for CPP application"

--- a/src/raid/raid1/raid1_resync_task.cpp
+++ b/src/raid/raid1/raid1_resync_task.cpp
@@ -1,5 +1,7 @@
 #include "raid1_resync_task.hpp"
 
+#include <pthread.h>
+#include <sched.h>
 #include <ublksrv.h>
 #include <sisl/utility/thread_factory.hpp>
 
@@ -190,10 +192,14 @@ void Raid1ResyncTask::launch(std::string const& str_uuid, std::shared_ptr< Mirro
     // to a joinable std::thread calls std::terminate(), so join here first.
     if (_resync_task.joinable()) _resync_task.join();
 
-    _resync_task = sisl::named_thread(
-        fmt::format("r_{}", str_uuid.substr(0, 13)),
-        [this, uuid = str_uuid, clean = std::move(clean_mirror), dirty = std::move(dirty_mirror),
-         compl_cb = std::move(complete)] mutable { _start(uuid, clean, dirty, std::move(compl_cb)); });
+    _resync_task = sisl::named_thread(fmt::format("r_{}", str_uuid.substr(0, 13)),
+                                      [this, uuid = str_uuid, clean = std::move(clean_mirror),
+                                       dirty = std::move(dirty_mirror), compl_cb = std::move(complete)] mutable {
+                                          sched_param sp{.sched_priority = 0};
+                                          if (int rc = pthread_setschedparam(pthread_self(), SCHED_OTHER, &sp); rc != 0)
+                                              RLOGE("resync thread: failed to reset to SCHED_OTHER: {}", strerror(rc))
+                                          _start(uuid, clean, dirty, std::move(compl_cb));
+                                      });
 }
 
 void Raid1ResyncTask::__clean(uint64_t addr, uint32_t len, MirrorDevice& clean_mirror) {


### PR DESCRIPTION
Queue threads default to SCHED_FIFO (configurable via --sched other). Resync task thread explicitly resets to SCHED_OTHER on start so it does not inherit RT priority from a queue thread that triggers launch(); sync I/O calls in the resync path must be allowed to block without starving the CPU.