### PR TITLE
fix(target): fall back to fresh creation when kernel ublk device is gone after reboot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.33.3] - 2026-06-27
+
+### Fixed
+
+- **`ublkpp_tgt`: fall back to fresh device creation when kernel ublk state is gone after reboot**: previously, if `device_id >= 0` was passed to `ublkpp_tgt::run()` (recovery mode) but `ublksrv_ctrl_recover_init` returned NULL (e.g. node reboot cleared all `UBLK_F_USER_RECOVERY` state), the function returned an error and the volume was never recreated. Now, the recovery path detects the NULL return, resets `device_recovering = false`, and falls through to normal `ublksrv_ctrl_init + ublksrv_ctrl_add_dev` creation — bringing `/dev/ublkb*` and `/dev/ublkc*` back without manual intervention.
+
 ## [0.33.2] - 2026-06-17
 ### De-prioritize Resync threads to SCHED_OTHER
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -10,7 +10,7 @@ required_conan_version = ">=2.0"
 
 class UBlkPPConan(ConanFile):
     name = "ublkpp"
-    version = "0.33.2"
+    version = "0.33.3"
 
     homepage = "https://github.com/szmyd/ublkpp"
     description = "A UBlk library for CPP application"

--- a/src/target/ublkpp_tgt.cpp
+++ b/src/target/ublkpp_tgt.cpp
@@ -209,10 +209,26 @@ static std::expected< std::filesystem::path, std::error_condition > start(std::s
         }
     } else { // RECOVERY Path — reconnect to a kernel-preserved device (UBLK_F_USER_RECOVERY)
         tgt->ctrl_dev = ublksrv_ctrl_recover_init(tgt->dev_data.get());
+        bool need_fresh_create = false;
+
         if (!tgt->ctrl_dev) {
-            // Kernel device is gone (e.g. node reboot cleared all ublk state). Fall back to
-            // normal creation so the volume comes back without manual intervention.
-            TLOGW("Cannot recover disk {} (kernel device gone), falling back to fresh creation", tgt->device.load())
+            // /dev/ublk-control itself unavailable — fall back to fresh creation.
+            TLOGW("Cannot recover disk {} (ctrl init failed), falling back to fresh creation", tgt->device.load())
+            need_fresh_create = true;
+        } else if (auto ret = ublksrv_ctrl_get_info(tgt->ctrl_dev); ret < 0) {
+            // Kernel device is gone (e.g. node rebooted — all ublk state is in-memory only).
+            // Fall back to fresh creation so the volume comes back without manual intervention.
+            TLOGW("Cannot recover disk {} (device not in kernel, ret={}), falling back to fresh creation",
+                  tgt->device.load(), ret)
+            ublksrv_ctrl_deinit(tgt->ctrl_dev);
+            tgt->ctrl_dev = nullptr;
+            need_fresh_create = true;
+        } else if (auto ret = ublksrv_ctrl_start_recovery(tgt->ctrl_dev); ret < 0) {
+            TLOGE("Cannot start recovery for disk {}: {}", tgt->device.load(), ret)
+            return std::unexpected(std::make_error_condition(std::errc::operation_not_permitted));
+        }
+
+        if (need_fresh_create) {
             tgt->device_recovering = false;
             if (tgt->ctrl_dev = ublksrv_ctrl_init(tgt->dev_data.get()); !tgt->ctrl_dev) {
                 TLOGE("Cannot init disk {}", tgt->device.load())
@@ -220,15 +236,6 @@ static std::expected< std::filesystem::path, std::error_condition > start(std::s
             }
             if (auto ret = ublksrv_ctrl_add_dev(tgt->ctrl_dev); 0 > ret) {
                 TLOGE("Cannot add disk {}: {}", tgt->device.load(), ret)
-                return std::unexpected(std::make_error_condition(std::errc::operation_not_permitted));
-            }
-        } else {
-            if (auto ret = ublksrv_ctrl_get_info(tgt->ctrl_dev); ret < 0) {
-                TLOGE("Cannot get Ctrl Info for disk {}", tgt->device.load())
-                return std::unexpected(std::make_error_condition(std::errc::operation_not_permitted));
-            }
-            if (auto ret = ublksrv_ctrl_start_recovery(tgt->ctrl_dev); ret < 0) {
-                TLOGE("Cannot start recovery for disk {}: {}", tgt->device.load(), ret)
                 return std::unexpected(std::make_error_condition(std::errc::operation_not_permitted));
             }
         }

--- a/src/target/ublkpp_tgt.cpp
+++ b/src/target/ublkpp_tgt.cpp
@@ -207,18 +207,30 @@ static std::expected< std::filesystem::path, std::error_condition > start(std::s
             TLOGE("Cannot add disk {}: {}", tgt->device.load(), ret)
             return std::unexpected(std::make_error_condition(std::errc::operation_not_permitted));
         }
-    } else { // RECOVERY Path
-        if (tgt->ctrl_dev = ublksrv_ctrl_recover_init(tgt->dev_data.get()); !tgt->ctrl_dev) {
-            TLOGE("Cannot recover disk {}", tgt->device.load())
-            return std::unexpected(std::make_error_condition(std::errc::operation_not_permitted));
-        }
-        if (auto ret = ublksrv_ctrl_get_info(tgt->ctrl_dev); ret < 0) {
-            TLOGE("Cannot get Ctrl Info for disk {}", tgt->device.load())
-            return std::unexpected(std::make_error_condition(std::errc::operation_not_permitted));
-        }
-        if (auto ret = ublksrv_ctrl_start_recovery(tgt->ctrl_dev); ret < 0) {
-            TLOGE("Cannot start recovery for disk {}: {}", tgt->device.load(), ret)
-            return std::unexpected(std::make_error_condition(std::errc::operation_not_permitted));
+    } else { // RECOVERY Path — reconnect to a kernel-preserved device (UBLK_F_USER_RECOVERY)
+        tgt->ctrl_dev = ublksrv_ctrl_recover_init(tgt->dev_data.get());
+        if (!tgt->ctrl_dev) {
+            // Kernel device is gone (e.g. node reboot cleared all ublk state). Fall back to
+            // normal creation so the volume comes back without manual intervention.
+            TLOGW("Cannot recover disk {} (kernel device gone), falling back to fresh creation", tgt->device.load())
+            tgt->device_recovering = false;
+            if (tgt->ctrl_dev = ublksrv_ctrl_init(tgt->dev_data.get()); !tgt->ctrl_dev) {
+                TLOGE("Cannot init disk {}", tgt->device.load())
+                return std::unexpected(std::make_error_condition(std::errc::operation_not_permitted));
+            }
+            if (auto ret = ublksrv_ctrl_add_dev(tgt->ctrl_dev); 0 > ret) {
+                TLOGE("Cannot add disk {}: {}", tgt->device.load(), ret)
+                return std::unexpected(std::make_error_condition(std::errc::operation_not_permitted));
+            }
+        } else {
+            if (auto ret = ublksrv_ctrl_get_info(tgt->ctrl_dev); ret < 0) {
+                TLOGE("Cannot get Ctrl Info for disk {}", tgt->device.load())
+                return std::unexpected(std::make_error_condition(std::errc::operation_not_permitted));
+            }
+            if (auto ret = ublksrv_ctrl_start_recovery(tgt->ctrl_dev); ret < 0) {
+                TLOGE("Cannot start recovery for disk {}: {}", tgt->device.load(), ret)
+                return std::unexpected(std::make_error_condition(std::errc::operation_not_permitted));
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

- When `ublkpp_tgt::run()` is called with `device_id >= 0` (recovery mode after restart with persisted state), `ublksrv_ctrl_recover_init()` returns NULL if the kernel ublk device was cleared by a node reboot — `UBLK_F_USER_RECOVERY` only keeps devices alive across *process* death, not across reboots
- Previously this was a hard failure with no fallback, leaving `/dev/ublkb*` and `/dev/ublkc*` absent
- Now the code detects NULL, resets `device_recovering = false`, and falls through to normal `ublksrv_ctrl_init + ublksrv_ctrl_add_dev` — volumes come back automatically after reboot

## Key detail

The `device_recovering` flag reset is essential: it controls whether `ublksrv_ctrl_start_dev` (normal path) or `ublksrv_ctrl_end_recovery` (recovery path) is called at the end of `start()`. Without resetting it, the wrong end-of-startup call fires and the device fails.

## Test plan

- [ ] Verify `/dev/ublkb*` and `/dev/ublkc*` appear after node reboot with persisted volumes
- [ ] Verify normal non-recovery path still works (device_id == -1)
- [ ] Verify live process restart (no reboot) still uses the recovery path successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)