### PR TITLE
feat(raid1): add snapshot_superbitmap primitive for race-free superblock writes

### DIFF
--- a/src/raid/raid1/raid1_superblock.cpp
+++ b/src/raid/raid1/raid1_superblock.cpp
@@ -4,6 +4,7 @@
 
 #include "lib/logging.hpp"
 #include "raid/superblock.hpp"
+#include "super_bitmap.hpp"
 
 namespace ublkpp::raid1 {
 
@@ -77,18 +78,21 @@ io_result write_superblock(ublk_disk& device, raid1::SuperBlock const* sb, bool 
     // concurrent write_superblock calls cannot race on the packed byte that clean_unmount,
     // read_route, and device_b share (M5).
     //
-    // Live I/O path (include_superbitmap=false): copy only header + fields (74 bytes).
-    // Leaving superbitmap_reserved zero avoids a TSan-visible non-atomic 8-byte load that
-    // would overlap SuperBitmap::set_bit's concurrent atomic_ref::fetch_or at offset 74.
+    // Live I/O path (include_superbitmap=false): copy only header + fields (74 bytes) with
+    // memcpy (safe — bytes < 74 are never mutated under concurrent I/O), then snapshot the
+    // superbitmap with per-byte atomic acquire loads. A wide non-atomic memcpy of bytes
+    // 74..4095 would race set_bit's atomic_ref::fetch_or (UB + TSan).
     //
-    // Shutdown path (include_superbitmap=true): copy the full 4 KiB page so the on-disk
-    // superbitmap is up-to-date. Safe because resync has been joined and I/O is quiesced
-    // before the destructor runs; no concurrent set_bit/clear_bit can race the memcpy.
+    // Shutdown path (include_superbitmap=true): copy the full 4 KiB page. Safe because
+    // resync has been joined and I/O is quiesced before the destructor runs; no concurrent
+    // set_bit/clear_bit can race the memcpy.
     alignas(4096) SuperBlock local{};
     if (include_superbitmap)
         memcpy(&local, sb, sb_size);
-    else
+    else {
         memcpy(&local, sb, offsetof(SuperBlock, superbitmap_reserved));
+        snapshot_superbitmap(sb->superbitmap_reserved, local.superbitmap_reserved);
+    }
     local.fields.read_route = static_cast< uint8_t >(read_route);
     local.fields.device_b = device_b ? 1 : 0;
     auto iov = iovec{.iov_base = &local, .iov_len = sb_size};

--- a/src/raid/raid1/super_bitmap.cpp
+++ b/src/raid/raid1/super_bitmap.cpp
@@ -80,4 +80,12 @@ uint8_t* SuperBitmap::data() noexcept { return _bits; }
 
 const uint8_t* SuperBitmap::data() const noexcept { return _bits; }
 
+void snapshot_superbitmap(uint8_t const* src, uint8_t* dst) noexcept {
+    // Acquire pairs per-object with set_bit's release fetch_or on src[i]:
+    // any bit observed set is guaranteed to be in the durable image (superset —
+    // at worst a redundant resync, never a missed resync).
+    for (size_t i = 0; i < k_superbitmap_size; ++i)
+        dst[i] = std::atomic_ref< uint8_t const >(src[i]).load(std::memory_order_acquire);
+}
+
 } // namespace ublkpp::raid1

--- a/src/raid/raid1/super_bitmap.hpp
+++ b/src/raid/raid1/super_bitmap.hpp
@@ -36,4 +36,9 @@ public:
     const uint8_t* data() const noexcept;
 };
 
+// Race-free per-byte acquire snapshot of the live superbitmap into dst.
+// NEVER use memcpy for this: the source is offset-74 misaligned, 4022 bytes long,
+// and concurrently mutated by set_bit's atomic fetch_or (UB + TSan).
+void snapshot_superbitmap(uint8_t const* src, uint8_t* dst) noexcept;
+
 } // namespace ublkpp::raid1

--- a/src/raid/raid1/tests/bitmap/super_bitmap_test.cpp
+++ b/src/raid/raid1/tests/bitmap/super_bitmap_test.cpp
@@ -384,6 +384,93 @@ TEST_F(SuperBitmapTest, NextSetBitByteBoundary) {
     EXPECT_EQ(sb.next_set_bit(17), k_superbitmap_bits);
 }
 
