### PR TITLE
fix(target): drop gated I/O on shutdown instead of completing -EAGAIN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.34.1] - 2026-06-29
+
+### Fixed
+
+- **Shutdown drain no longer errors I/O back to the block layer**: after `begin_shutdown()`, gated I/O was completed with `-EAGAIN`, which the kernel maps to `BLK_STS_AGAIN` and logs as `nonblocking retry error, dev ublkbN ...` before failing the request (a normal, non-`REQ_NOWAIT` request is not retried on `AGAIN`). Gated ops (now including `FLUSH`) are instead **dropped** -- left uncompleted (`OWNED_BY_SRV`) so the kernel requeues/reissues them to the next daemon under `UBLK_F_USER_RECOVERY(_REISSUE)` when the process exits via the recovery path (drop the `unique_ptr`, not `remove()`). The drain accounting (`record_queue_depth_change` / `try_drain`) is unchanged, so `wait_for_drain()` and the `clean_unmount=1` flush still fire exactly once.
+
 ## [0.34.0] - 2026-06-17
 
 ### Added

--- a/conanfile.py
+++ b/conanfile.py
@@ -10,7 +10,7 @@ required_conan_version = ">=2.0"
 
 class UBlkPPConan(ConanFile):
     name = "ublkpp"
-    version = "0.34.0"
+    version = "0.34.1"
 
     homepage = "https://github.com/szmyd/ublkpp"
     description = "A UBlk library for CPP application"

--- a/include/ublkpp/target.hpp
+++ b/include/ublkpp/target.hpp
@@ -32,12 +32,12 @@ struct ublkpp_tgt {
     // operation_not_permitted on permission/setup failure, invalid_argument on bad geometry).
     static run_result_t run(boost::uuids::uuid const& vol_id, disk_handle device, int device_id = -1);
 
-    // Signals the target to begin a graceful drain. After this call, reads and writes are
-    // rejected with EAGAIN before they reach the backing device; FLUSH ops are allowed through
-    // (they complete instantly with result=0 and do not access device*). In-flight ops complete
-    // normally. When the last in-flight op finishes (or immediately if the system is already
-    // idle), the backing device is destroyed exactly once — flushing the RAID-1 dirty bitmap and
-    // writing clean_unmount=1. Idempotent: subsequent calls are no-ops (guarded by CAS).
+    // Signals the target to begin a graceful drain. After this call, new I/O is dropped (left
+    // uncompleted / OWNED_BY_SRV) so the kernel requeues it to the next daemon under
+    // UBLK_F_USER_RECOVERY(_REISSUE) when this process exits via the recovery path (drop the
+    // unique_ptr, NOT remove()). In-flight ops complete normally. When the last in-flight op
+    // finishes (or immediately if already idle), the backing device is destroyed exactly once,
+    // flushing the RAID-1 dirty bitmap and writing clean_unmount=1. Idempotent (guarded by CAS).
     // Note: if there are in-flight ops when this is called, it returns immediately and
     // the backing device is destroyed later on a queue thread; there is no completion callback.
     // Must be called from a normal thread context, not a signal handler: the idle-drain path

--- a/src/target/ublkpp_tgt.cpp
+++ b/src/target/ublkpp_tgt.cpp
@@ -338,21 +338,17 @@ static exec::task< void > __handle_io_async(ublksrv_queue const* q, ublk_io_data
     // The seq_cst increment participates in the C++ total order S alongside begin_shutdown's
     // seq_cst store and all_idle()'s seq_cst loads. Either the increment precedes the store in
     // S (begin_shutdown's counter reads see it → skips reset) or the store precedes the
-    // increment in S (our gate check below sees _shutting_down=true → rejects).
+    // increment in S (our gate check below sees _shutting_down=true → drops).
     qs->tgt->metrics.record_queue_depth_change(q, op, true);
 
-    // Drain gate: reject reads/writes during shutdown before they reach the backing device.
-    // FLUSH is exempted: it completes instantly with result=0 and never dereferences device*.
-    // EAGAIN signals "temporarily unavailable, retry" so filesystems back off and retry once
-    // the new process reconnects the device (UBLK_F_USER_RECOVERY hot-restart path).
-    if (op != UBLK_IO_OP_FLUSH && qs->tgt->_shutting_down.load(std::memory_order_seq_cst)) {
-        qs->tgt->metrics.record_queue_depth_change(q, op, false);
-        TLOGD("Rejecting I/O [tag:{:#0x}] during shutdown", data->tag)
-        ublksrv_complete_io(q, data->tag, -EAGAIN);
-        // The rejected op may be the last in-flight — check drain here too.
-        // Without this, the common case (ops in-flight when begin_shutdown fires) would
-        // decrement to zero in this branch and never trigger device = {}.
-        qs->tgt->try_drain();
+    // Drain gate: during shutdown DROP every op (leave it uncompleted / OWNED_BY_SRV) so the kernel
+    // requeues it to the next daemon under UBLK_F_USER_RECOVERY(_REISSUE) on exit. Completing with
+    // -EAGAIN instead maps to BLK_STS_AGAIN, which the block layer logs as "nonblocking retry error"
+    // and fails.
+    if (qs->tgt->_shutting_down.load(std::memory_order_seq_cst)) {
+        qs->tgt->metrics.record_queue_depth_change(q, op, false); // undo pre-gate increment (no-op for FLUSH)
+        TLOGD("Dropping I/O [tag:{:#0x}] during shutdown", data->tag)
+        qs->tgt->try_drain(); // dropped op may be the last in-flight
         co_return;
     }
 
@@ -389,9 +385,7 @@ static exec::task< void > __handle_io_async(ublksrv_queue const* q, ublk_io_data
     }
     ublksrv_complete_io(q, data->tag, result);
 
-    // FLUSH reaches here too: it skips the gate and the counter, so this load is the only
-    // shutdown check it sees. try_drain() after FLUSH is safe — if counters are already zero
-    // the CAS protects against double-reset; if not, it is a benign early check.
+    // Fire device = {} once the last in-flight op (dispatched before begin_shutdown) drains.
     if (qs->tgt->_shutting_down.load(std::memory_order_seq_cst)) qs->tgt->try_drain();
 }
 


### PR DESCRIPTION
After begin_shutdown(), the drain gate completed gated reads/writes with -EAGAIN. The kernel maps that to BLK_STS_AGAIN and logs it as "nonblocking retry error, dev ublkbN ..." before failing the request -- a normal, non-REQ_NOWAIT request is not retried on AGAIN.

Drop gated ops (now including FLUSH) instead: leave them uncompleted (OWNED_BY_SRV) so the kernel requeues/reissues them to the next daemon under UBLK_F_USER_RECOVERY(_REISSUE) when the process exits via the recovery path (drop the unique_ptr, not remove()). The gate is before async_iov, so a dropped op never touched the backing store and REISSUE replays it exactly once.

Drain accounting (record_queue_depth_change / try_drain) is unchanged, so wait_for_drain() and the clean_unmount=1 flush still fire exactly once.