+// snapshot_superbitmap tests
+TEST_F(SuperBitmapTest, SnapshotRoundTrip) {
+    SuperBitmap sb(buffer.get());
+    sb.set_bit(0);
+    sb.set_bit(42);
+    sb.set_bit(32175);
+
+    auto dst = std::make_unique< uint8_t[] >(k_superbitmap_size);
+    snapshot_superbitmap(buffer.get(), dst.get());
+
+    EXPECT_EQ(std::memcmp(buffer.get(), dst.get(), k_superbitmap_size), 0);
+}
+
+TEST_F(SuperBitmapTest, SnapshotPicksUpFlip) {
+    SuperBitmap sb(buffer.get());
+    sb.set_bit(5);
+
+    auto dst = std::make_unique< uint8_t[] >(k_superbitmap_size);
+    snapshot_superbitmap(buffer.get(), dst.get());
+    EXPECT_NE(dst[0], 0);
+
+    sb.clear_bit(5);
+    sb.set_bit(6);
+    std::memset(dst.get(), 0, k_superbitmap_size);
+    snapshot_superbitmap(buffer.get(), dst.get());
+
+    EXPECT_EQ(dst[0] & (1U << 5), 0U);
+    EXPECT_NE(dst[0] & (1U << 6), 0U);
+}
+
+TEST_F(SuperBitmapTest, SnapshotBoundaryBits) {
+    SuperBitmap sb(buffer.get());
+    sb.set_bit(0);
+    sb.set_bit(32175);
+
+    auto dst = std::make_unique< uint8_t[] >(k_superbitmap_size);
+    snapshot_superbitmap(buffer.get(), dst.get());
+
+    EXPECT_NE(dst[0] & 0x01, 0U);
+    EXPECT_NE(dst[k_superbitmap_size - 1] & 0x80, 0U);
+}
+
+TEST_F(SuperBitmapTest, SnapshotAsanTailGuard) {
+    SuperBitmap sb(buffer.get());
+    sb.set_bit(0);
+
+    // Allocate exactly k_superbitmap_size bytes; ASan red-zone immediately follows.
+    // Any read past byte 4021 triggers ASan heap-buffer-overflow.
+    auto dst = std::make_unique< uint8_t[] >(k_superbitmap_size);
+    snapshot_superbitmap(buffer.get(), dst.get());
+
+    EXPECT_NE(dst[0] & 0x01, 0U);
+    EXPECT_EQ(dst[k_superbitmap_size - 1], buffer[k_superbitmap_size - 1]);
+}
+
+TEST_F(SuperBitmapTest, SnapshotConcurrencyTSan) {
+    // Thread S hammers set_bit on bits 0..63 (bytes 0..7).
+    // Thread F repeatedly snapshots; asserts every bit it sees was actually set.
+    // TSan must report no data races.
+    SuperBitmap sb(buffer.get());
+    constexpr int k_iters = 500;
+    constexpr int k_setter_bits = 64;
+
+    std::barrier sync_point{2};
+    std::atomic< bool > stop{false};
+
+    std::thread setter([&]() {
+        sync_point.arrive_and_wait();
+        for (int i = 0; i < k_iters; ++i) {
+            for (int bit = 0; bit < k_setter_bits; ++bit)
+                sb.set_bit(static_cast< uint32_t >(bit));
+        }
+        stop.store(true, std::memory_order_release);
+    });
+
+    auto dst = std::make_unique< uint8_t[] >(k_superbitmap_size);
+    sync_point.arrive_and_wait();
+    while (!stop.load(std::memory_order_acquire)) {
+        snapshot_superbitmap(buffer.get(), dst.get());
+        // Superset property: no bit in dst can be set unless set_bit was called for it.
+        for (int i = 8; i < static_cast< int >(k_superbitmap_size); ++i)
+            ASSERT_EQ(dst[i], 0) << "Byte " << i << " outside setter range must stay zero";
+    }
+
+    setter.join();
+}
+
 // Integration test with actual SuperBlock
 TEST_F(SuperBitmapTest, IntegrationWithSuperBlock) {
     // Allocate a real SuperBlock


### PR DESCRIPTION
## Summary

Part 1 of #313 — inert primitive that unblocks the write-intent superbitmap redesign.

- Adds `snapshot_superbitmap(src, dst)`: a per-byte `atomic_ref<uint8_t const>::load(acquire)` copy of the live superbitmap. The acquire pairs per-object with `set_bit`'s release `fetch_or`, so any bit observed set is guaranteed in the durable image (superset — worst case is a redundant resync, never a missed one).
- Wires it into the **live branch** of `write_superblock` (previously that branch zero-filled `superbitmap_reserved` because a wide `memcpy` races `set_bit`'s concurrent atomic RMW — UB + TSan).
- Shutdown branch (`include_superbitmap=true`) and on-disk format are **unchanged**.

This change is **inert on its own**: the healthy write path never calls `set_bit` today, so the snapshot captures all-zeros in practice. Behavioral impact comes in follow-up PRs (parts (a)–(d) of #313).

## Tests

- `SnapshotRoundTrip` — basic correctness: set bits, snapshot, compare
- `SnapshotPicksUpFlip` — snapshot reflects state after clear+set
- `SnapshotBoundaryBits` — bits 0 and 32175 (first/last)
- `SnapshotAsanTailGuard` — exactly-sized dst; ASan catches any over-read past byte 4021
- `SnapshotConcurrencyTSan` — setter hammers bytes 0–7 concurrently; snapshot thread verifies bytes 8–4021 stay zero; TSan must report zero races

## Test plan

- [ ] Debug build + unit tests green (`GccCoverage` / `ClangRelease`)
- [ ] `GccAddressSanitize`: `SnapshotAsanTailGuard` catches over-reads
- [ ] `GccThreadSanitize`: `SnapshotConcurrencyTSan` reports no data races

Closes part 1 of #313.

🤖 Generated with [Claude Code](https://claude.com/claude-code)